### PR TITLE
Add persistent hotkey config

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ You can change the Whisper model by right-clicking the system tray icon and sele
 
 You can change the recording key by right-clicking the system tray icon and selecting "⌨ Configure Key Binding...".
 
+The chosen key is stored in `~/.config/transclip/config.json` using the
+XDG Base Directory convention so it persists across sessions. You can edit this
+file manually if you want to set the key outside of the application.
+
 ### Accessing Recent Transcriptions
 
 The system tray menu also provides access to recent transcriptions, which you can select to copy again to the clipboard.

--- a/transclip/config.py
+++ b/transclip/config.py
@@ -1,0 +1,34 @@
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+CONFIG_HOME = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+CONFIG_DIR = CONFIG_HOME / "transclip"
+CONFIG_FILE = CONFIG_DIR / "config.json"
+
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "recording_key": "Key.home",
+}
+
+
+def load_config() -> Dict[str, Any]:
+    """Load configuration from disk.
+
+    Returns an empty dict if the config file does not exist or is invalid.
+    """
+    try:
+        with CONFIG_FILE.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        return {}
+    except Exception:
+        return {}
+
+
+def save_config(data: Dict[str, Any]) -> None:
+    """Save configuration to disk."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    with CONFIG_FILE.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=4)
+

--- a/transclip/hotkey.py
+++ b/transclip/hotkey.py
@@ -5,7 +5,7 @@ combinations.
 """
 
 from collections.abc import Callable
-from typing import Optional, cast
+from typing import cast
 
 from pynput import keyboard
 


### PR DESCRIPTION
## Summary
- add config module following XDG Base Directory
- store and load recording hotkey from ~/.config/transclip/config.json
- document new config location in README
- fix ruff issues

## Testing
- `ruff check transclip/`
- `mypy --strict transclip/` *(fails: Library stubs not installed for pynput, etc.)*