### PR TITLE
Add NeMo Parakeet model integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,12 @@ Available models:
 - `medium`: ~1.5GB (slower, more accurate)
 - `large`: ~3GB (slowest, most accurate)
 - `large-v2`, `large-v3`: ~3GB (improved large models)
-- `parakeet-tdt-0.6b-v2`: ~1.2GB (NVIDIA Parakeet model)
+- `parakeet-tdt-0.6b-v2`: ~1.2GB (NVIDIA Parakeet model, requires `nemo_toolkit`)
+
+To use the Parakeet model, install NeMo first:
+```bash
+uv pip install "nemo_toolkit[asr]"
+```
 
 ## Development
 

--- a/install.sh
+++ b/install.sh
@@ -156,6 +156,11 @@ if [ "$TEST_SERVICE_CONFIG" = false ]; then
         esac
     done
 
+    if [[ " ${models_to_download[@]} " == *"nvidia/parakeet-tdt-0.6b-v2"* ]]; then
+        echo "Installing nemo_toolkit for Parakeet model..."
+        uv pip install "nemo_toolkit[asr]"
+    fi
+
     for model in "${models_to_download[@]}"; do
         echo "Downloading ${model} model..."
         if python -m transclip.download_models --model "${model}"; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,7 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = ["fastpunct.*", "onnxruntime.*", "silero_punctuation.*", "llama_cpp.*"]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["nemo.*"]
+ignore_missing_imports = true

--- a/tests/test_change_model.py
+++ b/tests/test_change_model.py
@@ -50,6 +50,7 @@ class ChangeModelTests(unittest.TestCase):
             {
                 "TINY": "tiny",
                 "BASE": "base",
+                "PARAKEET_TDT_0_6B_V2": "nvidia/parakeet-tdt-0.6b-v2",
                 "get_description": classmethod(lambda cls, m: str(m)),
             },
         )
@@ -58,6 +59,8 @@ class ChangeModelTests(unittest.TestCase):
             modules["transclip.transcription"].WhisperModelType.BASE
         )
         modules["transclip.transcription"].TranscriptionWorker = object
+        modules["transclip.transcription"].NeMoTranscriptionWorker = object
+        modules["transclip.transcription"].load_nemo_model = lambda m: "nemo_model"
         modules["faster_whisper"].WhisperModel = object
         qtwidgets = modules["PyQt5.QtWidgets"]
         qtwidgets.QSystemTrayIcon = type(

--- a/tests/test_key_persistence.py
+++ b/tests/test_key_persistence.py
@@ -48,13 +48,19 @@ class KeyPersistenceTests(unittest.TestCase):
         modules["transclip.transcription"].WhisperModelType = type(
             "WhisperModelType",
             (),
-            {"BASE": "base", "get_description": classmethod(lambda cls, m: str(m))},
+            {
+                "BASE": "base",
+                "PARAKEET_TDT_0_6B_V2": "nvidia/parakeet-tdt-0.6b-v2",
+                "get_description": classmethod(lambda cls, m: str(m)),
+            },
         )
         modules["transclip.transcription"].get_model_path = lambda m: str(m)
         modules["transclip.transcription"].DEFAULT_MODEL_TYPE = (
             modules["transclip.transcription"].WhisperModelType.BASE
         )
         modules["transclip.transcription"].TranscriptionWorker = object
+        modules["transclip.transcription"].NeMoTranscriptionWorker = object
+        modules["transclip.transcription"].load_nemo_model = lambda m: "nemo_model"
         modules["faster_whisper"].WhisperModel = object
         qtwidgets = modules["PyQt5.QtWidgets"]
         qtwidgets.QSystemTrayIcon = type(

--- a/transclip/transcription.py
+++ b/transclip/transcription.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 import logging
 from enum import StrEnum
 from pathlib import Path
-from typing import Dict
+from typing import Any, Dict
 
 import numpy as np
 from faster_whisper import WhisperModel
+
+try:
+    from nemo.collections.asr.models import EncDecRNNTModel
+except Exception:  # pragma: no cover - optional dependency
+    EncDecRNNTModel = None
 from PyQt5.QtCore import QThread, pyqtSignal
 
 logger = logging.getLogger(__name__)
@@ -78,3 +83,78 @@ class TranscriptionWorker(QThread):
         except Exception as exc:  # pragma: no cover - logging
             logger.error("Transcription failed: %s", exc)
             self.finished.emit("")
+
+
+class NeMoTranscriptionWorker(QThread):
+    """Worker thread running NeMo transcription."""
+
+    finished = pyqtSignal(str)
+
+    def __init__(self, audio_data: np.ndarray, sample_rate: int, model: Any) -> None:
+        super().__init__()
+        self.audio_data = audio_data
+        self.sample_rate = sample_rate
+        self.model = model
+
+    def run(self) -> None:  # pragma: no cover - heavy external call
+        """Run the NeMo transcription process."""
+        if EncDecRNNTModel is None:
+            logger.error(
+                "nemo_toolkit is not installed. Unable to run NeMo transcription."
+            )
+            self.finished.emit("")
+            return
+
+        import os
+        import tempfile
+        import wave
+
+        tmp_path = ""
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+                tmp_path = tmp.name
+                with wave.open(tmp, "wb") as wf:
+                    wf.setnchannels(1)
+                    wf.setsampwidth(2)
+                    wf.setframerate(self.sample_rate)
+                    int16_audio = (self.audio_data * 32767).astype(np.int16)
+                    wf.writeframes(int16_audio.tobytes())
+
+            result = self.model.transcribe([tmp_path])
+            text = result[0] if isinstance(result, list) else result
+            self.finished.emit(str(text).strip())
+        except Exception as exc:  # pragma: no cover - logging
+            logger.error("NeMo transcription failed: %s", exc)
+            self.finished.emit("")
+        finally:
+            if tmp_path:
+                try:
+                    os.remove(tmp_path)
+                except OSError:
+                    pass
+
+
+def load_nemo_model(model_type: WhisperModelType) -> Any:
+    """Load a NeMo model, downloading if necessary."""
+    if EncDecRNNTModel is None:  # pragma: no cover - runtime guard
+        raise RuntimeError(
+            "nemo_toolkit is required to load NeMo models. Install with 'pip install nemo_toolkit[asr]'"
+        )
+
+    cache_dir = Path.home() / ".cache" / "whisper"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    model_file = cache_dir / f"{model_type.value.replace('/', '_')}.nemo"
+
+    try:
+        if model_file.exists():
+            return EncDecRNNTModel.restore_from(str(model_file))
+
+        model = EncDecRNNTModel.from_pretrained(model_name=model_type.value)
+        try:
+            model.save_to(str(model_file))
+        except Exception:  # pragma: no cover - optional
+            logger.warning("Failed to cache NeMo model", exc_info=True)
+        return model
+    except Exception as exc:  # pragma: no cover - logging
+        logger.error("Failed to load NeMo model: %s", exc)
+        raise


### PR DESCRIPTION
## Summary
- integrate NVIDIA NeMo Parakeet model
- add NeMo transcription worker and model loader
- switch app to use NeMo when the Parakeet model is selected
- optionally download Parakeet model with NeMo in download script
- install NeMo if Parakeet model chosen in install.sh
- document NeMo installation
- adjust tests for new stubs

## Testing
- `ruff check transclip/ tests/`
- `mypy --strict transclip/`
- `python -m unittest discover -s tests`