### PR TITLE
Add configurable cleanup prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A desktop application that transcribes speech to text when you hold down a key. 
 - Optional automatic pasting into the active window
 - Optional text cleanup with punctuation and language model support
   that can be toggled from the tray menu
+- Customizable cleanup prompt for the language model
 - Configurable key binding
 - Visual feedback during recording (icon changes)
 - Error handling and status notifications
@@ -124,6 +125,12 @@ You can change the recording key by right-clicking the system tray icon and sele
 The chosen key is stored in `~/.config/transclip/config.json` using the
 XDG Base Directory convention so it persists across sessions. You can edit this
 file manually if you want to set the key outside of the application.
+
+### Customizing Cleanup Prompt
+
+You can modify the instruction used for the optional LLM cleanup stage by
+editing the `cleanup_prompt` value in `~/.config/transclip/config.json`.
+Use `{text}` in the string to insert the transcript.
 
 ### Accessing Recent Transcriptions
 

--- a/tests/test_cleanup_prompt.py
+++ b/tests/test_cleanup_prompt.py
@@ -1,0 +1,41 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+class CleanupPromptTests(unittest.TestCase):
+    def test_custom_prompt_used(self) -> None:
+        llama_mod = types.ModuleType("llama_cpp")
+
+        class DummyLlama:
+            def __init__(self, *args, **kwargs) -> None:
+                self.last_prompt = None
+
+            def __call__(self, prompt: str, max_tokens: int = 0, temperature: float = 0.0):
+                self.last_prompt = prompt
+                return {"choices": [{"text": "CLEAN"}]}
+
+        llama_mod.Llama = DummyLlama
+        trans_module = types.ModuleType("transclip.transcription")
+        trans_module.WhisperModelType = type("WhisperModelType", (), {})
+        patches = {"llama_cpp": llama_mod, "transclip.transcription": trans_module}
+        with mock.patch.dict(sys.modules, patches):
+            import transclip.cleanup as cleanup_mod
+            importlib.reload(cleanup_mod)
+            cfg = {
+                "cleanup_enable": True,
+                "cleanup_llm_model": "model.gguf",
+                "cleanup_punct_model": "none",
+                "cleanup_prompt": "PROMPT {text}",
+            }
+            cleaner = cleanup_mod.Cleaner(cfg)
+            result = cleaner("hello")
+            self.assertEqual(result, "CLEAN")
+            assert isinstance(cleaner.llm, DummyLlama)
+            self.assertEqual(cleaner.llm.last_prompt, "PROMPT hello")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/transclip/config.py
+++ b/transclip/config.py
@@ -15,6 +15,10 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "cleanup_llm_model": "tinyllama.gguf",
     "cleanup_threads": 4,
     "cleanup_gpu_layers": 0,
+    "cleanup_prompt": (
+        "Rewrite the following transcript into clear, well-punctuated English.\n\n"
+        "INPUT:\n{text}\n\nCLEANED:"
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- allow custom cleanup prompt via `cleanup_prompt` in config
- use new prompt in `Cleaner`
- document cleanup prompt in README
- add regression test for custom prompt

## Testing
- `ruff check transclip/ tests/`
- `mypy --strict transclip/`
- `python -m unittest discover -s tests`