### PR TITLE
Enable optional auto-paste after transcription

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,7 +41,7 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(self.config.load_config(), {})
 
     def test_save_and_load(self):
-        data = {"recording_key": "Key.home"}
+        data = {"recording_key": "Key.home", "auto_paste": True}
         self.config.save_config(data)
         self.assertTrue(self.config_file.exists())
         self.assertEqual(self.config.load_config(), data)

--- a/transclip/config.py
+++ b/transclip/config.py
@@ -9,6 +9,7 @@ CONFIG_FILE = CONFIG_DIR / "config.json"
 
 DEFAULT_CONFIG: Dict[str, Any] = {
     "recording_key": "Key.home",
+    "auto_paste": False,
 }
 
 


### PR DESCRIPTION
## Summary
- add `auto_paste` option to configuration
- store user preference when toggling menu item
- implement automatic paste using keyboard controller
- expose toggle in tray menu
- extend config tests

## Testing
- `ruff check transclip/ tests/`
- `mypy --strict transclip/` *(fails: Returning Any from function declared to return dict[str, Any]; etc.)*
- `python -m unittest discover -s tests`