### PR TITLE
Add first-class macOS support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Sync dependencies
+        run: uv sync --extra dev --extra audio
+      - name: Ruff
+        run: uv run ruff check .
+      - name: Compile
+        run: uv run python -m compileall transclip scripts tests
+      - name: Unit tests
+        run: uv run python -m unittest discover -s tests -v
+
+  macos:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Sync dependencies
+        run: uv sync --extra dev --extra audio --extra mlx
+      - name: Ruff
+        run: uv run ruff check .
+      - name: Compile
+        run: uv run python -m compileall transclip scripts tests
+      - name: Unit tests
+        run: uv run python -m unittest discover -s tests -v
+      - name: MLX import smoke
+        run: uv run python -c "import platform, mlx; from mlx_audio.stt.generate import generate_transcription; print(platform.machine(), generate_transcription)"

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,3 +43,16 @@ validation, and token budgeting for model-backed cleanup.
 meets the current dictation quality and latency expectations. It covers manifest
 shape, warmup handling, measured cases, metrics, thresholds, and the JSON output
 consumed by scripts.
+
+**Runtime profile**: Platform-aware defaults and capability metadata, including
+config/cache/log roots, supported inference runtimes (Torch CUDA/ROCm, MLX),
+default ASR backend/model, and service manager (`systemd` on Linux, per-user
+`launchd` on macOS dev installs).
+
+**Backend catalog**: The mapping from model IDs to backend kind, runtime kind,
+platform support, prefetch strategy, and cache layout. ASR factory dispatch and
+doctor checks derive from the selected catalog entry.
+
+**MLX ASR path**: macOS Apple Silicon inference through `mlx-audio` STT, with
+offline prefetch via `huggingface_hub.snapshot_download` into the Hugging Face
+hub cache under `~/Library/Caches/huggingface/hub` unless overridden.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The runnable app lives in `transclip/`: Python inference service,
 settings, audio capture, cleanup, paste injection, daemon install/status/log
 commands, debug capture, Python AppIndicator tray, and eval harness.
 
-## Quick Start
+## Linux Quick Start
 
 Create default config files:
 
@@ -23,10 +23,7 @@ Create default config files:
 uv run -m transclip.cli init-config
 ```
 
-This writes `settings.toml` under the platform config directory:
-
-- Linux: `~/.config/transclip/settings.toml`
-- macOS: `~/Library/Application Support/transclip/settings.toml`
+This writes `settings.toml` under `~/.config/transclip/settings.toml`.
 
 Install the daemon and native shortcut:
 
@@ -65,6 +62,9 @@ not expose `gi`. Install the system bindings if missing:
 ```bash
 sudo apt install -y python3-gi gir1.2-ayatanaappindicator3-0.1
 ```
+
+Use the macOS Apple Silicon quick start below on M-series Macs. Intel Macs are
+not a supported runtime target for this branch.
 
 Service controls:
 
@@ -105,7 +105,8 @@ to `~/Library/Caches/huggingface/hub`. Selectable MLX models:
 - `mlx-community/whisper-large-v3-turbo-asr-fp16` (default)
 - `mlx-community/granite-4.0-1b-speech-8bit` (`asr_backend = "granite_mlx"`)
 
-Granite Speech 4.1 NAR is not supported on macOS. Use the MLX backends above.
+Granite Speech 4.1 NAR is not supported on macOS. macOS support in this branch
+is Apple Silicon only; use the MLX backends above on M-series Macs.
 
 ## Linux CUDA / ROCm Quick Start
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ on macOS by TransClip's current backends.
 
 ## Linux CUDA / ROCm Quick Start
 
-For the portable CPU/CUDA path, install the model extras first:
+For the portable Torch path, install the model extras first:
 
 ```bash
 uv pip install -e '.[models,audio,llama]'
@@ -139,7 +139,7 @@ uv pip install --python .venv-gfx1151/bin/python \
   --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ \
   --pre torch torchaudio torchvision pytorch-triton-rocm
 uv pip install --python .venv-gfx1151/bin/python \
-  -e . 'transformers>=4.52.1' 'accelerate>=1.0' 'soundfile>=0.12' 'sounddevice>=0.5'
+  -e . 'transformers>=5.8' 'accelerate>=1.0' 'soundfile>=0.12' 'sounddevice>=0.5'
 FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE MAX_JOBS=4 \
   uv pip install --python .venv-gfx1151/bin/python --no-deps \
   flash-attn==2.8.3 --no-build-isolation

--- a/README.md
+++ b/README.md
@@ -105,8 +105,19 @@ to `~/Library/Caches/huggingface/hub`. Selectable MLX models:
 - `mlx-community/whisper-large-v3-turbo-asr-fp16` (default)
 - `mlx-community/granite-4.0-1b-speech-8bit` (`asr_backend = "granite_mlx"`)
 
-Granite Speech 4.1 NAR is not supported on macOS. macOS support in this branch
-is Apple Silicon only; use the MLX backends above on M-series Macs.
+Granite Speech 4.1 autoregressive models are also selectable on Apple Silicon
+through the Torch/MPS backend with `uv sync --extra audio --extra models`:
+
+```toml
+asr_backend = "granite"
+asr_model = "ibm-granite/granite-speech-4.1-2b"
+asr_device = "auto"
+```
+
+`ibm-granite/granite-speech-4.1-2b-plus` uses the same backend. The MLX
+Whisper path remains the macOS default because it is the smallest first-class
+Apple Silicon runtime in this app. Granite Speech 4.1 NAR is still not supported
+on macOS by TransClip's current backends.
 
 ## Linux CUDA / ROCm Quick Start
 
@@ -266,6 +277,7 @@ VIRTUAL_ENV=$PWD/.venv-gfx1151 uv run --active scripts/run_real_eval_pipeline.py
 | --- | --- | --- | --- |
 | Linux GPU | `granite_nar` | `ibm-granite/granite-speech-4.1-2b-nar` | `models` |
 | macOS ARM | `mlx_audio_whisper` | `mlx-community/whisper-large-v3-turbo-asr-fp16` | `mlx`, `audio` |
+| macOS ARM optional | `granite` | `ibm-granite/granite-speech-4.1-2b` / `ibm-granite/granite-speech-4.1-2b-plus` | `models`, `audio` |
 | Test/file | `file:/path/to.txt` | n/a | none |
 
 ## Permissions (macOS TCC)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # TransClip
 
-Local-only toggle-to-talk dictation for Linux and macOS, with local ASR and
-faithful cleanup for technical notes. Granite NAR is the default backend, but
-TransClip is the product surface.
+Local-only toggle-to-talk dictation for Linux and macOS Apple Silicon, with
+local ASR and faithful cleanup for technical notes. Linux defaults to Granite
+NAR (Torch + FlashAttention 2 on GPU). macOS Apple Silicon defaults to MLX via
+`mlx-audio`.
 
 The default path is now the pure-Python dictation daemon:
 
@@ -22,7 +23,10 @@ Create default config files:
 uv run -m transclip.cli init-config
 ```
 
-This writes `settings.toml` under the platform config directory.
+This writes `settings.toml` under the platform config directory:
+
+- Linux: `~/.config/transclip/settings.toml`
+- macOS: `~/Library/Application Support/transclip/settings.toml`
 
 Install the daemon and native shortcut:
 
@@ -45,11 +49,14 @@ uv run -m transclip.cli smoke-test
 uv run -m transclip.cli logs
 ```
 
-Run the Python tray:
+Run the Python tray (Linux only):
 
 ```bash
 transclip tray
 ```
+
+On macOS, `transclip tray` exits with guidance to use a Keyboard Shortcut or
+Shortcuts.app action until a native menu bar UI exists.
 
 On Linux this uses PyGObject/Ayatana AppIndicator. When running through `uv`,
 the command hands off to system Python if the project virtual environment does
@@ -74,6 +81,34 @@ To run the service manually instead of using the service manager:
 uv run -m transclip.cli serve
 ```
 
+## macOS Apple Silicon Quick Start
+
+Requirements: Apple Silicon, native ARM Python 3.12+, macOS 14+.
+
+```bash
+uv sync --extra audio --extra mlx
+uv run -m transclip.cli init-config
+uv run -m transclip.cli models prefetch --model mlx-community/whisper-large-v3-turbo-asr-fp16
+uv run -m transclip.cli install
+uv run -m transclip.cli status
+uv run -m transclip.cli doctor
+```
+
+Configure a global shortcut or Shortcuts.app action to run
+`transclip toggle-record --paste`. Grant Microphone permission when recording
+starts. Grant Accessibility and/or Automation permission for `osascript` paste
+injection. If paste is denied, the transcript remains on the clipboard.
+
+Dev LaunchAgent logs live under `~/Library/Logs/transclip/`. Model cache defaults
+to `~/Library/Caches/huggingface/hub`. Selectable MLX models:
+
+- `mlx-community/whisper-large-v3-turbo-asr-fp16` (default)
+- `mlx-community/granite-4.0-1b-speech-8bit` (`asr_backend = "granite_mlx"`)
+
+Granite Speech 4.1 NAR is not supported on macOS. Use the MLX backends above.
+
+## Linux CUDA / ROCm Quick Start
+
 For the portable CPU/CUDA path, install the model extras first:
 
 ```bash
@@ -81,8 +116,10 @@ uv pip install -e '.[models,audio,llama]'
 ```
 
 On the current Linux `gfx1151` workstation, the V1 latency profile uses AMD's
-TheRock ROCm nightly index plus FlashAttention's Triton AMD backend. Do not use
-the local custom wheel for this app; it fails GPU tensor execution on this host.
+TheRock ROCm nightly index plus FlashAttention's Triton AMD backend. ROCm
+support here is project-validated where FlashAttention ROCm works; it is not an
+IBM-documented Granite runtime guarantee. Do not use the local custom wheel for
+this app; it fails GPU tensor execution on this host.
 
 ```bash
 uv venv --python 3.13 .venv-gfx1151
@@ -222,11 +259,27 @@ VIRTUAL_ENV=$PWD/.venv-gfx1151 uv run --active scripts/run_real_eval_pipeline.py
   ~/transclip-real-eval
 ```
 
+## Model / Runtime Matrix
+
+| Platform | Default backend | Default model | Extra |
+| --- | --- | --- | --- |
+| Linux GPU | `granite_nar` | `ibm-granite/granite-speech-4.1-2b-nar` | `models` |
+| macOS ARM | `mlx_audio_whisper` | `mlx-community/whisper-large-v3-turbo-asr-fp16` | `mlx`, `audio` |
+| Test/file | `file:/path/to.txt` | n/a | none |
+
+## Permissions (macOS TCC)
+
+| Action | Permission | Identity |
+| --- | --- | --- |
+| Recording | Microphone | Terminal, LaunchAgent Python, Shortcuts, or packaged `.app` |
+| Paste via `osascript` | Accessibility and/or Automation | Same controlling process |
+
 ## Tests
 
 ```bash
 uv run -m unittest discover -s tests -v
 uv run -m compileall scripts transclip tests
+uv run ruff check .
 VIRTUAL_ENV=$PWD/.venv-gfx1151 uv run --active scripts/check_v1_completion.py
 ```
 

--- a/eval/macos/manifest.json
+++ b/eval/macos/manifest.json
@@ -1,0 +1,154 @@
+{
+  "name": "transclip-macos-eval",
+  "description": "Apple Silicon MLX dictation eval gate (separate from Linux/V1 thresholds)",
+  "platform": "darwin-arm64",
+  "candidates": [
+    {
+      "label": "whisper-mlx",
+      "asr_backend": "mlx_audio_whisper",
+      "asr_model": "mlx-community/whisper-large-v3-turbo-asr-fp16"
+    },
+    {
+      "label": "granite-mlx",
+      "asr_backend": "granite_mlx",
+      "asr_model": "mlx-community/granite-4.0-1b-speech-8bit"
+    }
+  ],
+  "thresholds": {
+    "warm_transcribe_p95_ms": 2500,
+    "release_to_ready_p95_ms": 3500,
+    "wer_max": 0.18,
+    "keyword_preservation_min": 0.95
+  },
+  "warmup_cases": [
+    {
+      "audio_path": "../v1-synthetic/audio/warmup.wav",
+      "reference": "PyTorch on ROCm with gfx1151 is ready for the Granite speech benchmark.",
+      "keywords": ["PyTorch", "ROCm", "gfx1151", "Granite"],
+      "cleanup": true
+    }
+  ],
+  "cases": [
+    {
+      "audio_path": "../v1-synthetic/audio/case_01.wav",
+      "reference": "Please check the Python tray icon after the service reports ready.",
+      "keywords": ["Python tray"],
+      "cleanup": true
+    },
+    {
+      "audio_path": "../v1-synthetic/audio/case_02.wav",
+      "reference": "Set the cleanup runtime to rule for the latency profile.",
+      "keywords": ["cleanup"],
+      "cleanup": true
+    },
+    {
+      "audio_path": "../v1-synthetic/audio/case_03.wav",
+      "reference": "Granite NAR should stay under seven hundred milliseconds after warm up.",
+      "keywords": ["Granite", "NAR"],
+      "cleanup": true
+    },
+    {
+      "audio_path": "../v1-synthetic/audio/case_04.wav",
+      "reference": "Add PyTorch, ROCm, and gfx1151 to the technical note.",
+      "keywords": ["PyTorch", "ROCm", "gfx1151"],
+      "cleanup": true
+    },
+    {
+      "audio_path": "../v1-synthetic/audio/case_05.wav",
+      "reference": "The localhost Python inference service is listening on port eight seven six five.",
+      "keywords": ["Python"],
+      "cleanup": true
+    },
+    {
+      "audio_path": "../v1-synthetic/audio/case_06.wav",
+      "reference": "Use wtype on Wayland and xdotool on X eleven when paste injection is needed.",
+      "keywords": ["wtype", "Wayland", "xdotool"],
+      "cleanup": true
+    },
+    {
+      "audio_path": "../v1-synthetic/audio/case_07.wav",
+      "reference": "The macOS menu bar item may need accessibility permission for command V.",
+      "keywords": ["macOS"],
+      "cleanup": true
+    },
+    {
+      "audio_path": "../v1-synthetic/audio/case_08.wav",
+      "reference": "Do not add cloud fallback or transcript telemetry in version one.",
+      "keywords": ["telemetry"],
+      "cleanup": true
+    },
+    {
+      "audio_path": "../v1-synthetic/audio/case_09.wav",
+      "reference": "Keep the Gemma cleanup backend available for quality comparisons.",
+      "keywords": ["Gemma"],
+      "cleanup": true
+    },
+    {
+      "audio_path": "../v1-synthetic/audio/case_10.wav",
+      "reference": "Open the settings file and verify Hugging Face is preserved exactly.",
+      "keywords": ["Hugging Face"],
+      "cleanup": true
+    },
+    {
+      "audio_path": "../v1-synthetic/audio/case_11.wav",
+      "reference": "Run the unit tests after changing the Python tray.",
+      "keywords": ["Python tray"],
+      "cleanup": true
+    },
+    {
+      "audio_path": "../v1-synthetic/audio/case_12.wav",
+      "reference": "The recent transcripts submenu should keep the last five snippets.",
+      "keywords": ["recent transcripts"],
+      "cleanup": true
+    },
+    {
+      "audio_path": "../v1-synthetic/audio/case_13.wav",
+      "reference": "Clipboard restoration should wait five hundred milliseconds before replacing text.",
+      "keywords": ["Clipboard"],
+      "cleanup": true
+    },
+    {
+      "audio_path": "../v1-synthetic/audio/case_14.wav",
+      "reference": "The app should hide the secondary status window instead of quitting.",
+      "keywords": ["status window"],
+      "cleanup": true
+    },
+    {
+      "audio_path": "../v1-synthetic/audio/case_15.wav",
+      "reference": "Use the TheRock nightly index for the Radeon eight zero six zero S.",
+      "keywords": ["TheRock", "Radeon"],
+      "cleanup": true
+    },
+    {
+      "audio_path": "../v1-synthetic/audio/case_16.wav",
+      "reference": "FlashAttention Triton AMD is required for the Granite NAR backend.",
+      "keywords": ["FlashAttention", "Triton", "AMD", "Granite", "NAR"],
+      "cleanup": true
+    },
+    {
+      "audio_path": "../v1-synthetic/audio/case_17.wav",
+      "reference": "The debug capture folder should include audio dot wav and timings dot json.",
+      "keywords": ["debug capture"],
+      "cleanup": true
+    },
+    {
+      "audio_path": "../v1-synthetic/audio/case_18.wav",
+      "reference": "Avoid rewriting llama.cpp as llama.cpp during cleanup.",
+      "keywords": ["llama.cpp"],
+      "cleanup": true
+    },
+    {
+      "audio_path": "../v1-synthetic/audio/case_19.wav",
+      "reference": "The service health endpoint should include the active hotkey and paste shortcut.",
+      "keywords": ["health endpoint"],
+      "cleanup": true
+    },
+    {
+      "audio_path": "../v1-synthetic/audio/case_20.wav",
+      "reference": "Do not treat the Dock as the primary home for this app.",
+      "keywords": ["Dock"],
+      "cleanup": true
+    }
+  ],
+  "output_dir": "eval/macos/results"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ build-backend = "hatchling.build"
 
 [project.optional-dependencies]
 audio = ["sounddevice>=0.5", "numpy>=1.26"]
-models = ["transformers>=4.52.1", "torch>=2.5", "torchaudio>=2.5", "torchcodec>=0.5", "torchvision>=0.20", "accelerate>=1.0", "soundfile>=0.12", "pillow>=10"]
+models = ["transformers>=5.5.3", "torch>=2.9.1", "torchaudio>=2.5", "torchcodec>=0.5", "torchvision>=0.20", "accelerate>=1.0", "soundfile>=0.12", "pillow>=10"]
+mlx = ["mlx-audio[stt]>=0.4.3", "huggingface_hub>=0.27", "soundfile>=0.12"]
+macos-ui = []
 llama = ["llama-cpp-python>=0.3"]
 dev = [
     "coverage[toml]>=7.10",
@@ -50,6 +52,9 @@ allowed-unresolved-imports = [
     "gi",
     "gi.repository",
     "llama_cpp",
+    "mlx",
+    "mlx_audio",
+    "mlx_audio.stt.generate",
     "sounddevice",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "hatchling.build"
 
 [project.optional-dependencies]
 audio = ["sounddevice>=0.5", "numpy>=1.26"]
-models = ["transformers>=5.5.3", "torch>=2.9.1", "torchaudio>=2.5", "torchcodec>=0.5", "torchvision>=0.20", "accelerate>=1.0", "soundfile>=0.12", "pillow>=10"]
+models = ["transformers>=5.8", "torch>=2.9.1", "torchaudio>=2.5", "torchcodec>=0.5", "torchvision>=0.20", "accelerate>=1.0", "soundfile>=0.12", "pillow>=10"]
 mlx = ["mlx-audio[stt]>=0.4.3", "huggingface_hub>=0.27", "soundfile>=0.12"]
 macos-ui = []
 llama = ["llama-cpp-python>=0.3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "hatchling.build"
 
 [project.optional-dependencies]
 audio = ["sounddevice>=0.5", "numpy>=1.26"]
-models = ["transformers>=5.8", "torch>=2.9.1", "torchaudio>=2.5", "torchcodec>=0.5", "torchvision>=0.20", "accelerate>=1.0", "soundfile>=0.12", "pillow>=10"]
+models = ["transformers>=5.8", "torch>=2.9.1,<2.12", "torchaudio>=2.9.1,<2.12", "torchcodec>=0.5", "torchvision>=0.24,<0.27", "accelerate>=1.0", "soundfile>=0.12", "pillow>=10"]
 mlx = ["mlx-audio[stt]>=0.4.3", "huggingface_hub>=0.27", "soundfile>=0.12"]
 macos-ui = []
 llama = ["llama-cpp-python>=0.3"]

--- a/scripts/check_v1_completion.py
+++ b/scripts/check_v1_completion.py
@@ -79,7 +79,7 @@ def check_completion(
         blockers.append(f"real-usage eval results missing: {real_results_path}")
 
     if doctor_checked:
-        failed_checks = [check for check in doctor_checks if not check.ok]
+        failed_checks = [check for check in doctor_checks if check.required and not check.ok]
         evidence["doctor"] = [{"name": check.name, "ok": check.ok, "detail": check.detail} for check in doctor_checks]
         for check in failed_checks:
             blockers.append(f"doctor {check.name} failed: {check.detail}")

--- a/tests/platform_helpers.py
+++ b/tests/platform_helpers.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from tests.service_helpers import FakeRuntime
+
+
+def linux_runtime(home: Path | None = None) -> FakeRuntime:
+    return FakeRuntime(system="Linux", home=home or Path("/home/test"))
+
+
+def darwin_arm_runtime(home: Path | None = None) -> FakeRuntime:
+    return FakeRuntime(system="Darwin", home=home or Path("/Users/test"), check_output_text="arm64")

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -49,6 +49,16 @@ class ASRTests(unittest.TestCase):
             runtime=self.linux,
         )
         self.assertIsInstance(ar_backend, GraniteSpeechTransformersBackend)
+        mlx_legacy_ar_backend = build_asr_backend(
+            Settings(
+                asr_backend="granite",
+                asr_model="ibm-granite/granite-speech-4.1-2b",
+                asr_device="mlx",
+            ),
+            runtime=self.linux,
+        )
+        self.assertIsInstance(mlx_legacy_ar_backend, GraniteSpeechTransformersBackend)
+        self.assertEqual(mlx_legacy_ar_backend.device, "auto")
         self.assertIsInstance(
             build_asr_backend(Settings(asr_backend="file:/tmp/transcript.txt"), runtime=self.linux),
             FileTranscriptASRBackend,
@@ -221,7 +231,24 @@ class ASRTests(unittest.TestCase):
             result = backend.transcribe(Path("input.wav"))
 
         self.assertEqual(result.text, "hello")
-        self.assertEqual(calls, [{"model": "mlx/model", "audio": "prepared.wav"}])
+        self.assertEqual(calls[0]["model"], "mlx/model")
+        self.assertEqual(calls[0]["audio"], "prepared.wav")
+        self.assertEqual(calls[0]["format"], "txt")
+        self.assertIn("transclip-mlx-", calls[0]["output_path"])
+
+    def test_mlx_audio_backend_resolves_model_before_preparing_temp_wav(self):
+        backend = MlxAudioASRBackend("mlx/missing", "mlx_audio_whisper", Settings(model_cache_dir="/tmp/missing"))
+        backend.local_files_only = True
+        backend.audio_preparer = SimpleNamespace(prepare=lambda _path: self.fail("audio should not be prepared"))
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {"mlx_audio.stt.generate": SimpleNamespace(generate_transcription=lambda **_kwargs: None)},
+            ),
+            self.assertRaisesRegex(RuntimeError, "Local MLX model artifacts missing"),
+        ):
+            backend.transcribe(Path("input.wav"))
 
     def test_mlx_audio_backend_removes_temporary_prepared_wav(self):
         temp_path = Path("/tmp/transclip-test-prepared.wav")
@@ -245,14 +272,22 @@ class ASRTests(unittest.TestCase):
         self.assertFalse(temp_path.exists())
 
     def test_granite_nar_transcribe_uses_processor_and_model_transcribe(self):
-        backend = GraniteSpeechNarTransformersBackend("ibm-granite/granite-speech-4.1-2b-nar", "cpu")
+        backend = GraniteSpeechNarTransformersBackend("ibm-granite/granite-speech-4.1-2b-nar", "cuda")
         waveform = SimpleNamespace()
+
         class Processor:
             def __call__(self, waveforms, device):
                 return {"waveforms": waveforms, "device": device}
 
             def batch_decode(self, preds):
                 return [f"decoded:{preds[0]}"]
+
+        class InferenceMode:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
 
         processor = Processor()
         model = SimpleNamespace(
@@ -263,7 +298,10 @@ class ASRTests(unittest.TestCase):
             prepare=lambda _path: SimpleNamespace(wav=SimpleNamespace(squeeze=lambda _dim: waveform)),
         )
 
-        with patch.object(backend, "_device", return_value="cpu"):
+        with (
+            patch.dict("sys.modules", {"torch": SimpleNamespace(inference_mode=lambda: InferenceMode())}),
+            patch.object(backend, "_device", return_value="cuda"),
+        ):
             result = backend.transcribe(Path("sample.wav"))
 
         self.assertEqual(result.text, "decoded:pred-text")
@@ -306,42 +344,11 @@ class ASRTests(unittest.TestCase):
         self.assertEqual(captured["model_kwargs"]["attn_implementation"], "flash_attention_2")
         self.assertEqual(captured["model_kwargs"]["device_map"], "cuda")
 
-    def test_granite_nar_load_does_not_require_flash_attention_on_cpu(self):
+    def test_granite_nar_load_rejects_cpu(self):
         backend = GraniteSpeechNarTransformersBackend("ibm-granite/granite-speech-4.1-2b-nar", "cpu")
-        captured: dict[str, object] = {}
 
-        class FakeModel:
-            def to(self, device):
-                captured["to_device"] = device
-                return self
-
-            def eval(self):
-                return self
-
-        def from_pretrained(_model, **kwargs):
-            captured["model_kwargs"] = kwargs
-            return FakeModel()
-
-        fake_transformers = SimpleNamespace(
-            AutoModel=SimpleNamespace(from_pretrained=from_pretrained),
-            AutoProcessor=SimpleNamespace(from_pretrained=lambda *_args, **_kwargs: "processor"),
-        )
-        fake_torch = SimpleNamespace(
-            bfloat16="bf16",
-            float32="fp32",
-            version=SimpleNamespace(hip=None),
-        )
-
-        with (
-            patch.dict("sys.modules", {"transformers": fake_transformers, "torch": fake_torch}),
-            patch("transclip.asr._configure_rocm_nar_attention_env"),
-            patch("transclip.asr._granite_nar_dtype", return_value="fp32"),
-        ):
+        with self.assertRaisesRegex(RuntimeError, "requires CUDA/ROCm"):
             backend._load("cpu")
-
-        self.assertNotIn("attn_implementation", captured["model_kwargs"])
-        self.assertNotIn("device_map", captured["model_kwargs"])
-        self.assertEqual(captured["to_device"], "cpu")
 
 
 if __name__ == "__main__":

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -14,6 +14,7 @@ from transclip.asr import (
     TorchAudioPreparer,
     _configure_rocm_nar_attention_env,
     _granite_nar_dtype,
+    _granite_transformers_dtype,
     build_asr_backend,
     granite_user_prompt,
 )
@@ -96,6 +97,15 @@ class ASRTests(unittest.TestCase):
 
         torch.version.hip = None
         self.assertEqual(_granite_nar_dtype(torch, "cuda"), "bfloat16")
+
+    def test_granite_transformers_uses_bfloat16_on_mps(self):
+        torch = SimpleNamespace(
+            bfloat16="bfloat16",
+            float32="float32",
+        )
+
+        self.assertEqual(_granite_transformers_dtype(torch, "mps"), "bfloat16")
+        self.assertEqual(_granite_transformers_dtype(torch, "cpu"), "float32")
 
     def test_granite_nar_sets_rocm_attention_environment(self):
         environ = {}

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -114,7 +114,11 @@ class ASRTests(unittest.TestCase):
             float32="float32",
         )
 
-        self.assertEqual(_granite_transformers_dtype(torch, "mps"), "bfloat16")
+        with patch("transclip.asr.py_platform.mac_ver", return_value=("14.0", ("", "", ""), "")):
+            self.assertEqual(_granite_transformers_dtype(torch, "mps"), "bfloat16")
+        with patch("transclip.asr.py_platform.mac_ver", return_value=("13.6", ("", "", ""), "")):
+            self.assertEqual(_granite_transformers_dtype(torch, "mps"), "float32")
+        self.assertEqual(_granite_transformers_dtype(torch, "cuda"), "bfloat16")
         self.assertEqual(_granite_transformers_dtype(torch, "cpu"), "float32")
 
     def test_granite_nar_sets_rocm_attention_environment(self):

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -22,6 +22,7 @@ from transclip.settings import Settings
 
 class ASRTests(unittest.TestCase):
     linux = linux_runtime()
+
     def test_granite_prompt_requests_punctuation(self):
         self.assertEqual(
             granite_user_prompt(),
@@ -185,6 +186,7 @@ class ASRTests(unittest.TestCase):
         self.assertNotEqual(prepared.wav_path, Path("sample.wav"))
         self.assertEqual(captured["sample_rate"], 16000)
         self.assertEqual(len(captured["data"]), 160)
+        self.assertTrue(prepared.temporary)
 
     def test_path_preparer_returns_existing_mono_wav(self):
         wav_path = Path("/tmp/sample.wav")
@@ -194,6 +196,7 @@ class ASRTests(unittest.TestCase):
             prepared = PathAudioPreparer().prepare(wav_path)
         self.assertEqual(prepared.wav_path, wav_path)
         self.assertEqual(prepared.sample_rate, 16000)
+        self.assertFalse(prepared.temporary)
 
     def test_mlx_audio_backend_uses_current_generate_api(self):
         calls = []
@@ -209,6 +212,27 @@ class ASRTests(unittest.TestCase):
 
         self.assertEqual(result.text, "hello")
         self.assertEqual(calls, [{"model": "mlx/model", "audio": "prepared.wav"}])
+
+    def test_mlx_audio_backend_removes_temporary_prepared_wav(self):
+        temp_path = Path("/tmp/transclip-test-prepared.wav")
+        temp_path.write_bytes(b"wav")
+        fake_generate = SimpleNamespace(
+            generate_transcription=lambda **_kwargs: SimpleNamespace(text="hello"),
+        )
+        backend = MlxAudioASRBackend("mlx/model", "mlx_audio_whisper")
+        backend.local_files_only = False
+        backend.audio_preparer = SimpleNamespace(
+            prepare=lambda _path: SimpleNamespace(wav_path=temp_path, temporary=True),
+        )
+
+        try:
+            with patch.dict("sys.modules", {"mlx_audio.stt.generate": fake_generate}):
+                result = backend.transcribe(Path("input.wav"))
+        finally:
+            temp_path.unlink(missing_ok=True)
+
+        self.assertEqual(result.text, "hello")
+        self.assertFalse(temp_path.exists())
 
     def test_granite_nar_transcribe_uses_processor_and_model_transcribe(self):
         backend = GraniteSpeechNarTransformersBackend("ibm-granite/granite-speech-4.1-2b-nar", "cpu")
@@ -271,6 +295,43 @@ class ASRTests(unittest.TestCase):
         self.assertIsInstance(model, FakeModel)
         self.assertEqual(captured["model_kwargs"]["attn_implementation"], "flash_attention_2")
         self.assertEqual(captured["model_kwargs"]["device_map"], "cuda")
+
+    def test_granite_nar_load_does_not_require_flash_attention_on_cpu(self):
+        backend = GraniteSpeechNarTransformersBackend("ibm-granite/granite-speech-4.1-2b-nar", "cpu")
+        captured: dict[str, object] = {}
+
+        class FakeModel:
+            def to(self, device):
+                captured["to_device"] = device
+                return self
+
+            def eval(self):
+                return self
+
+        def from_pretrained(_model, **kwargs):
+            captured["model_kwargs"] = kwargs
+            return FakeModel()
+
+        fake_transformers = SimpleNamespace(
+            AutoModel=SimpleNamespace(from_pretrained=from_pretrained),
+            AutoProcessor=SimpleNamespace(from_pretrained=lambda *_args, **_kwargs: "processor"),
+        )
+        fake_torch = SimpleNamespace(
+            bfloat16="bf16",
+            float32="fp32",
+            version=SimpleNamespace(hip=None),
+        )
+
+        with (
+            patch.dict("sys.modules", {"transformers": fake_transformers, "torch": fake_torch}),
+            patch("transclip.asr._configure_rocm_nar_attention_env"),
+            patch("transclip.asr._granite_nar_dtype", return_value="fp32"),
+        ):
+            backend._load("cpu")
+
+        self.assertNotIn("attn_implementation", captured["model_kwargs"])
+        self.assertNotIn("device_map", captured["model_kwargs"])
+        self.assertEqual(captured["to_device"], "cpu")
 
 
 if __name__ == "__main__":

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -4,11 +4,14 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
+from tests.platform_helpers import linux_runtime
 from transclip.asr import (
-    DefaultASRAudioPreparer,
     FileTranscriptASRBackend,
     GraniteSpeechNarTransformersBackend,
     GraniteSpeechTransformersBackend,
+    MlxAudioASRBackend,
+    PathAudioPreparer,
+    TorchAudioPreparer,
     _configure_rocm_nar_attention_env,
     _granite_nar_dtype,
     build_asr_backend,
@@ -18,6 +21,7 @@ from transclip.settings import Settings
 
 
 class ASRTests(unittest.TestCase):
+    linux = linux_runtime()
     def test_granite_prompt_requests_punctuation(self):
         self.assertEqual(
             granite_user_prompt(),
@@ -31,7 +35,7 @@ class ASRTests(unittest.TestCase):
         )
 
     def test_backend_selection(self):
-        backend = build_asr_backend(Settings(model_cache_dir="/models"))
+        backend = build_asr_backend(Settings(model_cache_dir="/models"), runtime=self.linux)
         self.assertIsInstance(backend, GraniteSpeechNarTransformersBackend)
         self.assertTrue(backend.local_files_only)
         self.assertEqual(backend.cache_dir, "/models")
@@ -39,11 +43,12 @@ class ASRTests(unittest.TestCase):
             Settings(
                 asr_backend="granite",
                 asr_model="ibm-granite/granite-speech-4.1-2b",
-            )
+            ),
+            runtime=self.linux,
         )
         self.assertIsInstance(ar_backend, GraniteSpeechTransformersBackend)
         self.assertIsInstance(
-            build_asr_backend(Settings(asr_backend="file:/tmp/transcript.txt")),
+            build_asr_backend(Settings(asr_backend="file:/tmp/transcript.txt"), runtime=self.linux),
             FileTranscriptASRBackend,
         )
         nar_backend = build_asr_backend(
@@ -51,7 +56,8 @@ class ASRTests(unittest.TestCase):
                 asr_backend="granite_nar",
                 asr_model="ibm-granite/granite-speech-4.1-2b-nar",
                 model_cache_dir="/models",
-            )
+            ),
+            runtime=self.linux,
         )
         self.assertIsInstance(nar_backend, GraniteSpeechNarTransformersBackend)
         self.assertTrue(nar_backend.local_files_only)
@@ -59,20 +65,22 @@ class ASRTests(unittest.TestCase):
 
     def test_non_granite_model_is_rejected(self):
         with self.assertRaises(ValueError):
-            build_asr_backend(Settings(asr_model="openai/whisper-tiny"))
+            build_asr_backend(Settings(asr_model="openai/whisper-tiny"), runtime=self.linux)
         with self.assertRaises(ValueError):
             build_asr_backend(
                 Settings(
                     asr_backend="granite_nar",
                     asr_model="ibm-granite/granite-speech-4.1-2b",
-                )
+                ),
+                runtime=self.linux,
             )
         with self.assertRaises(ValueError):
             build_asr_backend(
                 Settings(
                     asr_backend="granite",
                     asr_model="ibm-granite/granite-speech-4.1-2b-nar",
-                )
+                ),
+                runtime=self.linux,
             )
 
     def test_granite_nar_uses_float32_on_rocm(self):
@@ -151,11 +159,118 @@ class ASRTests(unittest.TestCase):
                 "torchaudio": fake_torchaudio,
             },
         ):
-            audio = DefaultASRAudioPreparer().prepare(Path("sample.wav"))
+            audio = TorchAudioPreparer().prepare(Path("sample.wav"))
 
         self.assertEqual(audio.sample_rate, 16000)
         np.testing.assert_allclose(audio.wav.data, np.array([[2.0, 6.0]], dtype=np.float32))
         self.assertEqual(resample_calls, [(8000, 16000)])
+
+    def test_path_preparer_resamples_non_target_rate(self):
+        samples = np.linspace(0.0, 1.0, num=480, dtype=np.float32)
+        captured: dict[str, object] = {}
+
+        def write(_path, data, sample_rate):
+            captured["data"] = data
+            captured["sample_rate"] = sample_rate
+
+        fake_soundfile = SimpleNamespace(
+            read=lambda *_args, **_kwargs: (samples[:, None], 48000),
+            write=write,
+        )
+
+        with patch.dict("sys.modules", {"soundfile": fake_soundfile}):
+            prepared = PathAudioPreparer().prepare(Path("sample.wav"))
+
+        self.assertEqual(prepared.sample_rate, 16000)
+        self.assertNotEqual(prepared.wav_path, Path("sample.wav"))
+        self.assertEqual(captured["sample_rate"], 16000)
+        self.assertEqual(len(captured["data"]), 160)
+
+    def test_path_preparer_returns_existing_mono_wav(self):
+        wav_path = Path("/tmp/sample.wav")
+        samples = np.array([[0.1], [0.2]], dtype=np.float32)
+        fake_soundfile = SimpleNamespace(read=lambda *_args, **_kwargs: (samples, 16000))
+        with patch.dict("sys.modules", {"soundfile": fake_soundfile}):
+            prepared = PathAudioPreparer().prepare(wav_path)
+        self.assertEqual(prepared.wav_path, wav_path)
+        self.assertEqual(prepared.sample_rate, 16000)
+
+    def test_mlx_audio_backend_uses_current_generate_api(self):
+        calls = []
+        fake_generate = SimpleNamespace(
+            generate_transcription=lambda **kwargs: calls.append(kwargs) or SimpleNamespace(text="hello"),
+        )
+        backend = MlxAudioASRBackend("mlx/model", "mlx_audio_whisper")
+        backend.local_files_only = False
+        backend.audio_preparer = SimpleNamespace(prepare=lambda _path: SimpleNamespace(wav_path=Path("prepared.wav")))
+
+        with patch.dict("sys.modules", {"mlx_audio.stt.generate": fake_generate}):
+            result = backend.transcribe(Path("input.wav"))
+
+        self.assertEqual(result.text, "hello")
+        self.assertEqual(calls, [{"model": "mlx/model", "audio": "prepared.wav"}])
+
+    def test_granite_nar_transcribe_uses_processor_and_model_transcribe(self):
+        backend = GraniteSpeechNarTransformersBackend("ibm-granite/granite-speech-4.1-2b-nar", "cpu")
+        waveform = SimpleNamespace()
+        class Processor:
+            def __call__(self, waveforms, device):
+                return {"waveforms": waveforms, "device": device}
+
+            def batch_decode(self, preds):
+                return [f"decoded:{preds[0]}"]
+
+        processor = Processor()
+        model = SimpleNamespace(
+            transcribe=lambda **_kwargs: SimpleNamespace(preds=["pred-text"]),
+        )
+        backend._loaded = (processor, model)
+        backend.audio_preparer = SimpleNamespace(
+            prepare=lambda _path: SimpleNamespace(wav=SimpleNamespace(squeeze=lambda _dim: waveform)),
+        )
+
+        with patch.object(backend, "_device", return_value="cpu"):
+            result = backend.transcribe(Path("sample.wav"))
+
+        self.assertEqual(result.text, "decoded:pred-text")
+
+    def test_granite_nar_load_uses_auto_processor_and_flash_attention(self):
+        backend = GraniteSpeechNarTransformersBackend("ibm-granite/granite-speech-4.1-2b-nar", "cuda")
+        captured: dict[str, object] = {}
+
+        class FakeModel:
+            def eval(self):
+                return self
+
+        def from_pretrained(_model, **kwargs):
+            captured["model_kwargs"] = kwargs
+            return FakeModel()
+
+        def processor_from_pretrained(_model, **kwargs):
+            captured["processor_kwargs"] = kwargs
+            return "processor"
+
+        fake_transformers = SimpleNamespace(
+            AutoModel=SimpleNamespace(from_pretrained=from_pretrained),
+            AutoProcessor=SimpleNamespace(from_pretrained=processor_from_pretrained),
+        )
+        fake_torch = SimpleNamespace(
+            bfloat16="bf16",
+            float32="fp32",
+            version=SimpleNamespace(hip=None),
+        )
+
+        with (
+            patch.dict("sys.modules", {"transformers": fake_transformers, "torch": fake_torch}),
+            patch("transclip.asr._configure_rocm_nar_attention_env"),
+            patch("transclip.asr._granite_nar_dtype", return_value="bf16"),
+        ):
+            processor, model = backend._load("cuda")
+
+        self.assertEqual(processor, "processor")
+        self.assertIsInstance(model, FakeModel)
+        self.assertEqual(captured["model_kwargs"]["attn_implementation"], "flash_attention_2")
+        self.assertEqual(captured["model_kwargs"]["device_map"], "cuda")
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
+from tests.platform_helpers import linux_runtime
 from tests.service_helpers import FakeRecorder, serve_test_engine, stop_server
 from transclip.cli import main
 from transclip.settings import Settings, write_settings
@@ -196,7 +197,10 @@ class CliTests(unittest.TestCase):
 
     def test_models_list_uses_local_catalog(self):
         stdout = io.StringIO()
-        with redirect_stdout(stdout):
+        with (
+            patch("transclip.runtime_profile.get_runtime", return_value=linux_runtime()),
+            redirect_stdout(stdout),
+        ):
             code = main(["models", "list"])
 
         self.assertEqual(code, 0)
@@ -228,7 +232,10 @@ class CliTests(unittest.TestCase):
         self.assertIn("Binding: <Control><Alt>space", stdout.getvalue())
 
     def test_tray_command_runs_python_tray(self):
-        with patch("transclip.tray.run_python_tray", return_value=7):
+        with (
+            patch("transclip.tray.get_runtime", return_value=linux_runtime()),
+            patch("transclip.tray.run_python_tray", return_value=7),
+        ):
             code = main(["tray"])
 
         self.assertEqual(code, 7)

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -121,6 +121,24 @@ class DaemonTests(unittest.TestCase):
             calls,
         )
 
+    def test_macos_restart_bootstraps_unloaded_launch_agent(self):
+        calls = []
+
+        def runner(command, **_kwargs):
+            calls.append(command)
+            if command[:2] == ["launchctl", "print"]:
+                return type("Completed", (), {"returncode": 1, "stdout": "not loaded"})()
+            return type("Completed", (), {"returncode": 0, "stdout": ""})()
+
+        runtime = FakeRuntime(system="Darwin", home=Path("/Users/test"), check_output_text="501")
+        result = service_action("restart", runner=runner, runtime=runtime)
+
+        self.assertTrue(result.ok)
+        self.assertIn(
+            ["launchctl", "bootstrap", "gui/501", "/Users/test/Library/LaunchAgents/com.paulbrav.transclip.plist"],
+            calls,
+        )
+
     def test_macos_service_state_requires_running_launchd_job(self):
         runtime = FakeRuntime(system="Darwin", home=Path("/Users/test"), check_output_text="501")
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -11,6 +11,8 @@ from transclip.daemon import (
     collect_status,
     install_linux_daemon,
     last_toggle_log_event,
+    service_action,
+    service_state,
     toggle_log_path,
 )
 from transclip.settings import Settings
@@ -83,6 +85,54 @@ class DaemonTests(unittest.TestCase):
                 toggle_log_path(runtime),
                 Path(tmp) / ".cache" / "transclip" / "toggle-record.log",
             )
+
+    def test_macos_start_kickstarts_loaded_launch_agent(self):
+        calls = []
+
+        def runner(command, **_kwargs):
+            calls.append(command)
+            return type("Completed", (), {"returncode": 0, "stdout": "state = running"})()
+
+        runtime = FakeRuntime(system="Darwin", home=Path("/Users/test"), check_output_text="501")
+        result = service_action("start", runner=runner, runtime=runtime)
+
+        self.assertTrue(result.ok)
+        self.assertIn(["launchctl", "print", "gui/501/com.paulbrav.transclip"], calls)
+        self.assertIn(["launchctl", "kickstart", "-k", "gui/501/com.paulbrav.transclip"], calls)
+        self.assertNotIn(
+            ["launchctl", "bootstrap", "gui/501", "/Users/test/Library/LaunchAgents/com.paulbrav.transclip.plist"],
+            calls,
+        )
+
+    def test_macos_start_bootstraps_unloaded_launch_agent(self):
+        calls = []
+
+        def runner(command, **_kwargs):
+            calls.append(command)
+            return_code = 1 if command[:2] == ["launchctl", "print"] else 0
+            return type("Completed", (), {"returncode": return_code, "stdout": ""})()
+
+        runtime = FakeRuntime(system="Darwin", home=Path("/Users/test"), check_output_text="501")
+        result = service_action("start", runner=runner, runtime=runtime)
+
+        self.assertTrue(result.ok)
+        self.assertIn(
+            ["launchctl", "bootstrap", "gui/501", "/Users/test/Library/LaunchAgents/com.paulbrav.transclip.plist"],
+            calls,
+        )
+
+    def test_macos_service_state_requires_running_launchd_job(self):
+        runtime = FakeRuntime(system="Darwin", home=Path("/Users/test"), check_output_text="501")
+
+        def loaded_not_running(_command, **_kwargs):
+            return type("Completed", (), {"returncode": 0, "stdout": "state = exited"})()
+
+        self.assertFalse(service_state(runner=loaded_not_running, runtime=runtime)["active"])
+
+        def running(_command, **_kwargs):
+            return type("Completed", (), {"returncode": 0, "stdout": "state = running\npid = 123"})()
+
+        self.assertTrue(service_state(runner=running, runtime=runtime)["active"])
 
     def test_paste_status_reports_probe_failure(self):
         capability = type(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -71,13 +71,13 @@ class DoctorTests(unittest.TestCase):
         ):
             self.assertTrue(check_asr_runtime(Settings()).ok)
 
-    def test_nar_asr_runtime_does_not_require_flash_attn_on_cpu(self):
+    def test_nar_asr_runtime_rejects_cpu(self):
         torch = SimpleNamespace(version=SimpleNamespace(hip=None))
         with patch.dict("sys.modules", {"torch": torch}):
             check = check_asr_runtime(Settings(asr_device="cpu"))
 
-        self.assertTrue(check.ok)
-        self.assertIn("without flash-attn", check.detail)
+        self.assertFalse(check.ok)
+        self.assertIn("requires CUDA/ROCm", check.detail)
 
     def test_formatters(self):
         checks = [Check("thing", False, "missing thing")]

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -22,7 +22,7 @@ from transclip.doctor import (
 )
 from transclip.gnome_shortcut import GnomeShortcutStatus
 from transclip.models import hf_cache_dir
-from transclip.settings import Settings
+from transclip.settings import Settings, default_settings
 
 
 class DoctorTests(unittest.TestCase):
@@ -98,6 +98,15 @@ class DoctorTests(unittest.TestCase):
         config = next(check for check in checks if check.name == "asr_config")
         self.assertFalse(config.ok)
         self.assertRegex(config.detail, "not supported on Darwin|mlx_audio_whisper")
+
+    def test_darwin_non_arm_default_reports_unsupported_asr_config(self):
+        runtime = FakeRuntime(system="Darwin", home=Path("/Users/test"), check_output_text="x86_64")
+        checks = build_backend_checks(default_settings(runtime), runtime)
+        config = next(check for check in checks if check.name == "asr_config")
+
+        self.assertFalse(config.ok)
+        self.assertIn("unsupported platform", config.detail)
+        self.assertIn("Darwin x86_64", config.detail)
 
     def test_run_checks_does_not_crash_on_darwin_arm(self):
         settings = Settings(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -65,8 +65,19 @@ class DoctorTests(unittest.TestCase):
 
     def test_nar_asr_runtime_checks_flash_attn(self):
         torch = SimpleNamespace(version=SimpleNamespace(hip=None))
-        with patch.dict("sys.modules", {"flash_attn": object(), "torch": torch}):
+        with (
+            patch.dict("sys.modules", {"flash_attn": object(), "torch": torch}),
+            patch("transclip.doctor.resolve_torch_device", return_value="cuda"),
+        ):
             self.assertTrue(check_asr_runtime(Settings()).ok)
+
+    def test_nar_asr_runtime_does_not_require_flash_attn_on_cpu(self):
+        torch = SimpleNamespace(version=SimpleNamespace(hip=None))
+        with patch.dict("sys.modules", {"torch": torch}):
+            check = check_asr_runtime(Settings(asr_device="cpu"))
+
+        self.assertTrue(check.ok)
+        self.assertIn("without flash-attn", check.detail)
 
     def test_formatters(self):
         checks = [Check("thing", False, "missing thing")]

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -4,17 +4,21 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from tests.platform_helpers import darwin_arm_runtime
 from tests.service_helpers import FakeRuntime
 from transclip.doctor import (
     Check,
+    build_backend_checks,
     check_asr_runtime,
     check_config_files,
     check_hotkey_readiness,
+    check_last_shortcut_log_event,
     check_microphone_devices,
     check_model_cache,
     check_paste_tools,
     checks_as_json,
     checks_as_text,
+    run_checks,
 )
 from transclip.gnome_shortcut import GnomeShortcutStatus
 from transclip.models import hf_cache_dir
@@ -47,6 +51,18 @@ class DoctorTests(unittest.TestCase):
             (Path(tmp) / "models--local--asr").mkdir()
             self.assertTrue(check_model_cache(settings).ok)
 
+    def test_file_asr_still_checks_transformers_cleanup_cache(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            settings = Settings(
+                asr_backend="file:/tmp/transcript.txt",
+                cleanup_model="local/cleanup",
+                cleanup_runtime="transformers",
+                model_cache_dir=tmp,
+            )
+            self.assertFalse(check_model_cache(settings).ok)
+            (Path(tmp) / "models--local--cleanup").mkdir()
+            self.assertTrue(check_model_cache(settings).ok)
+
     def test_nar_asr_runtime_checks_flash_attn(self):
         torch = SimpleNamespace(version=SimpleNamespace(hip=None))
         with patch.dict("sys.modules", {"flash_attn": object(), "torch": torch}):
@@ -56,6 +72,34 @@ class DoctorTests(unittest.TestCase):
         checks = [Check("thing", False, "missing thing")]
         self.assertIn('"name": "thing"', checks_as_json(checks))
         self.assertEqual(checks_as_text(checks), "missing\tthing\tmissing thing")
+
+    def test_last_shortcut_log_check_accepts_runtime(self):
+        check = check_last_shortcut_log_event(runtime=FakeRuntime(system="Linux", home=Path("/tmp")))
+        self.assertFalse(check.ok)
+        self.assertIn("toggle-record.log", check.detail)
+
+    def test_stale_granite_nar_on_darwin_reports_asr_config(self):
+        settings = Settings(
+            asr_backend="granite_nar",
+            asr_model="ibm-granite/granite-speech-4.1-2b-nar",
+        )
+        checks = build_backend_checks(settings, darwin_arm_runtime())
+        config = next(check for check in checks if check.name == "asr_config")
+        self.assertFalse(config.ok)
+        self.assertRegex(config.detail, "not supported on Darwin|mlx_audio_whisper")
+
+    def test_run_checks_does_not_crash_on_darwin_arm(self):
+        settings = Settings(
+            asr_backend="mlx_audio_whisper",
+            asr_model="mlx-community/whisper-large-v3-turbo-asr-fp16",
+        )
+        with (
+            patch("transclip.doctor.service_state", return_value={"installed": False, "active": False, "detail": ""}),
+            patch("transclip.doctor.InferenceClient") as client,
+        ):
+            client.return_value.health.side_effect = OSError("offline")
+            checks = run_checks(settings, runtime=darwin_arm_runtime())
+        self.assertTrue(any(check.name == "last_shortcut_log_event" for check in checks))
 
     def test_config_check_honors_config_dir(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -189,7 +233,7 @@ card 1: Generic_1 [HD-Audio Generic], device 0: ALC245 Analog [ALC245 Analog]
             available={"arecord": "/usr/bin/arecord"},
             run_func=lambda _command, **_kwargs: completed,
         )
-        check = check_microphone_devices(runtime)
+        check = check_microphone_devices(runtime=runtime)
 
         self.assertTrue(check.ok)
         self.assertIn("HD-Audio Generic", check.detail)
@@ -198,10 +242,11 @@ card 1: Generic_1 [HD-Audio Generic], device 0: ALC245 Analog [ALC245 Analog]
         completed = type("Completed", (), {"returncode": 1, "stdout": "no soundcards found..."})()
 
         runtime = FakeRuntime(
+            system="Linux",
             available={"arecord": "/usr/bin/arecord"},
             run_func=lambda _command, **_kwargs: completed,
         )
-        check = check_microphone_devices(runtime)
+        check = check_microphone_devices(runtime=runtime)
 
         self.assertFalse(check.ok)
         self.assertIn("arecord did not list", check.detail)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -126,6 +126,7 @@ class ModelsTests(unittest.TestCase):
             )
 
         self.assertIn("Library/Caches/huggingface/hub", captured["cache_dir"])
+        self.assertNotIn("local_dir_use_symlinks", captured)
 
     def test_mlx_snapshot_path_uses_refs_main(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,14 +1,17 @@
 import tempfile
+import types
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from tests.platform_helpers import darwin_arm_runtime, linux_runtime
 from transclip.models import (
     SUPPORTED_MODELS,
     cache_artifacts_present,
     ensure_disk_space,
     model_rows,
     normalize_asr_backend,
+    prefetch_model,
     required_model_cache_paths,
     validate_asr_model_backend,
 )
@@ -16,26 +19,41 @@ from transclip.settings import Settings
 
 
 class ModelsTests(unittest.TestCase):
+    linux = linux_runtime()
     def test_catalog_contains_current_granite_backends(self):
         rows = {(model.backend, model.model_id) for model in SUPPORTED_MODELS}
 
         self.assertIn(("granite_nar", "ibm-granite/granite-speech-4.1-2b-nar"), rows)
         self.assertIn(("granite", "ibm-granite/granite-speech-4.1-2b"), rows)
+        self.assertIn(("mlx_audio_whisper", "mlx-community/whisper-large-v3-turbo-asr-fp16"), rows)
+        self.assertIn(("granite_mlx", "mlx-community/granite-4.0-1b-speech-8bit"), rows)
+
+    def test_mlx_aliases_normalize(self):
+        self.assertEqual(normalize_asr_backend("mlx"), "mlx_audio_whisper")
+        self.assertEqual(normalize_asr_backend("mlx_whisper"), "mlx_audio_whisper")
 
     def test_model_catalog_owns_asr_backend_compatibility(self):
         self.assertEqual(normalize_asr_backend("nar"), "granite_nar")
         self.assertEqual(
-            validate_asr_model_backend("granite_nar", "ibm-granite/granite-speech-4.1-2b-nar"),
+            validate_asr_model_backend(
+                "granite_nar",
+                "ibm-granite/granite-speech-4.1-2b-nar",
+                self.linux,
+            ),
             "granite_nar",
         )
         self.assertEqual(
-            validate_asr_model_backend("transformers", "ibm-granite/granite-speech-4.1-2b"),
+            validate_asr_model_backend(
+                "transformers",
+                "ibm-granite/granite-speech-4.1-2b",
+                self.linux,
+            ),
             "granite",
         )
-        with self.assertRaisesRegex(ValueError, "Granite NAR ASR requires"):
-            validate_asr_model_backend("granite_nar", "ibm-granite/granite-speech-4.1-2b")
-        with self.assertRaisesRegex(ValueError, "Use asr_backend"):
-            validate_asr_model_backend("granite", "ibm-granite/granite-speech-4.1-2b-nar")
+        with self.assertRaisesRegex(ValueError, "requires asr_backend='granite'"):
+            validate_asr_model_backend("granite_nar", "ibm-granite/granite-speech-4.1-2b", self.linux)
+        with self.assertRaisesRegex(ValueError, "requires asr_backend='granite_nar'"):
+            validate_asr_model_backend("granite", "ibm-granite/granite-speech-4.1-2b-nar", self.linux)
 
     def test_cache_detection_and_rows_do_not_download(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -44,7 +62,9 @@ class ModelsTests(unittest.TestCase):
             model_dir.mkdir(parents=True)
 
             self.assertTrue(cache_artifacts_present(settings.asr_model, settings))
-            current = next(row for row in model_rows(settings) if row["model_id"] == settings.asr_model)
+            current = next(
+                row for row in model_rows(settings, runtime=self.linux) if row["model_id"] == settings.asr_model
+            )
             self.assertEqual(current["marker"], "current,default")
             self.assertTrue(current["cached"])
 
@@ -64,6 +84,23 @@ class ModelsTests(unittest.TestCase):
                     Path(tmp) / "models--local--cleanup",
                 ],
             )
+
+    def test_mlx_prefetch_uses_platform_cache_root(self):
+        captured: dict[str, str] = {}
+
+        def fake_snapshot_download(**kwargs):
+            captured.update(kwargs)
+            return "/tmp/fake"
+
+        fake_huggingface_hub = types.SimpleNamespace(snapshot_download=fake_snapshot_download)
+        with patch.dict("sys.modules", {"huggingface_hub": fake_huggingface_hub}):
+            prefetch_model(
+                "mlx-community/whisper-large-v3-turbo-asr-fp16",
+                Settings(),
+                darwin_arm_runtime(),
+            )
+
+        self.assertIn("Library/Caches/huggingface/hub", captured["cache_dir"])
 
     def test_disk_space_failure_uses_catalog_estimate(self):
         usage = type("Usage", (), {"free": 1})()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,6 +9,7 @@ from transclip.models import (
     SUPPORTED_MODELS,
     cache_artifacts_present,
     ensure_disk_space,
+    mlx_snapshot_path,
     model_rows,
     normalize_asr_backend,
     prefetch_model,
@@ -20,6 +21,7 @@ from transclip.settings import Settings
 
 class ModelsTests(unittest.TestCase):
     linux = linux_runtime()
+
     def test_catalog_contains_current_granite_backends(self):
         rows = {(model.backend, model.model_id) for model in SUPPORTED_MODELS}
 
@@ -101,6 +103,22 @@ class ModelsTests(unittest.TestCase):
             )
 
         self.assertIn("Library/Caches/huggingface/hub", captured["cache_dir"])
+
+    def test_mlx_snapshot_path_uses_refs_main(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            settings = Settings(model_cache_dir=tmp)
+            root = Path(tmp) / "models--mlx-community--whisper-large-v3-turbo-asr-fp16"
+            (root / "snapshots" / "aaa").mkdir(parents=True)
+            selected = root / "snapshots" / "bbb"
+            selected.mkdir()
+            (root / "snapshots" / "zzz").mkdir()
+            (root / "refs").mkdir()
+            (root / "refs" / "main").write_text("bbb\n", encoding="utf-8")
+
+            self.assertEqual(
+                mlx_snapshot_path("mlx-community/whisper-large-v3-turbo-asr-fp16", settings),
+                selected,
+            )
 
     def test_disk_space_failure_uses_catalog_estimate(self):
         usage = type("Usage", (), {"free": 1})()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from tests.platform_helpers import darwin_arm_runtime, linux_runtime
+from tests.service_helpers import FakeRuntime
 from transclip.models import (
     SUPPORTED_MODELS,
     cache_artifacts_present,
@@ -27,6 +28,7 @@ class ModelsTests(unittest.TestCase):
 
         self.assertIn(("granite_nar", "ibm-granite/granite-speech-4.1-2b-nar"), rows)
         self.assertIn(("granite", "ibm-granite/granite-speech-4.1-2b"), rows)
+        self.assertIn(("granite", "ibm-granite/granite-speech-4.1-2b-plus"), rows)
         self.assertIn(("mlx_audio_whisper", "mlx-community/whisper-large-v3-turbo-asr-fp16"), rows)
         self.assertIn(("granite_mlx", "mlx-community/granite-4.0-1b-speech-8bit"), rows)
 
@@ -52,10 +54,31 @@ class ModelsTests(unittest.TestCase):
             ),
             "granite",
         )
+        self.assertEqual(
+            validate_asr_model_backend(
+                "granite",
+                "ibm-granite/granite-speech-4.1-2b-plus",
+                darwin_arm_runtime(),
+            ),
+            "granite",
+        )
         with self.assertRaisesRegex(ValueError, "requires asr_backend='granite'"):
             validate_asr_model_backend("granite_nar", "ibm-granite/granite-speech-4.1-2b", self.linux)
         with self.assertRaisesRegex(ValueError, "requires asr_backend='granite_nar'"):
             validate_asr_model_backend("granite", "ibm-granite/granite-speech-4.1-2b-nar", self.linux)
+
+    def test_granite_autoregressive_models_are_listed_on_darwin_arm(self):
+        rows = {(row["backend"], row["model_id"]) for row in model_rows(Settings(), runtime=darwin_arm_runtime())}
+
+        self.assertIn(("granite", "ibm-granite/granite-speech-4.1-2b"), rows)
+        self.assertIn(("granite", "ibm-granite/granite-speech-4.1-2b-plus"), rows)
+        self.assertNotIn(("granite_nar", "ibm-granite/granite-speech-4.1-2b-nar"), rows)
+
+    def test_darwin_intel_rejects_apple_silicon_granite_mps_models(self):
+        runtime = FakeRuntime(system="Darwin", home=Path("/Users/test"), check_output_text="x86_64")
+
+        with self.assertRaisesRegex(ValueError, "requires aarch64, arm64"):
+            validate_asr_model_backend("granite", "ibm-granite/granite-speech-4.1-2b", runtime)
 
     def test_cache_detection_and_rows_do_not_download(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_platform_runtime.py
+++ b/tests/test_platform_runtime.py
@@ -2,6 +2,7 @@ import tempfile
 import unittest
 from dataclasses import replace
 from pathlib import Path
+from unittest.mock import patch
 
 from tests.service_helpers import FakeRuntime
 from transclip.platform_runtime import user_cache_dir, user_config_dir, user_log_dir
@@ -43,6 +44,17 @@ class PlatformRuntimeTests(unittest.TestCase):
         self.assertEqual(settings.asr_backend, "granite_nar")
         self.assertEqual(settings.asr_model, "ibm-granite/granite-speech-4.1-2b-nar")
 
+    def test_linux_cpu_profile_defaults_to_autoregressive_granite(self):
+        runtime = FakeRuntime(system="Linux", home=Path("/home/user"))
+        with patch("transclip.runtime_profile.machine_architecture", return_value="armv7l"):
+            profile = detect_runtime_profile(runtime)
+            settings = default_settings(runtime)
+
+        self.assertEqual(profile.profile_id, "linux_cpu")
+        self.assertEqual(settings.asr_backend, "granite")
+        self.assertEqual(settings.asr_model, "ibm-granite/granite-speech-4.1-2b")
+        self.assertEqual(settings.asr_device, "cpu")
+
     def test_darwin_arm_profile_defaults(self):
         runtime = FakeRuntime(system="Darwin", home=Path("/Users/test"), check_output_text="arm64")
         profile = detect_runtime_profile(runtime)
@@ -51,6 +63,13 @@ class PlatformRuntimeTests(unittest.TestCase):
         self.assertEqual(profile.profile_id, "darwin_arm_mlx")
         self.assertEqual(settings.asr_backend, "mlx_audio_whisper")
         self.assertEqual(settings.asr_model, "mlx-community/whisper-large-v3-turbo-asr-fp16")
+        self.assertEqual(settings.asr_device, "auto")
+
+    def test_darwin_non_arm_profile_defaults_to_valid_file_backend(self):
+        runtime = FakeRuntime(system="Darwin", home=Path("/Users/test"), check_output_text="x86_64")
+        settings = default_settings(runtime)
+
+        self.assertEqual(settings.asr_backend, "file:/dev/null")
 
     def test_granite_nar_rejected_on_darwin_arm(self):
         runtime = FakeRuntime(system="Darwin", home=Path("/Users/test"), check_output_text="arm64")

--- a/tests/test_platform_runtime.py
+++ b/tests/test_platform_runtime.py
@@ -1,0 +1,73 @@
+import tempfile
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+from tests.service_helpers import FakeRuntime
+from transclip.platform_runtime import user_cache_dir, user_config_dir, user_log_dir
+from transclip.runtime_profile import detect_runtime_profile
+from transclip.settings import default_settings
+
+
+class PlatformRuntimeTests(unittest.TestCase):
+    def test_linux_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = FakeRuntime(system="Linux", home=Path(tmp))
+            self.assertEqual(user_config_dir("transclip", runtime), Path(tmp) / ".config" / "transclip")
+            self.assertEqual(user_cache_dir("transclip", runtime), Path(tmp) / ".cache" / "transclip")
+            self.assertEqual(user_log_dir("transclip", runtime), Path(tmp) / ".cache" / "transclip")
+
+    def test_darwin_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = FakeRuntime(system="Darwin", home=Path(tmp))
+            self.assertEqual(
+                user_config_dir("transclip", runtime),
+                Path(tmp) / "Library" / "Application Support" / "transclip",
+            )
+            self.assertEqual(
+                user_cache_dir("transclip", runtime),
+                Path(tmp) / "Library" / "Caches" / "transclip",
+            )
+            self.assertEqual(user_log_dir("transclip", runtime), Path(tmp) / "Library" / "Logs" / "transclip")
+            self.assertEqual(
+                user_cache_dir("huggingface", runtime),
+                Path(tmp) / "Library" / "Caches" / "huggingface",
+            )
+
+    def test_linux_profile_defaults(self):
+        runtime = FakeRuntime(system="Linux", home=Path("/home/user"))
+        profile = detect_runtime_profile(runtime)
+        settings = default_settings(runtime)
+
+        self.assertEqual(profile.profile_id, "linux_gpu")
+        self.assertEqual(settings.asr_backend, "granite_nar")
+        self.assertEqual(settings.asr_model, "ibm-granite/granite-speech-4.1-2b-nar")
+
+    def test_darwin_arm_profile_defaults(self):
+        runtime = FakeRuntime(system="Darwin", home=Path("/Users/test"), check_output_text="arm64")
+        profile = detect_runtime_profile(runtime)
+        settings = default_settings(runtime)
+
+        self.assertEqual(profile.profile_id, "darwin_arm_mlx")
+        self.assertEqual(settings.asr_backend, "mlx_audio_whisper")
+        self.assertEqual(settings.asr_model, "mlx-community/whisper-large-v3-turbo-asr-fp16")
+
+    def test_granite_nar_rejected_on_darwin_arm(self):
+        runtime = FakeRuntime(system="Darwin", home=Path("/Users/test"), check_output_text="arm64")
+        settings = replace(
+            default_settings(runtime),
+            asr_backend="granite_nar",
+            asr_model="ibm-granite/granite-speech-4.1-2b-nar",
+        )
+        from transclip.models import validate_asr_model_backend
+
+        with self.assertRaisesRegex(ValueError, "not supported on Darwin"):
+            validate_asr_model_backend(settings.asr_backend, settings.asr_model, runtime)
+
+    def test_bytes_uname_output_is_decoded_for_arm_detection(self):
+        runtime = FakeRuntime(system="Darwin", home=Path("/Users/test"), check_output_text=b"arm64")
+        self.assertTrue(detect_runtime_profile(runtime).profile_id == "darwin_arm_mlx")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,7 +1,9 @@
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
+from tests.platform_helpers import linux_runtime
 from transclip.settings import (
     DEFAULT_HOTKEY_LINUX,
     Settings,
@@ -16,7 +18,7 @@ class SettingsTests(unittest.TestCase):
     def test_default_files_round_trip(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            settings_file = write_default_settings(root / "settings.toml")
+            settings_file = write_default_settings(root / "settings.toml", runtime=linux_runtime())
 
             settings = load_settings(settings_file)
 
@@ -39,13 +41,17 @@ class SettingsTests(unittest.TestCase):
 
     def test_platform_helpers_have_defaults(self):
         settings = Settings()
-        self.assertIn("XF86TouchpadOff", settings.active_hotkey)
-        self.assertIn("V", settings.paste_shortcut)
+        with patch("transclip.settings.default_platform_runtime.system", return_value="Linux"):
+            self.assertIn("XF86TouchpadOff", settings.active_hotkey)
+            self.assertEqual(settings.paste_shortcut, "Ctrl+Shift+V")
+        with patch("transclip.settings.default_platform_runtime.system", return_value="Darwin"):
+            self.assertEqual(settings.active_hotkey, "Option+Space")
+            self.assertEqual(settings.paste_shortcut, "Command+V")
 
     def test_set_setting_rewrites_canonical_toml(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "settings.toml"
-            write_default_settings(path)
+            write_default_settings(path, runtime=linux_runtime())
 
             updated = set_setting(path, "toggle_cooldown_ms", "750")
 
@@ -58,7 +64,7 @@ class SettingsTests(unittest.TestCase):
         self.assertEqual(coerce_setting_value("sample_rate", "22050"), 22050)
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "settings.toml"
-            write_default_settings(path)
+            write_default_settings(path, runtime=linux_runtime())
             with self.assertRaises(ValueError):
                 set_setting(path, "wat", "true")
 

--- a/tests/test_tray.py
+++ b/tests/test_tray.py
@@ -5,8 +5,9 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from tests.service_helpers import FakeRuntime
 from transclip.settings import DEFAULT_HOTKEY_LINUX, Settings, load_settings, write_settings
-from transclip.tray import run_python_tray
+from transclip.tray import run_python_tray, run_tray
 
 
 class FakeLabel:
@@ -152,6 +153,8 @@ class FakeClient:
 
 class TrayTests(unittest.TestCase):
     def setUp(self):
+        self.runtime_patch = patch("transclip.runtime_profile.get_runtime", return_value=FakeRuntime(system="Linux"))
+        self.runtime_patch.start()
         gi = types.ModuleType("gi")
         gi.require_version = lambda *_args: None
         repository = types.ModuleType("gi.repository")
@@ -177,6 +180,9 @@ class TrayTests(unittest.TestCase):
         repository.AyatanaAppIndicator3 = app_indicator
         repository.GLib = glib
         self.modules = {"gi": gi, "gi.repository": repository}
+
+    def tearDown(self):
+        self.runtime_patch.stop()
 
     def test_health_refresh_updates_existing_menu_without_replacing_it(self):
         with (
@@ -314,6 +320,25 @@ class TrayTests(unittest.TestCase):
 
         install_shortcut.assert_not_called()
         self.assertIn("not a valid", indicator.menus[0].children[0].child.text)
+
+    def test_darwin_tray_fails_clearly_without_gtk(self):
+        runtime = FakeRuntime(system="Darwin", home=Path("/Users/test"))
+        with patch("transclip.tray.get_runtime", return_value=runtime):
+            code = run_tray(Settings())
+        self.assertEqual(code, 1)
+
+    def test_linux_tray_filters_macos_only_models(self):
+        with (
+            patch.dict(sys.modules, self.modules),
+            patch("transclip.tray.InferenceClient", FakeClient),
+            patch("transclip.tray.read_history", return_value=[]),
+        ):
+            run_python_tray(Settings())
+            model_item = menu_item_by_label(FakeIndicatorFactory.current, "ASR model")
+
+        labels = [getattr(child.child, "text", "") for child in model_item.submenu.children]
+        self.assertIn("✓ Fast local ASR - Granite 4.1 NAR", labels)
+        self.assertNotIn("mlx-community/whisper-large-v3-turbo-asr-fp16", labels)
 
 
 def menu_item_by_label(indicator, label: str):

--- a/transclip/asr.py
+++ b/transclip/asr.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import platform as py_platform
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -374,9 +375,20 @@ def granite_user_prompt(keywords: list[str] | None = None) -> str:
 
 
 def _granite_transformers_dtype(torch, device: str):
-    if device in {"cuda", "mps"}:
+    if device == "cuda":
+        return torch.bfloat16
+    if device == "mps" and _mps_bfloat16_supported():
         return torch.bfloat16
     return torch.float32
+
+
+def _mps_bfloat16_supported() -> bool:
+    version = py_platform.mac_ver()[0]
+    try:
+        major = int(version.split(".", 1)[0])
+    except (TypeError, ValueError):
+        return True
+    return major >= 14
 
 
 def _granite_nar_dtype(torch, device: str):

--- a/transclip/asr.py
+++ b/transclip/asr.py
@@ -42,6 +42,7 @@ class PreparedTorchAudio:
 class PreparedPathAudio:
     wav_path: Path
     sample_rate: int
+    temporary: bool = False
 
 
 class AudioLoader:
@@ -98,7 +99,7 @@ class PathAudioPreparer:
         with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as handle:
             output = Path(handle.name)
         sf.write(str(output), mono, self.target_sample_rate)
-        return PreparedPathAudio(wav_path=output, sample_rate=self.target_sample_rate)
+        return PreparedPathAudio(wav_path=output, sample_rate=self.target_sample_rate, temporary=True)
 
 
 # Backward-compatible alias used in tests
@@ -214,15 +215,18 @@ class GraniteSpeechNarTransformersBackend:
 
         dtype = _granite_nar_dtype(torch, device)
         _configure_rocm_nar_attention_env(os, torch, device)
-        model = AutoModel.from_pretrained(
-            self.model,
-            trust_remote_code=True,
-            torch_dtype=dtype,
-            attn_implementation="flash_attention_2",
-            device_map=device,
-            local_files_only=self.local_files_only,
-            cache_dir=self.cache_dir or None,
-        )
+        model_kwargs = {
+            "trust_remote_code": True,
+            "torch_dtype": dtype,
+            "local_files_only": self.local_files_only,
+            "cache_dir": self.cache_dir or None,
+        }
+        if _granite_nar_uses_flash_attention(torch, device):
+            model_kwargs["attn_implementation"] = "flash_attention_2"
+            model_kwargs["device_map"] = device
+        model = AutoModel.from_pretrained(self.model, **model_kwargs)
+        if not _granite_nar_uses_flash_attention(torch, device) and hasattr(model, "to"):
+            model.to(device)
         model.eval()
         processor = AutoProcessor.from_pretrained(
             self.model,
@@ -292,9 +296,13 @@ class MlxAudioASRBackend:
             audio = self.audio_preparer.prepare(wav_path)
             model_path = self._model_path()
             try:
-                result = generate_transcription(model=model_path, audio=str(audio.wav_path))
-            except TypeError:
-                result = generate_transcription(audio_path=str(audio.wav_path), model_path=model_path)
+                try:
+                    result = generate_transcription(model=model_path, audio=str(audio.wav_path))
+                except TypeError:
+                    result = generate_transcription(audio_path=str(audio.wav_path), model_path=model_path)
+            finally:
+                if getattr(audio, "temporary", False):
+                    audio.wav_path.unlink(missing_ok=True)
             text = getattr(result, "text", None) or str(result)
         return TranscriptionResult(text.strip(), timings, self.name, self.model)
 
@@ -359,6 +367,11 @@ def _configure_rocm_nar_attention_env(os_module, torch, device: str) -> None:
     if device == "cuda" and getattr(torch.version, "hip", None):
         os_module.environ.setdefault("FLASH_ATTENTION_TRITON_AMD_ENABLE", "TRUE")
         os_module.environ.setdefault("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL", "1")
+
+
+def _granite_nar_uses_flash_attention(torch, device: str) -> bool:
+    del torch
+    return device == "cuda"
 
 
 def _linear_resample(samples: Any, source_rate: int, target_rate: int) -> Any:

--- a/transclip/asr.py
+++ b/transclip/asr.py
@@ -203,6 +203,11 @@ class GraniteSpeechNarTransformersBackend:
     def _load(self, device: str):
         if self._loaded is not None:
             return self._loaded
+        if device != "cuda":
+            raise RuntimeError(
+                "Granite Speech NAR requires CUDA/ROCm with flash-attn. "
+                "Use asr_backend='granite' or another CPU-supported backend for CPU."
+            )
         try:
             import os
 
@@ -220,13 +225,10 @@ class GraniteSpeechNarTransformersBackend:
             "torch_dtype": dtype,
             "local_files_only": self.local_files_only,
             "cache_dir": self.cache_dir or None,
+            "attn_implementation": "flash_attention_2",
+            "device_map": device,
         }
-        if _granite_nar_uses_flash_attention(torch, device):
-            model_kwargs["attn_implementation"] = "flash_attention_2"
-            model_kwargs["device_map"] = device
         model = AutoModel.from_pretrained(self.model, **model_kwargs)
-        if not _granite_nar_uses_flash_attention(torch, device) and hasattr(model, "to"):
-            model.to(device)
         model.eval()
         processor = AutoProcessor.from_pretrained(
             self.model,
@@ -242,11 +244,14 @@ class GraniteSpeechNarTransformersBackend:
         timings: dict[str, float] = {}
         device = self._device()
         with timed_ms(timings, "asr"):
+            import torch
+
             processor, model = self._load(device)
             audio = self.audio_preparer.prepare(wav_path)
             waveform = audio.wav.squeeze(0)
             inputs = processor([waveform], device=device)
-            output = model.transcribe(**inputs)
+            with torch.inference_mode():
+                output = model.transcribe(**inputs)
             decoded = processor.batch_decode(output.preds)
         return TranscriptionResult(decoded[0].strip(), timings, self.name, self.model)
 
@@ -293,17 +298,29 @@ class MlxAudioASRBackend:
                 raise RuntimeError(
                     "mlx-audio is required on macOS Apple Silicon. Install transclip[mlx]."
                 ) from exc
-            audio = self.audio_preparer.prepare(wav_path)
             model_path = self._model_path()
+            audio = self.audio_preparer.prepare(wav_path)
             try:
-                try:
-                    result = generate_transcription(model=model_path, audio=str(audio.wav_path))
-                except TypeError:
-                    result = generate_transcription(audio_path=str(audio.wav_path), model_path=model_path)
+                with tempfile.TemporaryDirectory(prefix="transclip-mlx-") as tmp:
+                    output_stem = str(Path(tmp) / "transcript")
+                    try:
+                        result = generate_transcription(
+                            model=model_path,
+                            audio=str(audio.wav_path),
+                            output_path=output_stem,
+                            format="txt",
+                        )
+                    except TypeError:
+                        result = generate_transcription(
+                            audio_path=str(audio.wav_path),
+                            model_path=model_path,
+                            output_path=output_stem,
+                            format="txt",
+                        )
+                    text = getattr(result, "text", None) or str(result)
             finally:
                 if getattr(audio, "temporary", False):
                     audio.wav_path.unlink(missing_ok=True)
-            text = getattr(result, "text", None) or str(result)
         return TranscriptionResult(text.strip(), timings, self.name, self.model)
 
 
@@ -333,12 +350,13 @@ def build_asr_backend(
     if entry is None:
         raise ValueError(f"Unsupported ASR configuration: {settings.asr_backend} / {settings.asr_model}")
 
+    torch_device = "auto" if backend_kind == "granite" and settings.asr_device == "mlx" else settings.asr_device
     if backend_kind == "granite_nar":
-        backend = GraniteSpeechNarTransformersBackend(settings.asr_model, settings.asr_device)
+        backend = GraniteSpeechNarTransformersBackend(settings.asr_model, torch_device)
     elif backend_kind in {"mlx_audio_whisper", "granite_mlx"}:
         backend = MlxAudioASRBackend(settings.asr_model, backend_kind, settings)
     else:
-        backend = GraniteSpeechTransformersBackend(settings.asr_model, settings.asr_device)
+        backend = GraniteSpeechTransformersBackend(settings.asr_model, torch_device)
 
     backend.local_files_only = settings.models_local_files_only
     backend.cache_dir = settings.model_cache_dir

--- a/transclip/asr.py
+++ b/transclip/asr.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
 from .device import resolve_torch_device
-from .models import validate_asr_model_backend
+from .models import (
+    mlx_snapshot_path,
+    model_cache_path,
+    resolve_catalog_entry,
+    validate_asr_model_backend,
+)
+from .platform_runtime import PlatformRuntime
 from .settings import Settings
 from .timing import timed_ms
 
@@ -26,20 +33,43 @@ class ASRBackend(Protocol):
 
 
 @dataclass(slots=True)
-class PreparedAudio:
+class PreparedTorchAudio:
     wav: Any
     sample_rate: int
 
 
-class DefaultASRAudioPreparer:
+@dataclass(slots=True)
+class PreparedPathAudio:
+    wav_path: Path
+    sample_rate: int
+
+
+class AudioLoader:
     def __init__(self, target_sample_rate: int = 16000):
         self.target_sample_rate = target_sample_rate
 
-    def prepare(self, wav_path: Path) -> PreparedAudio:
+    def load_samples(self, wav_path: Path) -> tuple[Any, int]:
         import soundfile as sf
-        import torch
 
         samples, sample_rate = sf.read(str(wav_path), dtype="float32", always_2d=True)
+        return samples, sample_rate
+
+    @staticmethod
+    def fold_mono(samples: Any) -> Any:
+        if samples.shape[1] == 1:
+            return samples[:, 0]
+        return samples.mean(axis=1)
+
+
+class TorchAudioPreparer:
+    def __init__(self, target_sample_rate: int = 16000):
+        self.target_sample_rate = target_sample_rate
+        self.loader = AudioLoader(target_sample_rate)
+
+    def prepare(self, wav_path: Path) -> PreparedTorchAudio:
+        import torch
+
+        samples, sample_rate = self.loader.load_samples(wav_path)
         wav = torch.from_numpy(samples.T)
         if wav.shape[0] != 1:
             wav = wav.mean(dim=0, keepdim=True)
@@ -47,7 +77,32 @@ class DefaultASRAudioPreparer:
             import torchaudio
 
             wav = torchaudio.functional.resample(wav, sample_rate, self.target_sample_rate)
-        return PreparedAudio(wav=wav, sample_rate=self.target_sample_rate)
+        return PreparedTorchAudio(wav=wav, sample_rate=self.target_sample_rate)
+
+
+class PathAudioPreparer:
+    def __init__(self, target_sample_rate: int = 16000):
+        self.target_sample_rate = target_sample_rate
+        self.loader = AudioLoader(target_sample_rate)
+
+    def prepare(self, wav_path: Path) -> PreparedPathAudio:
+        samples, sample_rate = self.loader.load_samples(wav_path)
+        if sample_rate == self.target_sample_rate and samples.shape[1] == 1:
+            return PreparedPathAudio(wav_path=wav_path, sample_rate=sample_rate)
+
+        import soundfile as sf
+
+        mono = self.loader.fold_mono(samples)
+        if sample_rate != self.target_sample_rate:
+            mono = _linear_resample(mono, sample_rate, self.target_sample_rate)
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as handle:
+            output = Path(handle.name)
+        sf.write(str(output), mono, self.target_sample_rate)
+        return PreparedPathAudio(wav_path=output, sample_rate=self.target_sample_rate)
+
+
+# Backward-compatible alias used in tests
+DefaultASRAudioPreparer = TorchAudioPreparer
 
 
 class GraniteSpeechTransformersBackend:
@@ -59,7 +114,7 @@ class GraniteSpeechTransformersBackend:
         self.local_files_only = True
         self.cache_dir = ""
         self._loaded = None
-        self.audio_preparer = DefaultASRAudioPreparer()
+        self.audio_preparer = TorchAudioPreparer()
 
     def _device(self):
         return resolve_torch_device(self.device)
@@ -139,7 +194,7 @@ class GraniteSpeechNarTransformersBackend:
         self.local_files_only = True
         self.cache_dir = ""
         self._loaded = None
-        self.audio_preparer = DefaultASRAudioPreparer()
+        self.audio_preparer = TorchAudioPreparer()
 
     def _device(self):
         return resolve_torch_device(self.device)
@@ -151,7 +206,7 @@ class GraniteSpeechNarTransformersBackend:
             import os
 
             import torch
-            from transformers import AutoFeatureExtractor, AutoModel
+            from transformers import AutoModel, AutoProcessor
         except ImportError as exc:
             raise RuntimeError(
                 "transformers, torch, and torchaudio are required. Install transclip[models]."
@@ -162,19 +217,20 @@ class GraniteSpeechNarTransformersBackend:
         model = AutoModel.from_pretrained(
             self.model,
             trust_remote_code=True,
-            dtype=dtype,
+            torch_dtype=dtype,
+            attn_implementation="flash_attention_2",
+            device_map=device,
             local_files_only=self.local_files_only,
             cache_dir=self.cache_dir or None,
         )
-        model.to(device)
         model.eval()
-        feature_extractor = AutoFeatureExtractor.from_pretrained(
+        processor = AutoProcessor.from_pretrained(
             self.model,
             trust_remote_code=True,
             local_files_only=self.local_files_only,
             cache_dir=self.cache_dir or None,
         )
-        self._loaded = (feature_extractor, model)
+        self._loaded = (processor, model)
         return self._loaded
 
     def transcribe(self, wav_path: Path, keywords: list[str] | None = None) -> TranscriptionResult:
@@ -182,15 +238,65 @@ class GraniteSpeechNarTransformersBackend:
         timings: dict[str, float] = {}
         device = self._device()
         with timed_ms(timings, "asr"):
-            import torch
-
-            feature_extractor, model = self._load(device)
+            processor, model = self._load(device)
             audio = self.audio_preparer.prepare(wav_path)
             waveform = audio.wav.squeeze(0)
-            inputs = feature_extractor([waveform], device=device)
-            with torch.inference_mode():
-                output = model.generate(**inputs)
-        return TranscriptionResult(output.text_preds[0].strip(), timings, self.name, self.model)
+            inputs = processor([waveform], device=device)
+            output = model.transcribe(**inputs)
+            decoded = processor.batch_decode(output.preds)
+        return TranscriptionResult(decoded[0].strip(), timings, self.name, self.model)
+
+
+class MlxAudioASRBackend:
+    name = "mlx-audio"
+
+    def __init__(self, model: str, backend_kind: str, settings: Settings | None = None):
+        self.model = model
+        self.backend_kind = backend_kind
+        self.settings = settings
+        self.local_files_only = True
+        self.cache_dir = ""
+        self._resolved_path: str | None = None
+        self.audio_preparer = PathAudioPreparer()
+
+    def _model_path(self) -> str:
+        if self._resolved_path:
+            return self._resolved_path
+        settings = self.settings
+        if self.local_files_only and settings is not None:
+            snapshot = mlx_snapshot_path(self.model, settings)
+            if snapshot is not None:
+                self._resolved_path = str(snapshot)
+                return self._resolved_path
+            cache_path = model_cache_path(self.model, settings)
+            if cache_path.exists():
+                self._resolved_path = str(cache_path)
+                return self._resolved_path
+            raise RuntimeError(
+                f"Local MLX model artifacts missing for {self.model}. "
+                f"Run: transclip models prefetch --model {self.model}"
+            )
+        self._resolved_path = self.model
+        return self._resolved_path
+
+    def transcribe(self, wav_path: Path, keywords: list[str] | None = None) -> TranscriptionResult:
+        del keywords
+        timings: dict[str, float] = {}
+        with timed_ms(timings, "asr"):
+            try:
+                from mlx_audio.stt.generate import generate_transcription
+            except ImportError as exc:
+                raise RuntimeError(
+                    "mlx-audio is required on macOS Apple Silicon. Install transclip[mlx]."
+                ) from exc
+            audio = self.audio_preparer.prepare(wav_path)
+            model_path = self._model_path()
+            try:
+                result = generate_transcription(model=model_path, audio=str(audio.wav_path))
+            except TypeError:
+                result = generate_transcription(audio_path=str(audio.wav_path), model_path=model_path)
+            text = getattr(result, "text", None) or str(result)
+        return TranscriptionResult(text.strip(), timings, self.name, self.model)
 
 
 class FileTranscriptASRBackend:
@@ -208,18 +314,28 @@ class FileTranscriptASRBackend:
         return TranscriptionResult(text.strip(), timings, self.name, self.model)
 
 
-def build_asr_backend(settings: Settings) -> ASRBackend:
+def build_asr_backend(
+    settings: Settings,
+    runtime: PlatformRuntime | None = None,
+) -> ASRBackend:
     if settings.asr_backend.startswith("file:"):
         return FileTranscriptASRBackend(Path(settings.asr_backend.removeprefix("file:")))
-    backend_kind = validate_asr_model_backend(settings.asr_backend, settings.asr_model)
+    backend_kind = validate_asr_model_backend(settings.asr_backend, settings.asr_model, runtime)
+    entry = resolve_catalog_entry(settings, runtime)
+    if entry is None:
+        raise ValueError(f"Unsupported ASR configuration: {settings.asr_backend} / {settings.asr_model}")
+
     if backend_kind == "granite_nar":
         backend = GraniteSpeechNarTransformersBackend(settings.asr_model, settings.asr_device)
-        backend.local_files_only = settings.models_local_files_only
-        backend.cache_dir = settings.model_cache_dir
-        return backend
-    backend = GraniteSpeechTransformersBackend(settings.asr_model, settings.asr_device)
+    elif backend_kind in {"mlx_audio_whisper", "granite_mlx"}:
+        backend = MlxAudioASRBackend(settings.asr_model, backend_kind, settings)
+    else:
+        backend = GraniteSpeechTransformersBackend(settings.asr_model, settings.asr_device)
+
     backend.local_files_only = settings.models_local_files_only
     backend.cache_dir = settings.model_cache_dir
+    if isinstance(backend, MlxAudioASRBackend) and settings.models_local_files_only:
+        backend._model_path()
     return backend
 
 
@@ -243,3 +359,16 @@ def _configure_rocm_nar_attention_env(os_module, torch, device: str) -> None:
     if device == "cuda" and getattr(torch.version, "hip", None):
         os_module.environ.setdefault("FLASH_ATTENTION_TRITON_AMD_ENABLE", "TRUE")
         os_module.environ.setdefault("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL", "1")
+
+
+def _linear_resample(samples: Any, source_rate: int, target_rate: int) -> Any:
+    if source_rate == target_rate:
+        return samples
+    import numpy as np
+
+    if len(samples) == 0:
+        return samples
+    target_length = max(1, round(len(samples) * target_rate / source_rate))
+    source_positions = np.linspace(0.0, 1.0, num=len(samples), endpoint=True)
+    target_positions = np.linspace(0.0, 1.0, num=target_length, endpoint=True)
+    return np.interp(target_positions, source_positions, samples).astype(samples.dtype, copy=False)

--- a/transclip/asr.py
+++ b/transclip/asr.py
@@ -131,7 +131,7 @@ class GraniteSpeechTransformersBackend:
                 "transformers, torch, and torchaudio are required. Install transclip[models]."
             ) from exc
 
-        dtype = torch.bfloat16 if device == "cuda" else torch.float32
+        dtype = _granite_transformers_dtype(torch, device)
         processor = AutoProcessor.from_pretrained(
             self.model,
             local_files_only=self.local_files_only,
@@ -353,6 +353,12 @@ def granite_user_prompt(keywords: list[str] | None = None) -> str:
         if keyword_text:
             return f"transcribe the speech to text. Keywords: {keyword_text}"
     return "transcribe the speech with proper punctuation and capitalization."
+
+
+def _granite_transformers_dtype(torch, device: str):
+    if device in {"cuda", "mps"}:
+        return torch.bfloat16
+    return torch.float32
 
 
 def _granite_nar_dtype(torch, device: str):

--- a/transclip/audio.py
+++ b/transclip/audio.py
@@ -33,13 +33,16 @@ class AudioRecorder:
                 return
             self._frames.append(indata.copy())
 
-        self._stream = sd.InputStream(
-            samplerate=self.settings.sample_rate,
-            channels=1,
-            dtype="int16",
-            callback=callback,
-        )
-        self._stream.start()
+        try:
+            self._stream = sd.InputStream(
+                samplerate=self.settings.sample_rate,
+                channels=1,
+                dtype="int16",
+                callback=callback,
+            )
+            self._stream.start()
+        except Exception as exc:
+            raise _recording_start_error(exc) from exc
 
     def stop_to_wav(self, output_path: Path) -> Path:
         audio = self.stop_samples()
@@ -54,6 +57,20 @@ class AudioRecorder:
         audio = self._np.concatenate(self._frames) if self._frames else self._np.zeros((0, 1), dtype="int16")
         self._stream = None
         return audio
+
+
+def _recording_start_error(exc: Exception) -> RuntimeError:
+    detail = str(exc)
+    lowered = detail.lower()
+    if "permission" in lowered or "denied" in lowered or "not authorized" in lowered:
+        return RuntimeError(
+            "Microphone permission denied. On macOS, grant Microphone access in "
+            "System Settings > Privacy & Security > Microphone for Terminal, your IDE, "
+            "or the LaunchAgent Python process."
+        )
+    if "no input" in lowered or "device" in lowered:
+        return RuntimeError(f"No usable microphone input device: {detail}")
+    return RuntimeError(f"Could not start microphone capture: {detail}")
 
 
 def recording_debug(

--- a/transclip/cli_commands.py
+++ b/transclip/cli_commands.py
@@ -16,14 +16,7 @@ from .daemon import (
     toggle_log_path,
 )
 from .daemon_lifecycle import install_daemon, service_action, uninstall_daemon
-from .doctor import (
-    check_asr_runtime,
-    check_model_cache,
-    check_torch_runtime,
-    checks_as_json,
-    checks_as_text,
-    run_checks,
-)
+from .doctor import build_backend_checks, checks_as_json, checks_as_text, run_checks
 from .eval_harness import run_eval
 from .gnome_shortcut import install_shortcut
 from .history import read_history
@@ -58,9 +51,9 @@ def handle_command(args: argparse.Namespace, parser: argparse.ArgumentParser) ->
     if args.command in {"install", "uninstall", "start", "stop", "restart", "status", "logs", "smoke-test"}:
         return handle_daemon_command(args, settings)
     if args.command == "tray":
-        from .tray import run_python_tray
+        from .tray import run_tray
 
-        return run_python_tray(settings, explicit_settings_path=args.settings)
+        return run_tray(settings, explicit_settings_path=args.settings)
     if args.command == "history":
         return handle_history(args)
     if args.command == "models":
@@ -111,7 +104,7 @@ def handle_doctor(args: argparse.Namespace, settings, config_dir: Path | None) -
         include_audio_debug=args.audio_debug,
     )
     print(checks_as_json(checks) if args.json else checks_as_text(checks))
-    return 0 if all(check.ok for check in checks) else 1
+    return 0 if _checks_pass(checks) else 1
 
 
 def handle_daemon_command(args: argparse.Namespace, settings) -> int:
@@ -163,13 +156,9 @@ def handle_models(args: argparse.Namespace, settings) -> int:
         print(_format_model_rows(model_rows(settings)))
         return 0
     if args.models_command == "doctor":
-        checks = [
-            check_model_cache(settings),
-            check_torch_runtime(settings),
-            check_asr_runtime(settings),
-        ]
+        checks = build_backend_checks(settings)
         print(checks_as_text(checks))
-        return 0 if all(check.ok for check in checks) else 1
+        return 0 if _checks_pass(checks) else 1
     if args.models_command == "prefetch":
         try:
             path = prefetch_model(args.model, settings)
@@ -254,6 +243,10 @@ def _print_command_results(results) -> None:
     for result in results:
         status = "ok" if result.ok else "failed"
         print(f"{status}\t{result.detail}")
+
+
+def _checks_pass(checks) -> bool:
+    return all(check.ok or not check.required for check in checks)
 
 
 def _format_status(status: dict) -> str:

--- a/transclip/cli_commands.py
+++ b/transclip/cli_commands.py
@@ -265,8 +265,9 @@ def _format_status(status: dict) -> str:
     if shortcut is not None:
         lines.append("shortcut\t" + json.dumps(shortcut, sort_keys=True))
     last_event = status.get("last_log_event")
+    log_path = status.get("toggle_log_path") or str(toggle_log_path())
     lines.append(
-        "last_log_event\t" + (json.dumps(last_event, sort_keys=True) if last_event else f"none at {toggle_log_path()}")
+        "last_log_event\t" + (json.dumps(last_event, sort_keys=True) if last_event else f"none at {log_path}")
     )
     return "\n".join(lines)
 

--- a/transclip/daemon.py
+++ b/transclip/daemon.py
@@ -125,6 +125,7 @@ def collect_status(
         "clipboard": clipboard,
         "paste": paste,
         "last_log_event": last_event,
+        "toggle_log_path": str(toggle_log_path(platform_runtime)),
     }
 
 
@@ -141,10 +142,22 @@ def stream_logs(
             command.append("-f")
         runner(command, check=False)
     elif system == "Darwin":
-        for path in (logs_dir(platform_runtime) / "service.out.log", logs_dir(platform_runtime) / "service.err.log"):
+        paths = [
+            logs_dir(platform_runtime) / "service.out.log",
+            logs_dir(platform_runtime) / "service.err.log",
+            toggle_log_path(platform_runtime),
+        ]
+        existing_paths = [path for path in paths if path.exists()]
+        if follow and existing_paths:
+            runner(["tail", "-n", "80", "-f", *[str(path) for path in existing_paths]], check=False)
+            return 0
+        for path in existing_paths:
             if path.exists():
                 print(f"==> {path}")
                 print(path.read_text(encoding="utf-8", errors="replace")[-8000:])
+        if toggle_log_path(platform_runtime) not in existing_paths:
+            print(f"no toggle log at {toggle_log_path(platform_runtime)}")
+        return 0
     path = toggle_log_path(platform_runtime)
     if path.exists():
         print(f"==> {path}")

--- a/transclip/daemon.py
+++ b/transclip/daemon.py
@@ -52,8 +52,11 @@ def append_toggle_log(event: dict[str, Any], path: Path | None = None) -> None:
         handle.write(json.dumps(event, sort_keys=True) + "\n")
 
 
-def last_toggle_log_event(path: Path | None = None) -> dict[str, Any] | None:
-    path = path or toggle_log_path()
+def last_toggle_log_event(
+    path: Path | None = None,
+    runtime: PlatformRuntime | None = None,
+) -> dict[str, Any] | None:
+    path = path or toggle_log_path(runtime)
     if not path.exists():
         return None
     last = _last_nonempty_line(path)
@@ -112,7 +115,7 @@ def collect_status(
 
     clipboard = _clipboard_status(platform_runtime)
     paste = _paste_status(platform_runtime)
-    last_event = last_toggle_log_event()
+    last_event = last_toggle_log_event(runtime=platform_runtime)
     ready = service.get("active") is True and health.get("status") in {"ready", "recording"}
     return {
         "ready": ready,
@@ -138,11 +141,11 @@ def stream_logs(
             command.append("-f")
         runner(command, check=False)
     elif system == "Darwin":
-        for path in (logs_dir() / "service.out.log", logs_dir() / "service.err.log"):
+        for path in (logs_dir(platform_runtime) / "service.out.log", logs_dir(platform_runtime) / "service.err.log"):
             if path.exists():
                 print(f"==> {path}")
                 print(path.read_text(encoding="utf-8", errors="replace")[-8000:])
-    path = toggle_log_path()
+    path = toggle_log_path(platform_runtime)
     if path.exists():
         print(f"==> {path}")
         print(path.read_text(encoding="utf-8", errors="replace")[-8000:])

--- a/transclip/daemon_lifecycle.py
+++ b/transclip/daemon_lifecycle.py
@@ -214,12 +214,12 @@ def service_action(
         plist_path = str(launch_agent_path(runtime))
         domain = launchd_gui_domain(runtime)
         target = launchd_target(runtime)
-        if action == "start" and _launchd_is_loaded(target, runner):
+        if action in {"start", "restart"} and _launchd_is_loaded(target, runner):
             return run_command(["launchctl", "kickstart", "-k", target], runner)
         commands = {
             "start": ["launchctl", "bootstrap", domain, plist_path],
             "stop": ["launchctl", "bootout", target],
-            "restart": ["launchctl", "kickstart", "-k", target],
+            "restart": ["launchctl", "bootstrap", domain, plist_path],
         }
         return run_command(commands[action], runner)
     return CommandResult(False, f"unsupported platform: {system}")

--- a/transclip/daemon_lifecycle.py
+++ b/transclip/daemon_lifecycle.py
@@ -90,12 +90,20 @@ def build_launch_agent(
         "KeepAlive": True,
         "StandardOutPath": str(log_root / "service.out.log"),
         "StandardErrorPath": str(log_root / "service.err.log"),
-        "EnvironmentVariables": {
-            "FLASH_ATTENTION_TRITON_AMD_ENABLE": "TRUE",
-            "TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL": "1",
-        },
     }
     return plistlib.dumps(payload, sort_keys=True)
+
+
+def launchd_gui_domain(runtime: PlatformRuntime | None = None) -> str:
+    output = get_runtime(runtime).check_output(["id", "-u"])
+    if isinstance(output, bytes):
+        output = output.decode()
+    uid = output.strip()
+    return f"gui/{uid}"
+
+
+def launchd_target(runtime: PlatformRuntime | None = None) -> str:
+    return f"{launchd_gui_domain(runtime)}/{LAUNCHD_LABEL}"
 
 
 def install_daemon(
@@ -149,8 +157,10 @@ def install_macos_daemon(
     plist_path.parent.mkdir(parents=True, exist_ok=True)
     plist_path.write_bytes(build_launch_agent(settings_path, runtime=runtime))
     results.append(CommandResult(True, f"wrote {plist_path}"))
-    results.append(run_command(["launchctl", "unload", str(plist_path)], runner, tolerate_failure=True))
-    results.append(run_command(["launchctl", "load", str(plist_path)], runner))
+    domain = launchd_gui_domain(runtime)
+    target = launchd_target(runtime)
+    results.append(run_command(["launchctl", "bootout", target], runner, tolerate_failure=True))
+    results.append(run_command(["launchctl", "bootstrap", domain, str(plist_path)], runner))
     results.append(
         CommandResult(
             True,
@@ -178,7 +188,8 @@ def uninstall_daemon(
         return results
     if system == "Darwin":
         path = launch_agent_path(runtime)
-        results = [run_command(["launchctl", "unload", str(path)], runner, tolerate_failure=True)]
+        target = launchd_target(runtime)
+        results = [run_command(["launchctl", "bootout", target], runner, tolerate_failure=True)]
         if path.exists():
             path.unlink()
             results.append(CommandResult(True, f"removed {path}"))
@@ -201,14 +212,12 @@ def service_action(
         return run_command(commands[action], runner)
     if system == "Darwin":
         plist_path = str(launch_agent_path(runtime))
+        domain = launchd_gui_domain(runtime)
+        target = launchd_target(runtime)
         commands = {
-            "start": ["launchctl", "load", plist_path],
-            "stop": ["launchctl", "unload", plist_path],
-            "restart": [
-                "sh",
-                "-lc",
-                f"launchctl unload {shlex.quote(plist_path)}; launchctl load {shlex.quote(plist_path)}",
-            ],
+            "start": ["launchctl", "bootstrap", domain, plist_path],
+            "stop": ["launchctl", "bootout", target],
+            "restart": ["launchctl", "kickstart", "-k", target],
         }
         return run_command(commands[action], runner)
     return CommandResult(False, f"unsupported platform: {system}")
@@ -242,8 +251,9 @@ def service_state(
         }
     if system == "Darwin":
         path = launch_agent_path(runtime)
+        target = launchd_target(runtime)
         result = runner(
-            ["launchctl", "list", LAUNCHD_LABEL],
+            ["launchctl", "print", target],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,

--- a/transclip/daemon_lifecycle.py
+++ b/transclip/daemon_lifecycle.py
@@ -214,6 +214,8 @@ def service_action(
         plist_path = str(launch_agent_path(runtime))
         domain = launchd_gui_domain(runtime)
         target = launchd_target(runtime)
+        if action == "start" and _launchd_is_loaded(target, runner):
+            return run_command(["launchctl", "kickstart", "-k", target], runner)
         commands = {
             "start": ["launchctl", "bootstrap", domain, plist_path],
             "stop": ["launchctl", "bootout", target],
@@ -259,9 +261,10 @@ def service_state(
             text=True,
             check=False,
         )
+        active = result.returncode == 0 and _launchd_print_reports_running(result.stdout)
         return {
             "installed": path.exists(),
-            "active": result.returncode == 0,
+            "active": active,
             "detail": result.stdout.strip() or f"exit {result.returncode}",
         }
     return {"installed": False, "active": False, "detail": f"unsupported platform: {system}"}
@@ -290,3 +293,24 @@ def run_command(
     elif result.returncode != 0:
         detail += f": exit {result.returncode}"
     return CommandResult(ok, detail)
+
+
+def _launchd_is_loaded(target: str, runner: Runner) -> bool:
+    result = runner(
+        ["launchctl", "print", target],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _launchd_print_reports_running(output: str) -> bool:
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("state ="):
+            return stripped.removeprefix("state =").strip() == "running"
+        if stripped.startswith("pid ="):
+            return True
+    return False

--- a/transclip/doctor.py
+++ b/transclip/doctor.py
@@ -12,7 +12,7 @@ from .audio import recording_debug
 from .client import InferenceClient
 from .daemon import last_toggle_log_event, service_state
 from .daemon_lifecycle import toggle_log_path
-from .device import torch_cuda_usable, torch_mps_available
+from .device import resolve_torch_device, torch_cuda_usable, torch_mps_available
 from .gnome_shortcut import shortcut_readiness
 from .models import (
     cache_artifacts_present,
@@ -109,7 +109,7 @@ def build_mlx_checks(settings: Settings, runtime: PlatformRuntime | None = None)
         ),
         Check(
             "mlx_native_python",
-            is_native_arm_python(),
+            is_native_arm_python(runtime),
             f"Python architecture is {py_platform.machine()}; MLX requires native ARM Python",
         ),
         check_macos_version(),
@@ -377,6 +377,9 @@ def check_asr_runtime(settings: Settings) -> Check:
         import torch
     except ImportError:
         return Check("asr_runtime", False, "torch is not installed")
+    device = resolve_torch_device(settings.asr_device)
+    if device != "cuda":
+        return Check("asr_runtime", True, f"Granite NAR will use {device} without flash-attn")
     if getattr(torch.version, "hip", None):
         os.environ.setdefault("FLASH_ATTENTION_TRITON_AMD_ENABLE", "TRUE")
     try:

--- a/transclip/doctor.py
+++ b/transclip/doctor.py
@@ -1,20 +1,30 @@
 from __future__ import annotations
 
 import json
+import platform as py_platform
 import subprocess
+import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from urllib.error import URLError
 
 from .audio import recording_debug
 from .client import InferenceClient
-from .daemon import last_toggle_log_event, service_state, toggle_log_path
+from .daemon import last_toggle_log_event, service_state
+from .daemon_lifecycle import toggle_log_path
 from .device import torch_cuda_usable, torch_mps_available
 from .gnome_shortcut import shortcut_readiness
-from .models import model_cache_root, required_model_cache_paths
+from .models import (
+    cache_artifacts_present,
+    model_cache_root,
+    normalize_asr_backend,
+    required_model_cache_paths,
+    resolve_catalog_entry,
+)
 from .paste import clipboard_capability, paste_capability
 from .platform_capabilities import session_info
 from .platform_runtime import PlatformRuntime, get_runtime
+from .runtime_profile import detect_runtime_profile, is_apple_silicon, is_native_arm_python
 from .settings import Settings, default_config_dir, settings_path
 
 
@@ -23,6 +33,7 @@ class Check:
     name: str
     ok: bool
     detail: str
+    required: bool = True
 
 
 def run_checks(
@@ -41,15 +52,71 @@ def run_checks(
         check_session_type(platform_runtime),
         check_clipboard_tools(platform_runtime),
         check_paste_tools(platform_runtime),
+        *build_backend_checks(settings, platform_runtime),
         check_hotkey_readiness(settings, platform_runtime),
-        check_microphone_devices(platform_runtime),
-        check_model_cache(settings),
-        check_torch_runtime(settings),
-        check_asr_runtime(settings),
-        check_last_shortcut_log_event(),
+        check_microphone_devices(settings, platform_runtime),
+        check_tcc_permissions(platform_runtime),
+        check_last_shortcut_log_event(platform_runtime),
     ]
     if include_audio_debug:
         checks.append(check_audio_debug(settings))
+    return checks
+
+
+def build_backend_checks(settings: Settings, runtime: PlatformRuntime | None = None) -> list[Check]:
+    if settings.asr_backend.startswith("file:"):
+        return [
+            check_model_cache(settings, runtime),
+            Check("asr_runtime", True, "file backend has no extra runtime checks", required=True),
+        ]
+    try:
+        backend = normalize_asr_backend(settings.asr_backend)
+        entry = resolve_catalog_entry(settings, runtime)
+    except ValueError as exc:
+        return [Check("asr_config", False, str(exc))]
+    checks = [check_model_cache(settings, runtime)]
+    if entry is not None and entry.runtime_kind == "mlx":
+        checks.extend(build_mlx_checks(settings, runtime))
+    elif backend == "granite_nar":
+        checks.extend(
+            [
+                check_torch_runtime(settings),
+                check_asr_runtime(settings),
+            ]
+        )
+    elif entry is not None and entry.runtime_kind == "torch":
+        checks.append(check_torch_runtime(settings))
+    else:
+        checks.append(Check("asr_runtime", True, f"{settings.asr_backend} has no extra runtime checks"))
+    return checks
+
+
+def build_mlx_checks(settings: Settings, runtime: PlatformRuntime | None = None) -> list[Check]:
+    platform_runtime = get_runtime(runtime)
+    system = platform_runtime.system()
+    checks = [
+        Check(
+            "mlx_platform",
+            system == "Darwin",
+            "MLX ASR requires macOS" if system != "Darwin" else "macOS",
+        ),
+        Check(
+            "mlx_apple_silicon",
+            is_apple_silicon(runtime),
+            "MLX ASR requires Apple Silicon (arm64)"
+            if not is_apple_silicon(runtime)
+            else f"architecture={detect_runtime_profile(runtime).architecture}",
+        ),
+        Check(
+            "mlx_native_python",
+            is_native_arm_python(),
+            f"Python architecture is {py_platform.machine()}; MLX requires native ARM Python",
+        ),
+        check_macos_version(),
+        check_mlx_import(),
+        check_mlx_audio_import(),
+        check_mlx_model_cache(settings, runtime),
+    ]
     return checks
 
 
@@ -66,9 +133,7 @@ def check_clipboard_tools(runtime: PlatformRuntime | None = None) -> Check:
 
 
 def check_paste_tools(runtime: PlatformRuntime | None = None) -> Check:
-    capability = paste_capability(
-        runtime=runtime,
-    )
+    capability = paste_capability(runtime=runtime)
     return Check("paste_tools", capability.ok, capability.detail)
 
 
@@ -129,18 +194,36 @@ def check_session_type(runtime: PlatformRuntime | None = None) -> Check:
     return Check("session_type", info.session != "unknown", f"session={info.session}; desktop={info.desktop}")
 
 
-def check_last_shortcut_log_event() -> Check:
-    event = last_toggle_log_event()
+def check_last_shortcut_log_event(runtime: PlatformRuntime | None = None) -> Check:
+    event = last_toggle_log_event(toggle_log_path(runtime))
     if event is None:
-        return Check("last_shortcut_log_event", False, f"no toggle log at {toggle_log_path()}")
+        return Check(
+            "last_shortcut_log_event",
+            False,
+            f"no toggle log at {toggle_log_path(runtime)}",
+            required=False,
+        )
     action = event.get("action") or event.get("unparsed", "unknown")
-    return Check("last_shortcut_log_event", "unparsed" not in event, f"last action={action}; log={toggle_log_path()}")
+    return Check(
+        "last_shortcut_log_event",
+        "unparsed" not in event,
+        f"last action={action}; log={toggle_log_path(runtime)}",
+        required=False,
+    )
 
 
 def check_hotkey_readiness(
     settings: Settings | None = None,
     runtime: PlatformRuntime | None = None,
 ) -> Check:
+    platform_runtime = get_runtime(runtime)
+    if platform_runtime.system() == "Darwin":
+        return Check(
+            "hotkey_readiness",
+            True,
+            "configure a macOS Keyboard Shortcut or Shortcuts.app action for transclip toggle-record --paste",
+            required=False,
+        )
     readiness = shortcut_readiness(
         expected_binding=(settings or Settings()).hotkey_linux,
         runtime=runtime,
@@ -148,15 +231,39 @@ def check_hotkey_readiness(
     return Check("hotkey_readiness", readiness.ok, readiness.detail)
 
 
-def check_microphone_devices(runtime: PlatformRuntime | None = None) -> Check:
+def check_microphone_devices(
+    settings: Settings | None = None,
+    runtime: PlatformRuntime | None = None,
+) -> Check:
+    del settings
     platform_runtime = get_runtime(runtime)
     system = platform_runtime.system()
     if system == "Darwin":
-        return Check(
-            "microphone_devices",
-            True,
-            "macOS microphone visibility is checked by the operating system permission prompt",
-        )
+        try:
+            import sounddevice as sd
+        except ImportError:
+            return Check(
+                "microphone_devices",
+                False,
+                "sounddevice is not installed; install transclip[audio]",
+            )
+        try:
+            default = sd.query_devices(kind="input")
+            name = default.get("name", "unknown")
+            return Check(
+                "microphone_devices",
+                True,
+                f"default input: {name}; grant Microphone permission when prompted on first recording",
+            )
+        except Exception as exc:
+            detail = str(exc)
+            if "permission" in detail.lower() or "denied" in detail.lower():
+                return Check(
+                    "microphone_devices",
+                    False,
+                    "Microphone permission denied; open System Settings > Privacy & Security > Microphone",
+                )
+            return Check("microphone_devices", False, f"sounddevice input query failed: {detail}")
     if system != "Linux":
         return Check("microphone_devices", True, f"not checked on {system}")
 
@@ -192,10 +299,14 @@ def check_microphone_devices(runtime: PlatformRuntime | None = None) -> Check:
     return Check("microphone_devices", False, "requires arecord or wpctl to inspect microphone devices")
 
 
-def check_model_cache(settings: Settings) -> Check:
-    cache_root = model_cache_root(settings)
-    required_paths = required_model_cache_paths(settings)
+def check_model_cache(settings: Settings, runtime: PlatformRuntime | None = None) -> Check:
+    cache_root = model_cache_root(settings, runtime)
+    required_paths = required_model_cache_paths(settings, runtime)
+    if not required_paths:
+        return Check("model_cache", True, "no local model artifacts required")
     missing = [str(path) for path in required_paths if not path.exists()]
+    if not missing and cache_artifacts_present(settings.asr_model, settings, runtime):
+        return Check("model_cache", True, f"found model artifacts under {cache_root}")
     if not missing:
         return Check("model_cache", True, f"found model artifacts under {cache_root}")
     return Check(
@@ -204,6 +315,17 @@ def check_model_cache(settings: Settings) -> Check:
         "missing local model artifacts: "
         + ", ".join(missing)
         + f"; run: transclip models prefetch --model {settings.asr_model}",
+    )
+
+
+def check_mlx_model_cache(settings: Settings, runtime: PlatformRuntime | None = None) -> Check:
+    if cache_artifacts_present(settings.asr_model, settings, runtime):
+        return Check("mlx_model_cache", True, f"found MLX snapshot for {settings.asr_model}")
+    return Check(
+        "mlx_model_cache",
+        False,
+        f"missing MLX model cache for {settings.asr_model}; "
+        f"run: transclip models prefetch --model {settings.asr_model}",
     )
 
 
@@ -247,7 +369,7 @@ def check_torch_runtime(settings: Settings) -> Check:
 
 
 def check_asr_runtime(settings: Settings) -> Check:
-    if settings.asr_backend not in {"granite_nar", "granite-nar", "nar"}:
+    if normalize_asr_backend(settings.asr_backend) != "granite_nar":
         return Check("asr_runtime", True, f"{settings.asr_backend} has no extra runtime checks")
     try:
         import os
@@ -260,8 +382,57 @@ def check_asr_runtime(settings: Settings) -> Check:
     try:
         import flash_attn  # noqa: F401
     except ImportError as exc:
-        return Check("asr_runtime", False, f"Granite NAR requires flash-attn; import failed: {exc}")
-    return Check("asr_runtime", True, "Granite NAR flash-attn runtime import passed")
+        return Check(
+            "asr_runtime",
+            False,
+            f"Granite NAR requires flash-attn (project-validated ROCm where available); import failed: {exc}",
+        )
+    return Check(
+        "asr_runtime",
+        True,
+        "Granite NAR flash-attn runtime import passed (ROCm support is project-validated, not an IBM guarantee)",
+    )
+
+
+def check_mlx_import() -> Check:
+    try:
+        import mlx  # noqa: F401
+    except ImportError as exc:
+        return Check("mlx_import", False, f"mlx import failed: {exc}; install transclip[mlx]")
+    return Check("mlx_import", True, "mlx import passed")
+
+
+def check_mlx_audio_import() -> Check:
+    try:
+        import mlx_audio  # noqa: F401
+    except ImportError as exc:
+        return Check("mlx_audio_import", False, f"mlx_audio import failed: {exc}; install transclip[mlx]")
+    return Check("mlx_audio_import", True, "mlx_audio import passed")
+
+
+def check_macos_version() -> Check:
+    if sys.platform != "darwin":
+        return Check("macos_version", True, "not checked off macOS")
+    version = tuple(int(part) for part in py_platform.mac_ver()[0].split(".")[:2] if part.isdigit())
+    ok = version >= (14, 0) if version else False
+    return Check(
+        "macos_version",
+        ok,
+        f"macOS {py_platform.mac_ver()[0]}; MLX requires macOS >= 14.0",
+    )
+
+
+def check_tcc_permissions(runtime: PlatformRuntime | None = None) -> Check:
+    platform_runtime = get_runtime(runtime)
+    if platform_runtime.system() != "Darwin":
+        return Check("tcc_permissions", True, "not checked off macOS", required=False)
+    return Check(
+        "tcc_permissions",
+        True,
+        "verify manually: Microphone (recording), Accessibility and/or Automation (osascript paste). "
+        "Permissions attach to Terminal, LaunchAgent Python, Shortcuts, or a packaged .app separately.",
+        required=False,
+    )
 
 
 def checks_as_json(checks: list[Check]) -> str:
@@ -272,5 +443,6 @@ def checks_as_text(checks: list[Check]) -> str:
     lines = []
     for check in checks:
         status = "ok" if check.ok else "missing"
-        lines.append(f"{status}\t{check.name}\t{check.detail}")
+        prefix = "" if check.required else "info\t"
+        lines.append(f"{prefix}{status}\t{check.name}\t{check.detail}")
     return "\n".join(lines)

--- a/transclip/doctor.py
+++ b/transclip/doctor.py
@@ -65,6 +65,16 @@ def run_checks(
 
 def build_backend_checks(settings: Settings, runtime: PlatformRuntime | None = None) -> list[Check]:
     if settings.asr_backend.startswith("file:"):
+        profile = detect_runtime_profile(runtime)
+        if settings.asr_backend == "file:/dev/null" and profile.profile_id in {"darwin_other", "unsupported"}:
+            return [
+                check_model_cache(settings, runtime),
+                Check(
+                    "asr_config",
+                    False,
+                    f"unsupported platform for production ASR: {profile.system} {profile.architecture}",
+                ),
+            ]
         return [
             check_model_cache(settings, runtime),
             Check("asr_runtime", True, "file backend has no extra runtime checks", required=True),

--- a/transclip/doctor.py
+++ b/transclip/doctor.py
@@ -379,7 +379,11 @@ def check_asr_runtime(settings: Settings) -> Check:
         return Check("asr_runtime", False, "torch is not installed")
     device = resolve_torch_device(settings.asr_device)
     if device != "cuda":
-        return Check("asr_runtime", True, f"Granite NAR will use {device} without flash-attn")
+        return Check(
+            "asr_runtime",
+            False,
+            "Granite NAR requires CUDA/ROCm with flash-attn; use asr_backend='granite' for CPU",
+        )
     if getattr(torch.version, "hip", None):
         os.environ.setdefault("FLASH_ATTENTION_TRITON_AMD_ENABLE", "TRUE")
     try:

--- a/transclip/gnome_shortcut.py
+++ b/transclip/gnome_shortcut.py
@@ -10,11 +10,11 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .platform_capabilities import session_info
-from .platform_runtime import PlatformRuntime, get_runtime
+from .platform_runtime import PlatformRuntime, get_runtime, user_log_dir
 from .product import (
-    CACHE_DIR_NAME,
     CLI_COMMAND,
     IMPORT_PACKAGE,
+    LOG_DIR_NAME,
     SHORTCUT_NAME,
     SHORTCUT_PATH,
 )
@@ -55,14 +55,20 @@ class ShortcutReadiness:
     status: GnomeShortcutStatus | None = None
 
 
-def build_toggle_command(settings_path: Path | None = None) -> str:
+def build_toggle_command(
+    settings_path: Path | None = None,
+    runtime: PlatformRuntime | None = None,
+) -> str:
     command = build_toggle_invocation(settings_path)
-    script = (
-        f'mkdir -p "$HOME/.cache/{CACHE_DIR_NAME}"; '
-        + shlex.join(command)
-        + f' >> "$HOME/.cache/{CACHE_DIR_NAME}/toggle-record.log" 2>&1'
-    )
+    log_path = toggle_log_shell_path(runtime)
+    quoted_log_path = shlex.quote(log_path)
+    script = f'mkdir -p "$(dirname {quoted_log_path})"; ' + shlex.join(command) + f" >> {quoted_log_path} 2>&1"
     return shlex.join(["/bin/sh", "-lc", script])
+
+
+def toggle_log_shell_path(runtime: PlatformRuntime | None = None) -> str:
+    log_dir = user_log_dir(LOG_DIR_NAME, runtime)
+    return str(log_dir / "toggle-record.log")
 
 
 def build_toggle_invocation(settings_path: Path | None = None) -> list[str]:

--- a/transclip/models.py
+++ b/transclip/models.py
@@ -193,6 +193,11 @@ def mlx_snapshot_path(model_id: str, settings: Settings, runtime: PlatformRuntim
     snapshots = cache_path / "snapshots"
     if not snapshots.exists():
         return None
+    ref = cache_path / "refs" / "main"
+    if ref.exists():
+        snapshot = snapshots / ref.read_text(encoding="utf-8").strip()
+        if snapshot.exists():
+            return snapshot
     candidates = sorted(snapshots.iterdir())
     return candidates[-1] if candidates else None
 

--- a/transclip/models.py
+++ b/transclip/models.py
@@ -309,7 +309,6 @@ def prefetch_model(model_id: str, settings: Settings, runtime: PlatformRuntime |
         snapshot_download(
             repo_id=entry.model_id,
             cache_dir=cache_dir,
-            local_dir_use_symlinks=False,
         )
         return model_cache_path(entry.model_id, settings, runtime)
 

--- a/transclip/models.py
+++ b/transclip/models.py
@@ -42,8 +42,18 @@ MODEL_CATALOG: tuple[ModelCatalogEntry, ...] = (
         backend="granite",
         runtime_kind="torch",
         estimated_bytes=8 * GIB,
-        supported_platforms=frozenset({"Linux"}),
-        supported_architectures=None,
+        supported_platforms=frozenset({"Darwin", "Linux"}),
+        supported_architectures=frozenset({"arm64", "aarch64"}),
+        dependency_extra="models",
+        prefetch_strategy="transformers",
+    ),
+    ModelCatalogEntry(
+        model_id="ibm-granite/granite-speech-4.1-2b-plus",
+        backend="granite",
+        runtime_kind="torch",
+        estimated_bytes=8 * GIB,
+        supported_platforms=frozenset({"Darwin", "Linux"}),
+        supported_architectures=frozenset({"arm64", "aarch64"}),
         dependency_extra="models",
         prefetch_strategy="transformers",
     ),
@@ -131,7 +141,7 @@ def validate_platform_support(
             f"Model {entry.model_id} is not supported on {system}. "
             f"Supported platforms: {', '.join(sorted(entry.supported_platforms))}"
         )
-    if entry.supported_architectures is not None:
+    if entry.supported_architectures is not None and system == "Darwin":
         arch = _machine_arch(runtime)
         if arch not in entry.supported_architectures:
             raise ValueError(

--- a/transclip/models.py
+++ b/transclip/models.py
@@ -3,33 +3,75 @@ from __future__ import annotations
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
-from .platform_runtime import user_cache_dir
-from .settings import Settings
+from .platform_runtime import PlatformRuntime, get_runtime, user_cache_dir
+from .runtime_profile import detect_runtime_profile, is_apple_silicon
+from .settings import Settings, default_settings
 
 GIB = 1024**3
+RuntimeKind = Literal["torch", "mlx", "file"]
+PrefetchStrategy = Literal["transformers", "snapshot_download", "none"]
 
 
 @dataclass(frozen=True, slots=True)
-class SupportedModel:
+class ModelCatalogEntry:
     model_id: str
     backend: str
+    runtime_kind: RuntimeKind
     estimated_bytes: int
+    supported_platforms: frozenset[str]
+    supported_architectures: frozenset[str] | None
+    dependency_extra: str
+    prefetch_strategy: PrefetchStrategy
 
 
-SUPPORTED_MODELS = [
-    SupportedModel(
-        "ibm-granite/granite-speech-4.1-2b-nar",
-        "granite_nar",
-        8 * GIB,
+MODEL_CATALOG: tuple[ModelCatalogEntry, ...] = (
+    ModelCatalogEntry(
+        model_id="ibm-granite/granite-speech-4.1-2b-nar",
+        backend="granite_nar",
+        runtime_kind="torch",
+        estimated_bytes=8 * GIB,
+        supported_platforms=frozenset({"Linux"}),
+        supported_architectures=None,
+        dependency_extra="models",
+        prefetch_strategy="transformers",
     ),
-    SupportedModel(
-        "ibm-granite/granite-speech-4.1-2b",
-        "granite",
-        8 * GIB,
+    ModelCatalogEntry(
+        model_id="ibm-granite/granite-speech-4.1-2b",
+        backend="granite",
+        runtime_kind="torch",
+        estimated_bytes=8 * GIB,
+        supported_platforms=frozenset({"Linux"}),
+        supported_architectures=None,
+        dependency_extra="models",
+        prefetch_strategy="transformers",
     ),
-]
+    ModelCatalogEntry(
+        model_id="mlx-community/whisper-large-v3-turbo-asr-fp16",
+        backend="mlx_audio_whisper",
+        runtime_kind="mlx",
+        estimated_bytes=int(1.61 * GIB),
+        supported_platforms=frozenset({"Darwin"}),
+        supported_architectures=frozenset({"arm64", "aarch64"}),
+        dependency_extra="mlx",
+        prefetch_strategy="snapshot_download",
+    ),
+    ModelCatalogEntry(
+        model_id="mlx-community/granite-4.0-1b-speech-8bit",
+        backend="granite_mlx",
+        runtime_kind="mlx",
+        estimated_bytes=int(2.9 * GIB),
+        supported_platforms=frozenset({"Darwin"}),
+        supported_architectures=frozenset({"arm64", "aarch64"}),
+        dependency_extra="mlx",
+        prefetch_strategy="snapshot_download",
+    ),
+)
+
+# Backward-compatible alias
+SupportedModel = ModelCatalogEntry
+SUPPORTED_MODELS = list(MODEL_CATALOG)
 
 ASR_BACKEND_ALIASES = {
     "granite_nar": "granite_nar",
@@ -37,15 +79,36 @@ ASR_BACKEND_ALIASES = {
     "nar": "granite_nar",
     "granite": "granite",
     "transformers": "granite",
+    "mlx": "mlx_audio_whisper",
+    "mlx_audio_whisper": "mlx_audio_whisper",
+    "mlx_audio": "mlx_audio_whisper",
+    "mlx_whisper": "mlx_audio_whisper",
+    "granite_mlx": "granite_mlx",
 }
 
 
-def model_by_id(model_id: str) -> SupportedModel:
-    for model in SUPPORTED_MODELS:
-        if model.model_id == model_id:
-            return model
-    supported = ", ".join(model.model_id for model in SUPPORTED_MODELS)
+def catalog_entry_for_model(model_id: str) -> ModelCatalogEntry:
+    for entry in MODEL_CATALOG:
+        if entry.model_id == model_id:
+            return entry
+    supported = ", ".join(entry.model_id for entry in MODEL_CATALOG)
     raise ValueError(f"Unsupported model: {model_id}. Supported models: {supported}")
+
+
+def model_by_id(model_id: str) -> ModelCatalogEntry:
+    return catalog_entry_for_model(model_id)
+
+
+def catalog_entry_for_backend(backend: str, model_id: str) -> ModelCatalogEntry:
+    normalized = normalize_asr_backend(backend)
+    if normalized == "file":
+        raise ValueError("file backends do not use the model catalog")
+    entry = catalog_entry_for_model(model_id)
+    if entry.backend != normalized:
+        raise ValueError(
+            f"Model {model_id} requires asr_backend={entry.backend!r}, not {backend!r}"
+        )
+    return entry
 
 
 def normalize_asr_backend(asr_backend: str) -> str:
@@ -57,46 +120,101 @@ def normalize_asr_backend(asr_backend: str) -> str:
         raise ValueError(f"Unsupported ASR backend: {asr_backend}") from exc
 
 
-def validate_asr_model_backend(asr_backend: str, model_id: str) -> str:
+def validate_platform_support(
+    entry: ModelCatalogEntry,
+    runtime: PlatformRuntime | None = None,
+) -> None:
+    platform_runtime = get_runtime(runtime)
+    system = platform_runtime.system()
+    if system not in entry.supported_platforms:
+        raise ValueError(
+            f"Model {entry.model_id} is not supported on {system}. "
+            f"Supported platforms: {', '.join(sorted(entry.supported_platforms))}"
+        )
+    if entry.supported_architectures is not None:
+        arch = _machine_arch(runtime)
+        if arch not in entry.supported_architectures:
+            raise ValueError(
+                f"Model {entry.model_id} requires {', '.join(sorted(entry.supported_architectures))}, "
+                f"but this machine reports {arch}"
+            )
+
+
+def validate_asr_model_backend(
+    asr_backend: str,
+    model_id: str,
+    runtime: PlatformRuntime | None = None,
+) -> str:
     backend = normalize_asr_backend(asr_backend)
     if backend == "file":
         return backend
+    entry = catalog_entry_for_backend(backend, model_id)
+    validate_platform_support(entry, runtime)
     if backend == "granite_nar":
         if "granite-speech" not in model_id or "-nar" not in model_id:
             raise ValueError("Granite NAR ASR requires an ibm-granite granite-speech NAR model")
-        return backend
-    if "-nar" in model_id:
-        raise ValueError('Use asr_backend = "granite_nar" with Granite NAR models')
-    if "granite-speech" not in model_id:
-        raise ValueError("V1 ASR requires an ibm-granite granite-speech model")
+    elif backend == "granite":
+        if "-nar" in model_id:
+            raise ValueError('Use asr_backend = "granite_nar" with Granite NAR models')
+        if "granite-speech" not in model_id:
+            raise ValueError("Granite ASR requires an ibm-granite granite-speech model")
+    profile = detect_runtime_profile(runtime)
+    if backend == "granite_nar" and profile.profile_id == "darwin_arm_mlx":
+        raise ValueError(
+            "Granite Speech 4.1 NAR is not supported on macOS. "
+            'Set asr_backend = "mlx_audio_whisper" or choose a supported MLX model.'
+        )
     return backend
 
 
-def model_cache_root(settings: Settings) -> Path:
+def resolve_catalog_entry(settings: Settings, runtime: PlatformRuntime | None = None) -> ModelCatalogEntry | None:
+    if settings.asr_backend.startswith("file:"):
+        return None
+    backend = validate_asr_model_backend(settings.asr_backend, settings.asr_model, runtime)
+    return catalog_entry_for_backend(backend, settings.asr_model)
+
+
+def model_cache_root(settings: Settings, runtime: PlatformRuntime | None = None) -> Path:
     if settings.model_cache_dir:
         return Path(settings.model_cache_dir).expanduser()
-    return user_cache_dir("huggingface") / "hub"
+    return user_cache_dir("huggingface", runtime) / "hub"
 
 
 def hf_cache_dir(model_id: str) -> str:
     return "models--" + model_id.replace("/", "--")
 
 
-def model_cache_path(model_id: str, settings: Settings) -> Path:
-    return model_cache_root(settings) / hf_cache_dir(model_id)
+def model_cache_path(model_id: str, settings: Settings, runtime: PlatformRuntime | None = None) -> Path:
+    return model_cache_root(settings, runtime) / hf_cache_dir(model_id)
 
 
-def required_model_cache_paths(settings: Settings) -> list[Path]:
-    paths = [model_cache_path(settings.asr_model, settings)]
+def mlx_snapshot_path(model_id: str, settings: Settings, runtime: PlatformRuntime | None = None) -> Path | None:
+    cache_path = model_cache_path(model_id, settings, runtime)
+    snapshots = cache_path / "snapshots"
+    if not snapshots.exists():
+        return None
+    candidates = sorted(snapshots.iterdir())
+    return candidates[-1] if candidates else None
+
+
+def required_model_cache_paths(settings: Settings, runtime: PlatformRuntime | None = None) -> list[Path]:
+    if settings.asr_backend.startswith("file:"):
+        paths: list[Path] = []
+    else:
+        paths = [model_cache_path(settings.asr_model, settings, runtime)]
     if settings.cleanup_runtime == "llama_cpp":
         paths.append(Path(settings.cleanup_model_path).expanduser())
     elif settings.cleanup_runtime == "transformers":
-        paths.append(model_cache_path(settings.cleanup_model, settings))
+        paths.append(model_cache_path(settings.cleanup_model, settings, runtime))
     return paths
 
 
-def cache_artifacts_present(model_id: str, settings: Settings) -> bool:
-    path = model_cache_path(model_id, settings)
+def cache_artifacts_present(
+    model_id: str,
+    settings: Settings,
+    runtime: PlatformRuntime | None = None,
+) -> bool:
+    path = model_cache_path(model_id, settings, runtime)
     if not path.exists():
         return False
     snapshots = path / "snapshots"
@@ -105,59 +223,94 @@ def cache_artifacts_present(model_id: str, settings: Settings) -> bool:
     return any(path.iterdir()) if path.is_dir() else False
 
 
-def model_rows(settings: Settings) -> list[dict[str, Any]]:
-    default = Settings()
+def supported_catalog_entries(runtime: PlatformRuntime | None = None) -> list[ModelCatalogEntry]:
+    profile = detect_runtime_profile(runtime)
+    entries: list[ModelCatalogEntry] = []
+    for entry in MODEL_CATALOG:
+        if entry.supported_platforms and profile.system not in entry.supported_platforms:
+            continue
+        if (
+            entry.supported_architectures is not None
+            and profile.system == "Darwin"
+            and not is_apple_silicon(runtime)
+        ):
+            continue
+        entries.append(entry)
+    return entries
+
+
+def model_rows(settings: Settings, runtime: PlatformRuntime | None = None) -> list[dict[str, Any]]:
+    defaults = default_settings(runtime)
     rows = []
-    for model in SUPPORTED_MODELS:
+    for entry in supported_catalog_entries(runtime):
         markers = []
-        if model.model_id == settings.asr_model:
+        if entry.model_id == settings.asr_model and entry.backend == normalize_asr_backend(settings.asr_backend):
             markers.append("current")
-        if model.model_id == default.asr_model:
+        if entry.model_id == defaults.asr_model and entry.backend == normalize_asr_backend(defaults.asr_backend):
             markers.append("default")
         rows.append(
             {
-                "model_id": model.model_id,
-                "backend": model.backend,
+                "model_id": entry.model_id,
+                "backend": entry.backend,
+                "runtime": entry.runtime_kind,
                 "marker": ",".join(markers) if markers else "-",
-                "cached": cache_artifacts_present(model.model_id, settings),
-                "cache_path": str(model_cache_path(model.model_id, settings)),
+                "cached": cache_artifacts_present(entry.model_id, settings, runtime),
+                "cache_path": str(model_cache_path(entry.model_id, settings, runtime)),
             }
         )
     return rows
 
 
-def ensure_disk_space(settings: Settings, model: SupportedModel) -> None:
-    root = model_cache_root(settings)
+def ensure_disk_space(
+    settings: Settings,
+    entry: ModelCatalogEntry,
+    runtime: PlatformRuntime | None = None,
+) -> None:
+    root = model_cache_root(settings, runtime)
     probe = root
     while not probe.exists() and probe.parent != probe:
         probe = probe.parent
     usage = shutil.disk_usage(probe)
-    if usage.free < model.estimated_bytes:
-        needed_gib = model.estimated_bytes / GIB
+    if usage.free < entry.estimated_bytes:
+        needed_gib = entry.estimated_bytes / GIB
         free_gib = usage.free / GIB
         raise RuntimeError(
-            f"Not enough free disk space for {model.model_id}: "
+            f"Not enough free disk space for {entry.model_id}: "
             f"need about {needed_gib:.1f} GiB, found {free_gib:.1f} GiB at {probe}"
         )
 
 
-def prefetch_model(model_id: str, settings: Settings) -> Path:
-    model = model_by_id(model_id)
-    ensure_disk_space(settings, model)
-    cache_dir = str(model_cache_root(settings)) if settings.model_cache_dir else None
-    if model.backend == "granite_nar":
+def prefetch_model(model_id: str, settings: Settings, runtime: PlatformRuntime | None = None) -> Path:
+    entry = model_by_id(model_id)
+    validate_platform_support(entry, runtime)
+    ensure_disk_space(settings, entry, runtime)
+    cache_dir = str(model_cache_root(settings, runtime))
+
+    if entry.prefetch_strategy == "snapshot_download":
         try:
-            from transformers import AutoFeatureExtractor, AutoModel
+            from huggingface_hub import snapshot_download
+        except ImportError as exc:
+            raise RuntimeError("huggingface_hub is required for MLX model prefetch.") from exc
+        snapshot_download(
+            repo_id=entry.model_id,
+            cache_dir=cache_dir,
+            local_dir_use_symlinks=False,
+        )
+        return model_cache_path(entry.model_id, settings, runtime)
+
+    if entry.backend == "granite_nar":
+        try:
+            from transformers import AutoModel, AutoProcessor
         except ImportError as exc:
             raise RuntimeError("transformers is required. Install transclip[models].") from exc
         AutoModel.from_pretrained(
-            model.model_id,
+            entry.model_id,
             trust_remote_code=True,
             local_files_only=False,
             cache_dir=cache_dir,
         )
-        AutoFeatureExtractor.from_pretrained(
-            model.model_id,
+        AutoProcessor.from_pretrained(
+            entry.model_id,
             trust_remote_code=True,
             local_files_only=False,
             cache_dir=cache_dir,
@@ -168,13 +321,19 @@ def prefetch_model(model_id: str, settings: Settings) -> Path:
         except ImportError as exc:
             raise RuntimeError("transformers is required. Install transclip[models].") from exc
         AutoModelForSpeechSeq2Seq.from_pretrained(
-            model.model_id,
+            entry.model_id,
             local_files_only=False,
             cache_dir=cache_dir,
         )
         AutoProcessor.from_pretrained(
-            model.model_id,
+            entry.model_id,
             local_files_only=False,
             cache_dir=cache_dir,
         )
-    return model_cache_path(model.model_id, settings)
+    return model_cache_path(entry.model_id, settings, runtime)
+
+
+def _machine_arch(runtime: PlatformRuntime | None) -> str:
+    from .runtime_profile import machine_architecture
+
+    return machine_architecture(runtime)

--- a/transclip/platform_runtime.py
+++ b/transclip/platform_runtime.py
@@ -53,7 +53,9 @@ class DefaultPlatformRuntime:
         return subprocess.run(command, **kwargs)
 
     def check_output(self, command: list[str], **kwargs: Any) -> str:
-        return subprocess.check_output(command, **kwargs)
+        kwargs.setdefault("text", True)
+        output = subprocess.check_output(command, **kwargs)
+        return output.decode() if isinstance(output, bytes) else output
 
 
 default_platform_runtime = DefaultPlatformRuntime()
@@ -71,7 +73,10 @@ def user_config_dir(app_name: str, runtime: PlatformRuntime | None = None) -> Pa
 
 
 def user_cache_dir(app_name: str, runtime: PlatformRuntime | None = None) -> Path:
-    return get_runtime(runtime).home_dir() / ".cache" / app_name
+    platform_runtime = get_runtime(runtime)
+    if platform_runtime.system() == "Darwin":
+        return platform_runtime.home_dir() / "Library" / "Caches" / app_name
+    return platform_runtime.home_dir() / ".cache" / app_name
 
 
 def user_log_dir(app_name: str, runtime: PlatformRuntime | None = None) -> Path:

--- a/transclip/runtime_profile.py
+++ b/transclip/runtime_profile.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import platform
+from dataclasses import dataclass
+from typing import Literal
+
+from .platform_runtime import PlatformRuntime, get_runtime, user_cache_dir, user_config_dir, user_log_dir
+from .product import CONFIG_DIR_NAME, LOG_DIR_NAME
+
+RuntimeKind = Literal["torch_cuda", "torch_rocm", "torch_cpu", "mlx", "file"]
+ProfileId = Literal["linux_gpu", "linux_cpu", "darwin_arm_mlx", "darwin_other", "unsupported"]
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeProfile:
+    profile_id: ProfileId
+    system: str
+    architecture: str
+    default_asr_backend: str
+    default_asr_model: str
+    default_asr_device: str
+    supported_runtime_kinds: tuple[RuntimeKind, ...]
+    service_manager: Literal["systemd", "launchd", "none"]
+    config_dir_name: str = CONFIG_DIR_NAME
+    log_dir_name: str = LOG_DIR_NAME
+
+
+def machine_architecture(runtime: PlatformRuntime | None = None) -> str:
+    platform_runtime = get_runtime(runtime)
+    if platform_runtime.system() == "Darwin":
+        try:
+            output = platform_runtime.check_output(["uname", "-m"])
+            if isinstance(output, bytes):
+                output = output.decode()
+            return output.strip().lower()
+        except Exception:
+            pass
+    return platform.machine().lower()
+
+
+def is_apple_silicon(runtime: PlatformRuntime | None = None) -> bool:
+    return machine_architecture(runtime) in {"arm64", "aarch64"}
+
+
+def is_native_arm_python() -> bool:
+    return platform.machine().lower() in {"arm64", "aarch64"}
+
+
+def detect_runtime_profile(runtime: PlatformRuntime | None = None) -> RuntimeProfile:
+    platform_runtime = get_runtime(runtime)
+    system = platform_runtime.system()
+    arch = machine_architecture(platform_runtime)
+
+    if system == "Linux":
+        if arch in {"x86_64", "amd64"}:
+            return RuntimeProfile(
+                profile_id="linux_gpu",
+                system=system,
+                architecture=arch,
+                default_asr_backend="granite_nar",
+                default_asr_model="ibm-granite/granite-speech-4.1-2b-nar",
+                default_asr_device="auto",
+                supported_runtime_kinds=("torch_cuda", "torch_rocm", "torch_cpu", "file"),
+                service_manager="systemd",
+            )
+        return RuntimeProfile(
+            profile_id="linux_cpu",
+            system=system,
+            architecture=arch,
+            default_asr_backend="granite_nar",
+            default_asr_model="ibm-granite/granite-speech-4.1-2b-nar",
+            default_asr_device="cpu",
+            supported_runtime_kinds=("torch_cpu", "file"),
+            service_manager="systemd",
+        )
+
+    if system == "Darwin":
+        if arch in {"arm64", "aarch64"}:
+            return RuntimeProfile(
+                profile_id="darwin_arm_mlx",
+                system=system,
+                architecture=arch,
+                default_asr_backend="mlx_audio_whisper",
+                default_asr_model="mlx-community/whisper-large-v3-turbo-asr-fp16",
+                default_asr_device="mlx",
+                supported_runtime_kinds=("mlx", "file"),
+                service_manager="launchd",
+            )
+        return RuntimeProfile(
+            profile_id="darwin_other",
+            system=system,
+            architecture=arch,
+            default_asr_backend="file",
+            default_asr_model="",
+            default_asr_device="cpu",
+            supported_runtime_kinds=("file",),
+            service_manager="launchd",
+        )
+
+    return RuntimeProfile(
+        profile_id="unsupported",
+        system=system,
+        architecture=arch,
+        default_asr_backend="file",
+        default_asr_model="",
+        default_asr_device="cpu",
+        supported_runtime_kinds=("file",),
+        service_manager="none",
+    )
+
+
+def profile_config_dir(profile: RuntimeProfile, runtime: PlatformRuntime | None = None) -> str:
+    del profile
+    return str(user_config_dir(CONFIG_DIR_NAME, runtime))
+
+
+def profile_cache_dir(profile: RuntimeProfile, runtime: PlatformRuntime | None = None) -> str:
+    del profile
+    return str(user_cache_dir(CONFIG_DIR_NAME, runtime))
+
+
+def profile_log_dir(profile: RuntimeProfile, runtime: PlatformRuntime | None = None) -> str:
+    del profile
+    return str(user_log_dir(LOG_DIR_NAME, runtime))
+
+
+def profile_model_cache_hint(runtime: PlatformRuntime | None = None) -> str:
+    return str(user_cache_dir("huggingface", runtime) / "hub")
+
+
+def default_settings_values(runtime: PlatformRuntime | None = None) -> dict[str, str]:
+    profile = detect_runtime_profile(runtime)
+    return {
+        "asr_backend": profile.default_asr_backend,
+        "asr_model": profile.default_asr_model,
+        "asr_device": profile.default_asr_device,
+    }

--- a/transclip/runtime_profile.py
+++ b/transclip/runtime_profile.py
@@ -42,8 +42,8 @@ def is_apple_silicon(runtime: PlatformRuntime | None = None) -> bool:
     return machine_architecture(runtime) in {"arm64", "aarch64"}
 
 
-def is_native_arm_python() -> bool:
-    return platform.machine().lower() in {"arm64", "aarch64"}
+def is_native_arm_python(runtime: PlatformRuntime | None = None) -> bool:
+    return machine_architecture(runtime) in {"arm64", "aarch64"}
 
 
 def detect_runtime_profile(runtime: PlatformRuntime | None = None) -> RuntimeProfile:

--- a/transclip/runtime_profile.py
+++ b/transclip/runtime_profile.py
@@ -7,7 +7,7 @@ from typing import Literal
 from .platform_runtime import PlatformRuntime, get_runtime, user_cache_dir, user_config_dir, user_log_dir
 from .product import CONFIG_DIR_NAME, LOG_DIR_NAME
 
-RuntimeKind = Literal["torch_cuda", "torch_rocm", "torch_cpu", "mlx", "file"]
+RuntimeKind = Literal["torch_cuda", "torch_rocm", "torch_mps", "torch_cpu", "mlx", "file"]
 ProfileId = Literal["linux_gpu", "linux_cpu", "darwin_arm_mlx", "darwin_other", "unsupported"]
 
 
@@ -67,8 +67,8 @@ def detect_runtime_profile(runtime: PlatformRuntime | None = None) -> RuntimePro
             profile_id="linux_cpu",
             system=system,
             architecture=arch,
-            default_asr_backend="granite_nar",
-            default_asr_model="ibm-granite/granite-speech-4.1-2b-nar",
+            default_asr_backend="granite",
+            default_asr_model="ibm-granite/granite-speech-4.1-2b",
             default_asr_device="cpu",
             supported_runtime_kinds=("torch_cpu", "file"),
             service_manager="systemd",
@@ -82,15 +82,15 @@ def detect_runtime_profile(runtime: PlatformRuntime | None = None) -> RuntimePro
                 architecture=arch,
                 default_asr_backend="mlx_audio_whisper",
                 default_asr_model="mlx-community/whisper-large-v3-turbo-asr-fp16",
-                default_asr_device="mlx",
-                supported_runtime_kinds=("mlx", "file"),
+                default_asr_device="auto",
+                supported_runtime_kinds=("mlx", "torch_mps", "torch_cpu", "file"),
                 service_manager="launchd",
             )
         return RuntimeProfile(
             profile_id="darwin_other",
             system=system,
             architecture=arch,
-            default_asr_backend="file",
+            default_asr_backend="file:/dev/null",
             default_asr_model="",
             default_asr_device="cpu",
             supported_runtime_kinds=("file",),
@@ -101,7 +101,7 @@ def detect_runtime_profile(runtime: PlatformRuntime | None = None) -> RuntimePro
         profile_id="unsupported",
         system=system,
         architecture=arch,
-        default_asr_backend="file",
+        default_asr_backend="file:/dev/null",
         default_asr_model="",
         default_asr_device="cpu",
         supported_runtime_kinds=("file",),

--- a/transclip/settings.py
+++ b/transclip/settings.py
@@ -5,8 +5,9 @@ from dataclasses import asdict, dataclass, fields, replace
 from pathlib import Path
 from typing import Any, get_type_hints
 
-from .platform_runtime import default_platform_runtime, user_config_dir
+from .platform_runtime import PlatformRuntime, default_platform_runtime, user_config_dir
 from .product import CONFIG_DIR_NAME
+from .runtime_profile import detect_runtime_profile
 
 DEFAULT_HOTKEY_LINUX = "<Super><Shift>XF86TouchpadOff"
 
@@ -53,10 +54,19 @@ def settings_path(config_dir: Path | None = None) -> Path:
     return (config_dir or default_config_dir()) / "settings.toml"
 
 
-def load_settings(path: Path | None = None) -> Settings:
+def default_settings(runtime: PlatformRuntime | None = None) -> Settings:
+    profile = detect_runtime_profile(runtime)
+    return Settings(
+        asr_backend=profile.default_asr_backend,
+        asr_model=profile.default_asr_model,
+        asr_device=profile.default_asr_device,
+    )
+
+
+def load_settings(path: Path | None = None, runtime: PlatformRuntime | None = None) -> Settings:
     path = path or settings_path()
     if not path.exists():
-        return Settings()
+        return default_settings(runtime)
     data = tomllib.loads(path.read_text(encoding="utf-8"))
     allowed = {field.name for field in fields(Settings)}
     unknown = sorted(set(data) - allowed)
@@ -140,12 +150,12 @@ def coerce_setting_value(field_name: str, raw_value: str) -> Any:
     raise ValueError(f"{field_name} has unsupported type {expected}")
 
 
-def write_default_settings(path: Path | None = None) -> Path:
+def write_default_settings(path: Path | None = None, runtime: PlatformRuntime | None = None) -> Path:
     path = path or settings_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     if path.exists():
         return path
-    write_settings(Settings(), path)
+    write_settings(default_settings(runtime), path)
     return path
 
 

--- a/transclip/tray.py
+++ b/transclip/tray.py
@@ -11,11 +11,24 @@ from .client import InferenceClient
 from .daemon_lifecycle import service_action
 from .gnome_shortcut import install_shortcut
 from .history import read_history
-from .models import SUPPORTED_MODELS
+from .models import model_rows
 from .paste import SystemClipboard
-from .product import APP_ID, DISPLAY_NAME, IMPORT_PACKAGE
+from .platform_runtime import get_runtime
+from .product import APP_ID, CLI_COMMAND, DISPLAY_NAME, IMPORT_PACKAGE
 from .recording_ops import toggle_recording
 from .settings import Settings, load_settings, settings_path, write_default_settings, write_settings
+
+
+def run_tray(settings: Settings, explicit_settings_path: Path | None = None) -> int:
+    if get_runtime().system() == "Darwin":
+        print(
+            "Native macOS menu bar UI is not implemented yet. "
+            f"Use a Keyboard Shortcut or Shortcuts.app action for `{CLI_COMMAND} toggle-record --paste`, "
+            f"and `{CLI_COMMAND} status` / `{CLI_COMMAND} doctor` for service state.",
+            file=sys.stderr,
+        )
+        return 1
+    return run_python_tray(settings, explicit_settings_path=explicit_settings_path)
 
 
 def run_python_tray(settings: Settings, explicit_settings_path: Path | None = None) -> int:
@@ -191,7 +204,8 @@ def run_python_tray(settings: Settings, explicit_settings_path: Path | None = No
         menu.append(model_item)
         menu_refs["model_menu"] = model_menu
         menu_refs["model_items"] = []
-        for model in SUPPORTED_MODELS:
+        for row in model_rows(settings):
+            model = type("ModelMenuEntry", (), {"model_id": row["model_id"], "backend": row["backend"]})()
             item = _append_item(
                 model_menu,
                 _model_menu_label(model.model_id, model.backend, settings),

--- a/transclip/tray.py
+++ b/transclip/tray.py
@@ -297,6 +297,8 @@ def _model_label(model_id: str, backend: str) -> str:
     if backend == "granite_nar":
         return "Fast local ASR - Granite 4.1 NAR"
     if backend == "granite":
+        if model_id.endswith("-plus"):
+            return "Speaker/timestamp ASR - Granite 4.1 Plus"
         return "Keyword-biased ASR - Granite 4.1"
     return model_id
 

--- a/uv.lock
+++ b/uv.lock
@@ -1686,7 +1686,7 @@ requires-dist = [
     { name = "torchaudio", marker = "extra == 'models'", specifier = ">=2.5" },
     { name = "torchcodec", marker = "extra == 'models'", specifier = ">=0.5" },
     { name = "torchvision", marker = "extra == 'models'", specifier = ">=0.20" },
-    { name = "transformers", marker = "extra == 'models'", specifier = ">=5.5.3" },
+    { name = "transformers", marker = "extra == 'models'", specifier = ">=5.8" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a19" },
 ]
 provides-extras = ["audio", "models", "mlx", "macos-ui", "llama", "dev", "chatgpt-ui"]

--- a/uv.lock
+++ b/uv.lock
@@ -569,6 +569,113 @@ wheels = [
 ]
 
 [[package]]
+name = "miniaudio"
+version = "1.71"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/d5/e5439dc08561f73656bfeb3340fc64ab63163e101426593d8fb9a025ff1e/miniaudio-1.71.tar.gz", hash = "sha256:ff51e2887bb673e2e757752b586b3dc924d59aa5fbcae9bbc45f4a111bd3262b", size = 1116480, upload-time = "2026-04-29T21:20:38.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/d3/71124f5abbcdcae62e040f58d3dca3bd3d90fd01faa7bb276b112387b47a/miniaudio-1.71-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:62db602651bc20a2698f36a0d356d7217ed6f4f917550c7ffb3705c8e8be90cf", size = 377186, upload-time = "2026-04-29T21:20:16.713Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ac/30a324f758bed1b193e017ec25183cfb10a79e549656331f5d068a2d343a/miniaudio-1.71-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8fc1a4f084cc1b4b25c567d22f54d1e46bfa505c17ed777c8b198e5c53d0f785", size = 351485, upload-time = "2026-04-29T21:20:17.761Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/62/ae884a9d3b2ebec9c2ed1db857593e74bff45b70c4ab17fccc11db31cbeb/miniaudio-1.71-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19be6f0a1e601c2237433e579734cfaf6469191b224c20c9e5f73c32ef9ee2b9", size = 643556, upload-time = "2026-04-29T21:20:18.87Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/39/84fc665e2ea8f9f1301b6370226e3a24f08d5ad5d97143b69b4ae7ac260a/miniaudio-1.71-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e6287f15caa808a88aad0700a182bec1ff6d98769717425adf9ebf41259d1936", size = 645176, upload-time = "2026-04-29T21:20:20.194Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b8/37d9f67d4511da29bdb82b6c73a3ef6f4ebf2fbd30f9524f1e4a84d6f033/miniaudio-1.71-cp312-cp312-win32.whl", hash = "sha256:ab100e5240b104b5326e4ec1be07b6ae461f7d3d4d7a694857fd2f0493d210f9", size = 235095, upload-time = "2026-04-29T21:20:21.653Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cf/c1a19e6800e725b6e2b4576407620a798d69e3528ebdea9aea84d69d7088/miniaudio-1.71-cp312-cp312-win_amd64.whl", hash = "sha256:f4a44b70b66628b0c307e40ae0ae857695978cae18462179b806d8edc807d416", size = 274252, upload-time = "2026-04-29T21:20:22.824Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/85/44545f767ec21142ffed5f9108406d11dc8a19aafed9bd57621a0892bb60/miniaudio-1.71-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:61b86f26d653040db32d9d15b05446321dd10e45beba25b44f841e26935213d5", size = 377184, upload-time = "2026-04-29T21:20:24.109Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/d1/071a560000c8ce903dc919968ecce40fbe7a73213ac399051b887184f8a3/miniaudio-1.71-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d9dc15eff711bcfc62a9d05e0c78e4bc34821a455595e049629f2fea7491a523", size = 351488, upload-time = "2026-04-29T21:20:25.183Z" },
+    { url = "https://files.pythonhosted.org/packages/46/24/5873a569451cae5686fb656ebd78ffe0b5eebe48ca21ef61e227d237d20a/miniaudio-1.71-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:12bc33e7e61072b4b541c14e10ef76119d5643e6bbb98e2dec0c0738889438fb", size = 643552, upload-time = "2026-04-29T21:20:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/90/9b/25785525e6b5ff9afd7f4c4279215dc09c3317ea4d837275b1ae17912b36/miniaudio-1.71-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:70fa2ea5353e6919aca59b8c5768144af009d18c3bca251749d66fb497424563", size = 645171, upload-time = "2026-04-29T21:20:27.494Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/6d/cbfd55fdc40256231f7b0c861e2bf79cc289bfbbe5e15869317944e6d673/miniaudio-1.71-cp313-cp313-win32.whl", hash = "sha256:1bf93aeede652926f27f430f0fd69ef0cf8a949c07b537d6a2f295602c747037", size = 235088, upload-time = "2026-04-29T21:20:29.031Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/8d/d5059c04b247b1079c0e48914a9ec20352910a3b9373060fb258dfd194ab/miniaudio-1.71-cp313-cp313-win_amd64.whl", hash = "sha256:4c849ccb1349f7b3553a77a66fe7e972315185f5c4c44a0bbda7ebcdd224db37", size = 274247, upload-time = "2026-04-29T21:20:29.96Z" },
+    { url = "https://files.pythonhosted.org/packages/16/e7/b3e0df641d2d5283446d7960fc407195ba722b9a0789bb0a1429bf9ee855/miniaudio-1.71-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3ef441d139264f8a5dcb9aa6fcd0b1e1e69f58715baae416ff33f045ffba6ad5", size = 378418, upload-time = "2026-04-29T21:20:31.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ea/f5940232d0c83777562e802f376a841046d78e94753450fb9a6685a44190/miniaudio-1.71-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:84139a10ef172acd762ccf120142877b037a1aaf71def99d2c75f66329f89d8b", size = 351473, upload-time = "2026-04-29T21:20:32.464Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a6/6b5ae21b74fe70da935de389e01b3cce86c790ca4083f6a63c3ee922673e/miniaudio-1.71-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a28ff4ad23e55bbde8808ce525d3bb7d249d7612f77646b30e06fc6b7a778ac", size = 643683, upload-time = "2026-04-29T21:20:33.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/43/ef851e2e1d9dfde2b97cc053f0d79c6612088b27044698ed5d8c687f05de/miniaudio-1.71-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:33986d5d725ebcbc253551e7358689bc81b19b6950b33cec8e8c1142ca4fc0a9", size = 645203, upload-time = "2026-04-29T21:20:34.713Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/4a/0da61fea8b8469d51b77d43846572ef9255d54c9b6b65a552446bbd55f90/miniaudio-1.71-cp314-cp314-win32.whl", hash = "sha256:3bbeb1e068fe42475e017e8150e9e345182b583d0dd4d9e77ffa20c39935d9ec", size = 241126, upload-time = "2026-04-29T21:20:35.975Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d0/ad7bfa63e1baacd2d4803ee04862bb06fcfbbb34a340bf2bf3979e0068dc/miniaudio-1.71-cp314-cp314-win_amd64.whl", hash = "sha256:154b085dd914a0e79e3d93160e1a07aacb27d66c65f9ef6a0d87c1a194f32c04", size = 281740, upload-time = "2026-04-29T21:20:37.07Z" },
+]
+
+[[package]]
+name = "mlx"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mlx-metal", marker = "sys_platform == 'darwin'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/47/5f33906cb03d6a378a697cd2d2641a26b37dea17ee3d9124d7e39e8eca01/mlx-0.31.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:e5067aaf2be1f3d7bba5be52348775804f111173c1ed04639618fd713b1a530f", size = 584863, upload-time = "2026-04-22T03:14:38.211Z" },
+    { url = "https://files.pythonhosted.org/packages/08/e7/a851a451b1327af9fb4df3991b9ae87d066b6f6630e854af55c288b0995a/mlx-0.31.2-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:edb9797db7d852477ca1c99708058654ee860d4148fe5765f0d55528e2b1aa22", size = 584860, upload-time = "2026-04-22T03:14:39.746Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/15/0d1dc0597644e5e7b011ca954ba0c47e13cd880a3b909b0c3f1b4d8bf8f1/mlx-0.31.2-cp312-cp312-macosx_26_0_arm64.whl", hash = "sha256:51ca102db641b01e7cb083ce8ecb580e281530a141a7ca12544bb370641630ae", size = 584887, upload-time = "2026-04-22T03:14:41.585Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/c3/00664239a98e8bd614733c4182cd402d2bacad2d7f79eca66562ac406870/mlx-0.31.2-cp312-cp312-manylinux_2_35_aarch64.whl", hash = "sha256:117c7583cae0ca107cd53c591cc34f8e75f97a505aa47088844b7dc0fc69dc67", size = 627863, upload-time = "2026-04-22T03:14:43.326Z" },
+    { url = "https://files.pythonhosted.org/packages/53/7b/af6cd73a79772af6f19eab2cb4c48eda23a9294d1650a4c1269a9996e532/mlx-0.31.2-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:99572133181481640a8bf8d449daf083816d0af3ee050c8adfc5bf45ceca91c6", size = 685090, upload-time = "2026-04-22T03:14:45.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/3f/888f8664d4f8e23a1363a5f50024be5216e199ab7ad0ba20988c7ed6d729/mlx-0.31.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:1b3fb0dda955b0d552ce57bdd6f42b3309ab21b067e40587d6848443d307e91f", size = 584796, upload-time = "2026-04-22T03:14:47.215Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/14/e9cd18b51f9e1dbcb060eec0fafc2d2428c8e1eacd9b0a02d7c5ce75b661/mlx-0.31.2-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:34b0171cd9eb5c43fdd82091f6135d6ccc5a065363a4a3e68fac64fb4e53d37c", size = 584790, upload-time = "2026-04-22T03:14:48.519Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/20/c6c5fb998c7834d094b2bfb9f003b5246cb270f0266da055c55546c34999/mlx-0.31.2-cp313-cp313-macosx_26_0_arm64.whl", hash = "sha256:c05981684279a8935d58b0dde3ea5b02d210c3bad3319aa0e9934ec2df165752", size = 584795, upload-time = "2026-04-22T03:14:49.904Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/19/aca251d4c5f3532ce9c2c1e95ad76740d9c6c298f406f62d992f465b9be0/mlx-0.31.2-cp313-cp313-manylinux_2_35_aarch64.whl", hash = "sha256:cd1f4189e5f1bc68735f44eb63ce98ae09d66ac75d7ab5b15a41afae7e9f0513", size = 627843, upload-time = "2026-04-22T03:14:51.351Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2b/b89364883b98f21c2fe29e52d4ac8bc2fa2fe0d79293b36ec421efc1854a/mlx-0.31.2-cp313-cp313-manylinux_2_35_x86_64.whl", hash = "sha256:53c8d57ffa9ce77f8355663be05014c0dd37280e57f19126fb0a24389a30684b", size = 685064, upload-time = "2026-04-22T03:14:52.75Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f5/e63f6a9316ded2d14a8ebc7a9ca25734c784e8c54d064a78b4dceeacec0e/mlx-0.31.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a13c9ce23c3deef6aa5a09315e7953e1a5dc311e851fa16fc74c81fb2509c0b9", size = 588417, upload-time = "2026-04-22T03:14:54.094Z" },
+    { url = "https://files.pythonhosted.org/packages/31/50/9d0c03ea3134cd85c132df7b0e4b75e6344bd8b4881a0b9c465cfa27f724/mlx-0.31.2-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:b0764bf11fc3a71dee988e19275eef67775cab63112d8bb7ef173ca8b2a1247c", size = 588421, upload-time = "2026-04-22T03:14:55.898Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5b/d364cc793bcb504621313acb55627cf0d5403ab2e0a594aa081cdbe4591f/mlx-0.31.2-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:59ccbd0f0044d4f97f11ebcbf0c480bc9e962935fd96275f120954afea65be8a", size = 588384, upload-time = "2026-04-22T03:14:57.439Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a4/e822202dd2e4e7d08671f2ecf7b6500af74f5bad5ceb27086b1aa6902f3a/mlx-0.31.2-cp314-cp314-manylinux_2_35_aarch64.whl", hash = "sha256:e81798c610f95a09c642c89214ba5c23b72ce18ce4728184aceabe7eddca33d7", size = 630473, upload-time = "2026-04-22T03:14:58.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/6f/da48d2d7a76e644d35438ef6f33c68755fdd382e2c546fd1804ccba01d04/mlx-0.31.2-cp314-cp314-manylinux_2_35_x86_64.whl", hash = "sha256:69fbc94bf53607a75af9eb3e22c354738a6fe4e25aa4e2b20934b009a4bba1f3", size = 685459, upload-time = "2026-04-22T03:15:00.45Z" },
+]
+
+[[package]]
+name = "mlx-audio"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "miniaudio" },
+    { name = "mlx" },
+    { name = "mlx-lm" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "sounddevice" },
+    { name = "tqdm" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/db/a9f95e3794eca373d681220c8b9f8f84451a0d14959f85cc341ca592394c/mlx_audio-0.4.3.tar.gz", hash = "sha256:8e87badf56a0f73bf91e3797b1195c01440a181cf0b64a2a08dc1bda4b037f54", size = 1144947, upload-time = "2026-04-28T20:18:12.09Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/25/0a89073ed7b7cdf34299042bd03d867c12c0c8b43f597be61bea7f146793/mlx_audio-0.4.3-py3-none-any.whl", hash = "sha256:6b87bf42d79d9ceb6b9310a77656b9b76429c2d6ddd89f634b2786c58a2e4721", size = 1373582, upload-time = "2026-04-28T20:18:10.512Z" },
+]
+
+[package.optional-dependencies]
+stt = [
+    { name = "sentencepiece" },
+]
+
+[[package]]
+name = "mlx-lm"
+version = "0.31.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "mlx", marker = "sys_platform == 'darwin'" },
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "pyyaml" },
+    { name = "sentencepiece" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/94/9a38d6b0c6fcca995b9136c94eb7da1e9c5165652edf228b96b29960fa7a/mlx_lm-0.31.3.tar.gz", hash = "sha256:61eb0e3ba09444f77f874aff295401d7ccd20b39495cbbce0c782a15474ce733", size = 304318, upload-time = "2026-04-22T07:37:27.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/02/9a67b8e4f87e3e2e5cd7b1ad79304b93c09a0db6af34bee75e6551c06c60/mlx_lm-0.31.3-py3-none-any.whl", hash = "sha256:758cfddf1180053b7613db76fad3d246a331a2a905808e1164a275621fc983b8", size = 408890, upload-time = "2026-04-22T07:37:25.965Z" },
+]
+
+[[package]]
+name = "mlx-metal"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/69/fe3b783ebe999f3118234e1e940feb622518bfb1dea6ac5d13b1d36a8449/mlx_metal-0.31.2-py3-none-macosx_14_0_arm64.whl", hash = "sha256:b25385bcee18fc194092255b8b53b9a3d8489eb650e59160f1b57aadd07aa2dc", size = 40055588, upload-time = "2026-04-22T03:14:14.43Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/5d/4c690d5b93c30ba002656c37363159d978705bf8eb801b8481840fb942c2/mlx_metal-0.31.2-py3-none-macosx_15_0_arm64.whl", hash = "sha256:e9d4e5fce6ca10a87a0e388597f99519ad594d09e674708b5312bd8bd4f5997d", size = 40053220, upload-time = "2026-04-22T03:14:18.048Z" },
+    { url = "https://files.pythonhosted.org/packages/99/82/11fd62a8d7a3e96e5c43220b17de0151e3f10101f8bb3b865f5bd9cdd074/mlx_metal-0.31.2-py3-none-macosx_26_0_arm64.whl", hash = "sha256:84ffb60ee503f03eb684f5fb168d5cff31e2a16b7f27c1731eaf7662bd6e9b46", size = 55792151, upload-time = "2026-04-22T03:14:22.059Z" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -906,6 +1013,21 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "7.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
+    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+]
+
+[[package]]
 name = "psutil"
 version = "7.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1174,6 +1296,115 @@ wheels = [
 ]
 
 [[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
+name = "sentencepiece"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/15/2e7a025fc62d764b151ae6d0f2a92f8081755ebe8d4a64099accc6f77ba6/sentencepiece-0.2.1.tar.gz", hash = "sha256:8138cec27c2f2282f4a34d9a016e3374cd40e5c6e9cb335063db66a0a3b71fad", size = 3228515, upload-time = "2025-08-12T07:00:51.718Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/be/32ce495aa1d0e0c323dcb1ba87096037358edee539cac5baf8755a6bd396/sentencepiece-0.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57cae326c8727de58c85977b175af132a7138d84c764635d7e71bbee7e774133", size = 1943152, upload-time = "2025-08-12T06:59:40.048Z" },
+    { url = "https://files.pythonhosted.org/packages/88/7e/ff23008899a58678e98c6ff592bf4d368eee5a71af96d0df6b38a039dd4f/sentencepiece-0.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:56dd39a3c4d6493db3cdca7e8cc68c6b633f0d4195495cbadfcf5af8a22d05a6", size = 1325651, upload-time = "2025-08-12T06:59:41.536Z" },
+    { url = "https://files.pythonhosted.org/packages/19/84/42eb3ce4796777a1b5d3699dfd4dca85113e68b637f194a6c8d786f16a04/sentencepiece-0.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d9381351182ff9888cc80e41c632e7e274b106f450de33d67a9e8f6043da6f76", size = 1253645, upload-time = "2025-08-12T06:59:42.903Z" },
+    { url = "https://files.pythonhosted.org/packages/89/fa/d3d5ebcba3cb9e6d3775a096251860c41a6bc53a1b9461151df83fe93255/sentencepiece-0.2.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99f955df238021bf11f0fc37cdb54fd5e5b5f7fd30ecc3d93fb48b6815437167", size = 1316273, upload-time = "2025-08-12T06:59:44.476Z" },
+    { url = "https://files.pythonhosted.org/packages/04/88/14f2f4a2b922d8b39be45bf63d79e6cd3a9b2f248b2fcb98a69b12af12f5/sentencepiece-0.2.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0cdfecef430d985f1c2bcbfff3defd1d95dae876fbd0173376012d2d7d24044b", size = 1387881, upload-time = "2025-08-12T06:59:46.09Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/b8/903e5ccb77b4ef140605d5d71b4f9e0ad95d456d6184688073ed11712809/sentencepiece-0.2.1-cp312-cp312-win32.whl", hash = "sha256:a483fd29a34c3e34c39ac5556b0a90942bec253d260235729e50976f5dba1068", size = 999540, upload-time = "2025-08-12T06:59:48.023Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/81/92df5673c067148c2545b1bfe49adfd775bcc3a169a047f5a0e6575ddaca/sentencepiece-0.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:4cdc7c36234fda305e85c32949c5211faaf8dd886096c7cea289ddc12a2d02de", size = 1054671, upload-time = "2025-08-12T06:59:49.895Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/02/c5e3bc518655d714622bec87d83db9cdba1cd0619a4a04e2109751c4f47f/sentencepiece-0.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:daeb5e9e9fcad012324807856113708614d534f596d5008638eb9b40112cd9e4", size = 1033923, upload-time = "2025-08-12T06:59:51.952Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/4a/85fbe1706d4d04a7e826b53f327c4b80f849cf1c7b7c5e31a20a97d8f28b/sentencepiece-0.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dcd8161eee7b41aae57ded06272905dbd680a0a04b91edd0f64790c796b2f706", size = 1943150, upload-time = "2025-08-12T06:59:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/83/4cfb393e287509fc2155480b9d184706ef8d9fa8cbf5505d02a5792bf220/sentencepiece-0.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c6c8f42949f419ff8c7e9960dbadcfbc982d7b5efc2f6748210d3dd53a7de062", size = 1325651, upload-time = "2025-08-12T06:59:55.073Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/de/5a007fb53b1ab0aafc69d11a5a3dd72a289d5a3e78dcf2c3a3d9b14ffe93/sentencepiece-0.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:097f3394e99456e9e4efba1737c3749d7e23563dd1588ce71a3d007f25475fff", size = 1253641, upload-time = "2025-08-12T06:59:56.562Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d2/f552be5928105588f4f4d66ee37dd4c61460d8097e62d0e2e0eec41bc61d/sentencepiece-0.2.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7b670879c370d350557edabadbad1f6561a9e6968126e6debca4029e5547820", size = 1316271, upload-time = "2025-08-12T06:59:58.109Z" },
+    { url = "https://files.pythonhosted.org/packages/96/df/0cfe748ace5485be740fed9476dee7877f109da32ed0d280312c94ec259f/sentencepiece-0.2.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7f0fd2f2693309e6628aeeb2e2faf6edd221134dfccac3308ca0de01f8dab47", size = 1387882, upload-time = "2025-08-12T07:00:00.701Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dd/f7774d42a881ced8e1739f393ab1e82ece39fc9abd4779e28050c2e975b5/sentencepiece-0.2.1-cp313-cp313-win32.whl", hash = "sha256:92b3816aa2339355fda2c8c4e021a5de92180b00aaccaf5e2808972e77a4b22f", size = 999541, upload-time = "2025-08-12T07:00:02.709Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/e9/932b9eae6fd7019548321eee1ab8d5e3b3d1294df9d9a0c9ac517c7b636d/sentencepiece-0.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:10ed3dab2044c47f7a2e7b4969b0c430420cdd45735d78c8f853191fa0e3148b", size = 1054669, upload-time = "2025-08-12T07:00:04.915Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/3a/76488a00ea7d6931689cda28726a1447d66bf1a4837943489314593d5596/sentencepiece-0.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac650534e2251083c5f75dde4ff28896ce7c8904133dc8fef42780f4d5588fcd", size = 1033922, upload-time = "2025-08-12T07:00:06.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b6/08fe2ce819e02ccb0296f4843e3f195764ce9829cbda61b7513f29b95718/sentencepiece-0.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8dd4b477a7b069648d19363aad0cab9bad2f4e83b2d179be668efa672500dc94", size = 1946052, upload-time = "2025-08-12T07:00:08.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/d9/1ea0e740591ff4c6fc2b6eb1d7510d02f3fb885093f19b2f3abd1363b402/sentencepiece-0.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0c0f672da370cc490e4c59d89e12289778310a0e71d176c541e4834759e1ae07", size = 1327408, upload-time = "2025-08-12T07:00:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/99/7e/1fb26e8a21613f6200e1ab88824d5d203714162cf2883248b517deb500b7/sentencepiece-0.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ad8493bea8432dae8d6830365352350f3b4144415a1d09c4c8cb8d30cf3b6c3c", size = 1254857, upload-time = "2025-08-12T07:00:11.021Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/85/c72fd1f3c7a6010544d6ae07f8ddb38b5e2a7e33bd4318f87266c0bbafbf/sentencepiece-0.2.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b81a24733726e3678d2db63619acc5a8dccd074f7aa7a54ecd5ca33ca6d2d596", size = 1315722, upload-time = "2025-08-12T07:00:12.989Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/e8/661e5bd82a8aa641fd6c1020bd0e890ef73230a2b7215ddf9c8cd8e941c2/sentencepiece-0.2.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a81799d0a68d618e89063fb423c3001a034c893069135ffe51fee439ae474d6", size = 1387452, upload-time = "2025-08-12T07:00:15.088Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5e/ae66c361023a470afcbc1fbb8da722c72ea678a2fcd9a18f1a12598c7501/sentencepiece-0.2.1-cp313-cp313t-win32.whl", hash = "sha256:89a3ea015517c42c0341d0d962f3e6aaf2cf10d71b1932d475c44ba48d00aa2b", size = 1002501, upload-time = "2025-08-12T07:00:16.966Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/03/d332828c4ff764e16c1b56c2c8f9a33488bbe796b53fb6b9c4205ddbf167/sentencepiece-0.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:33f068c9382dc2e7c228eedfd8163b52baa86bb92f50d0488bf2b7da7032e484", size = 1057555, upload-time = "2025-08-12T07:00:18.573Z" },
+    { url = "https://files.pythonhosted.org/packages/88/14/5aee0bf0864df9bd82bd59e7711362908e4935e3f9cdc1f57246b5d5c9b9/sentencepiece-0.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:b3616ad246f360e52c85781e47682d31abfb6554c779e42b65333d4b5f44ecc0", size = 1036042, upload-time = "2025-08-12T07:00:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/24/9c/89eb8b2052f720a612478baf11c8227dcf1dc28cd4ea4c0c19506b5af2a2/sentencepiece-0.2.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:5d0350b686c320068702116276cfb26c066dc7e65cfef173980b11bb4d606719", size = 1943147, upload-time = "2025-08-12T07:00:21.809Z" },
+    { url = "https://files.pythonhosted.org/packages/82/0b/a1432bc87f97c2ace36386ca23e8bd3b91fb40581b5e6148d24b24186419/sentencepiece-0.2.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:c7f54a31cde6fa5cb030370566f68152a742f433f8d2be458463d06c208aef33", size = 1325624, upload-time = "2025-08-12T07:00:23.289Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/99/bbe054ebb5a5039457c590e0a4156ed073fb0fe9ce4f7523404dd5b37463/sentencepiece-0.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c83b85ab2d6576607f31df77ff86f28182be4a8de6d175d2c33ca609925f5da1", size = 1253670, upload-time = "2025-08-12T07:00:24.69Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ad/d5c7075f701bd97971d7c2ac2904f227566f51ef0838dfbdfdccb58cd212/sentencepiece-0.2.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1855f57db07b51fb51ed6c9c452f570624d2b169b36f0f79ef71a6e6c618cd8b", size = 1316247, upload-time = "2025-08-12T07:00:26.435Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/03/35fbe5f3d9a7435eebd0b473e09584bd3cc354ce118b960445b060d33781/sentencepiece-0.2.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01e6912125cb45d3792f530a4d38f8e21bf884d6b4d4ade1b2de5cf7a8d2a52b", size = 1387894, upload-time = "2025-08-12T07:00:28.339Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/aa/956ef729aafb6c8f9c443104c9636489093bb5c61d6b90fc27aa1a865574/sentencepiece-0.2.1-cp314-cp314-win32.whl", hash = "sha256:c415c9de1447e0a74ae3fdb2e52f967cb544113a3a5ce3a194df185cbc1f962f", size = 1096698, upload-time = "2025-08-12T07:00:29.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/fe400d8836952cc535c81a0ce47dc6875160e5fedb71d2d9ff0e9894c2a6/sentencepiece-0.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:881b2e44b14fc19feade3cbed314be37de639fc415375cefaa5bc81a4be137fd", size = 1155115, upload-time = "2025-08-12T07:00:32.865Z" },
+    { url = "https://files.pythonhosted.org/packages/32/89/047921cf70f36c7b6b6390876b2399b3633ab73b8d0cb857e5a964238941/sentencepiece-0.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:2005242a16d2dc3ac5fe18aa7667549134d37854823df4c4db244752453b78a8", size = 1133890, upload-time = "2025-08-12T07:00:34.763Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/11/5b414b9fae6255b5fb1e22e2ed3dc3a72d3a694e5703910e640ac78346bb/sentencepiece-0.2.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:a19adcec27c524cb7069a1c741060add95f942d1cbf7ad0d104dffa0a7d28a2b", size = 1946081, upload-time = "2025-08-12T07:00:36.97Z" },
+    { url = "https://files.pythonhosted.org/packages/77/eb/7a5682bb25824db8545f8e5662e7f3e32d72a508fdce086029d89695106b/sentencepiece-0.2.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:e37e4b4c4a11662b5db521def4e44d4d30ae69a1743241412a93ae40fdcab4bb", size = 1327406, upload-time = "2025-08-12T07:00:38.669Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b0/811dae8fb9f2784e138785d481469788f2e0d0c109c5737372454415f55f/sentencepiece-0.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:477c81505db072b3ab627e7eab972ea1025331bd3a92bacbf798df2b75ea86ec", size = 1254846, upload-time = "2025-08-12T07:00:40.611Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/23/195b2e7ec85ebb6a547969f60b723c7aca5a75800ece6cc3f41da872d14e/sentencepiece-0.2.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:010f025a544ef770bb395091d57cb94deb9652d8972e0d09f71d85d5a0816c8c", size = 1315721, upload-time = "2025-08-12T07:00:42.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/aa/553dbe4178b5f23eb28e59393dddd64186178b56b81d9b8d5c3ff1c28395/sentencepiece-0.2.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:733e59ff1794d26db706cd41fc2d7ca5f6c64a820709cb801dc0ea31780d64ab", size = 1387458, upload-time = "2025-08-12T07:00:44.56Z" },
+    { url = "https://files.pythonhosted.org/packages/66/7c/08ff0012507297a4dd74a5420fdc0eb9e3e80f4e88cab1538d7f28db303d/sentencepiece-0.2.1-cp314-cp314t-win32.whl", hash = "sha256:d3233770f78e637dc8b1fda2cd7c3b99ec77e7505041934188a4e7fe751de3b0", size = 1099765, upload-time = "2025-08-12T07:00:46.058Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d5/2a69e1ce15881beb9ddfc7e3f998322f5cedcd5e4d244cb74dade9441663/sentencepiece-0.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:5e4366c97b68218fd30ea72d70c525e6e78a6c0a88650f57ac4c43c63b234a9d", size = 1157807, upload-time = "2025-08-12T07:00:47.673Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/16/54f611fcfc2d1c46cbe3ec4169780b2cfa7cf63708ef2b71611136db7513/sentencepiece-0.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:105e36e75cbac1292642045458e8da677b2342dcd33df503e640f0b457cb6751", size = 1136264, upload-time = "2025-08-12T07:00:49.485Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "81.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1420,6 +1651,11 @@ dev = [
 llama = [
     { name = "llama-cpp-python" },
 ]
+mlx = [
+    { name = "huggingface-hub" },
+    { name = "mlx-audio", extra = ["stt"] },
+    { name = "soundfile" },
+]
 models = [
     { name = "accelerate" },
     { name = "pillow" },
@@ -1435,22 +1671,25 @@ models = [
 requires-dist = [
     { name = "accelerate", marker = "extra == 'models'", specifier = ">=1.0" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=7.10" },
+    { name = "huggingface-hub", marker = "extra == 'mlx'", specifier = ">=0.27" },
     { name = "llama-cpp-python", marker = "extra == 'llama'", specifier = ">=0.3" },
+    { name = "mlx-audio", extras = ["stt"], marker = "extra == 'mlx'", specifier = ">=0.4.3" },
     { name = "numpy", marker = "extra == 'audio'", specifier = ">=1.26" },
     { name = "pillow", marker = "extra == 'models'", specifier = ">=10" },
     { name = "playwright", marker = "extra == 'chatgpt-ui'", specifier = ">=1.52" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.11" },
     { name = "sounddevice", marker = "extra == 'audio'", specifier = ">=0.5" },
+    { name = "soundfile", marker = "extra == 'mlx'", specifier = ">=0.12" },
     { name = "soundfile", marker = "extra == 'models'", specifier = ">=0.12" },
-    { name = "torch", marker = "extra == 'models'", specifier = ">=2.5" },
+    { name = "torch", marker = "extra == 'models'", specifier = ">=2.9.1" },
     { name = "torchaudio", marker = "extra == 'models'", specifier = ">=2.5" },
     { name = "torchcodec", marker = "extra == 'models'", specifier = ">=0.5" },
     { name = "torchvision", marker = "extra == 'models'", specifier = ">=0.20" },
-    { name = "transformers", marker = "extra == 'models'", specifier = ">=4.52.1" },
+    { name = "transformers", marker = "extra == 'models'", specifier = ">=5.5.3" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a19" },
 ]
-provides-extras = ["audio", "models", "llama", "dev", "chatgpt-ui"]
+provides-extras = ["audio", "models", "mlx", "macos-ui", "llama", "dev", "chatgpt-ui"]
 
 [[package]]
 name = "transformers"

--- a/uv.lock
+++ b/uv.lock
@@ -248,6 +248,9 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
 cudart = [
     { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
@@ -756,14 +759,11 @@ wheels = [
 
 [[package]]
 name = "nvidia-cublas"
-version = "13.1.1.3"
+version = "13.1.0.3"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
-]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/a5/fce49e2ae977e0ccc084e5adafceb4f0ac0c8333cb6863501618a7277f67/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c86fc7f7ae36d7528288c5d88098edcb7b02c633d262e7ddbb86b0ad91be5df2", size = 542851226, upload-time = "2025-10-09T08:59:04.818Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/44/423ac00af4dd95a5aeb27207e2c0d9b7118702149bf4704c3ddb55bb7429/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:ee8722c1f0145ab246bccb9e452153b5e0515fd094c3678df50b2a0888b8b171", size = 423133236, upload-time = "2025-10-09T08:59:32.536Z" },
 ]
 
 [[package]]
@@ -795,14 +795,14 @@ wheels = [
 
 [[package]]
 name = "nvidia-cudnn-cu13"
-version = "9.20.0.48"
+version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nvidia-cublas" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/22/0b4b932655d17a6da1b92fa92ab12844b053bb2ac2475e179ba6f043da1e/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:d20e1734305e9d68889a96e3f35094d733ff1f83932ebe462753973e53a572bf", size = 366066321, upload-time = "2026-02-03T20:44:52.837Z" },
 ]
 
 [[package]]
@@ -863,20 +863,20 @@ wheels = [
 
 [[package]]
 name = "nvidia-cusparselt-cu13"
-version = "0.8.1"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
-    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+    { url = "https://files.pythonhosted.org/packages/46/10/8dcd1175260706a2fc92a16a52e306b71d4c1ea0b0cc4a9484183399818a/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:400c6ed1cf6780fc6efedd64ec9f1345871767e6a1a0a552a1ea0578117ea77c", size = 220791277, upload-time = "2025-08-13T19:22:40.982Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/53/43b0d71f4e702fa9733f8b4571fdca50a8813f1e450b656c239beff12315/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25e30a8a7323935d4ad0340b95a0b69926eee755767e8e0b1cf8dd85b197d3fd", size = 169884119, upload-time = "2025-08-13T19:23:41.967Z" },
 ]
 
 [[package]]
 name = "nvidia-nccl-cu13"
-version = "2.29.7"
+version = "2.28.9"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
-    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
+    { url = "https://files.pythonhosted.org/packages/39/55/1920646a2e43ffd4fc958536b276197ed740e9e0c54105b4bb3521591fc7/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:01c873ba1626b54caa12272ed228dc5b2781545e0ae8ba3f432a8ef1c6d78643", size = 196561677, upload-time = "2025-11-18T05:49:03.45Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/b4/878fefaad5b2bcc6fcf8d474a25e3e3774bc5133e4b58adff4d0bca238bc/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:e4553a30f34195f3fa1da02a6da3d6337d28f2003943aa0a3d247bbc25fefc42", size = 196493177, upload-time = "2025-11-18T05:49:17.677Z" },
 ]
 
 [[package]]
@@ -1497,16 +1497,15 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.12.0"
+version = "2.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
     { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
     { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
     { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
@@ -1517,26 +1516,26 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/bb/285d643f254731294c9b595a007eac39db4600a98682d7bca688f42ca164/torch-2.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b41339df93d491435e790ff8bcbae1c0ce777175889bfd1281d119862793e6a2", size = 88010197, upload-time = "2026-05-13T14:55:35.414Z" },
-    { url = "https://files.pythonhosted.org/packages/79/81/76debf1db1343bd929bbb5d74c89fb437c2ed88eb144712557e7bd3eea45/torch-2.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8fbef9f108a863e7722a73740998967e3b074742a834fc5be3a535a2befa7057", size = 426376751, upload-time = "2026-05-13T14:55:03.353Z" },
-    { url = "https://files.pythonhosted.org/packages/de/f0/80026028b603c4650ff270fc3785bdef4bd6738765a9cc5a0f5a637d65a2/torch-2.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4b4f64c2c2b11f7510d93dd6412b87025ff6eddd6bb61c3b5a3d892ea20c4756", size = 532261691, upload-time = "2026-05-13T14:52:54.453Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/c2/64b06cbb7830fb3cd9be13e1158b31a3f36b68e6a209105ee3c9d9480be0/torch-2.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:8b958caff4a14d3a3b0b2dfc6a378f64dda9728a9dad28c08a0db9ce4dafb549", size = 122988114, upload-time = "2026-05-13T14:54:42.153Z" },
-    { url = "https://files.pythonhosted.org/packages/86/ca/01896c80ba921676aa45886b2c5b8d774912de2a1f719de48169c6f755cd/torch-2.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:90dd587a5f61bfe1307148b581e2084fc5bc4a06e2b90a20e9a36b81087ff16b", size = 88009511, upload-time = "2026-05-13T14:54:47.411Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/04/52bdaf4787eab6ac7d7f5851dff934e4def0bc8ead9c8fd2b69b3e529699/torch-2.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:864392c73b7654f4d2b3ae712f607937d0dbb1101c4555fbb41848106b297f39", size = 426383231, upload-time = "2026-05-13T14:53:32.129Z" },
-    { url = "https://files.pythonhosted.org/packages/49/8a/94bdecd13f5aaa90d45920b89789d9fe7c6f4af8c3cdd7ce01fcb59908fc/torch-2.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5d6b560dfa7d56291c07d615c3bb73e8d9943d9b6d87f76cd0d9d570c4797fa6", size = 532269288, upload-time = "2026-05-13T14:53:49.423Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/2f/bdbaaa267de519ef1b73054bf590d8c93c37a266c9a4e24a01bd38b6918f/torch-2.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:3fee918902090ade827643e758e98363278815de583c75d111fdd665ebffde9f", size = 122987706, upload-time = "2026-05-13T14:54:00.335Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/ad/e95e822f3538171e22640a7fbe839a1fdb666600bf6487025de2ff03b11a/torch-2.12.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:10ee1448a9f304d3b987eb4656f664ba6e4d7b410ca7a5a7c642199777a2cf88", size = 88319556, upload-time = "2026-05-13T14:54:05.574Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/07/055d06d985b445d67422d25b033c11cf55bbb81785d4c4e68e28bca5820e/torch-2.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:af68dbf403439cae9ceaeaaf92f8352b460787dcd27b92aa05c40dd4a19c0f1e", size = 426397656, upload-time = "2026-05-13T14:52:38.84Z" },
-    { url = "https://files.pythonhosted.org/packages/43/94/b0b4fdc3014122e0a7302fb90086d352aa48f2576f0b252561ebb38c01a8/torch-2.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a6a2eebb237d3b1d9ad3b378e86d9b9e0782afdea8b1e0eba6a13646b9b49c07", size = 532183124, upload-time = "2026-05-13T14:53:16.178Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/c8/052405e6ad05d3237bfe5a4df78f917773956f8e17813a2d44c059068b74/torch-2.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2140e373e9a51a3e22ef62e8d14366d0b470d18f0adf19fdc757368077133a34", size = 123232462, upload-time = "2026-05-13T14:52:27.26Z" },
-    { url = "https://files.pythonhosted.org/packages/67/dc/ac069f8d6e8be701535921141055293b0d4819d3d7f224a4612cf157c7f9/torch-2.12.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f7dfae4a519197dfa050e98d8e36378a0fb5899625a875c2b54445005a2e404e", size = 88027282, upload-time = "2026-05-13T14:53:05.258Z" },
-    { url = "https://files.pythonhosted.org/packages/33/c3/1c1eb00e34555b536dddf792676026a988d710ed36981aa00499b36b0620/torch-2.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:891c769072637c74e9a5a77a3bc782894696d8ffec83b938df8536dee7f0ba78", size = 426386961, upload-time = "2026-05-13T14:51:28.406Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/d4/7e730dba0c7032a4154dc9056b76cf9625515e030e269cfbf8098fcfee7d/torch-2.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e2ad3eb85d39c3cab62dfa93ed5a73516e6a53c6713cb97d004004fe089f0f1f", size = 532272265, upload-time = "2026-05-13T14:51:59.308Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/b4/92c80d1bbfee1c0036c06d1d2155a3065bd2423134c83bf8a47e65cd6b9b/torch-2.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:c66696857e987efb8bc1777a37357ec4f60ab5e8af6250b83d6034437fa2d8f3", size = 122987138, upload-time = "2026-05-13T14:51:45.942Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/78/2e12b37ce50a19a037d7bc62d652a5a8f27385a7b05859d6bc9204f20cfe/torch-2.12.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:b4556715c8572758625d62b6e0ae3b1f76c440221913a6fb5e100f321fb4fb02", size = 88320100, upload-time = "2026-05-13T14:51:39.955Z" },
-    { url = "https://files.pythonhosted.org/packages/56/5e/83c450ec7b0bb40a7b74611c1b5440f9260e33c54c90d556fd4a1f0fd955/torch-2.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a43ac605a5e13116c72b64c359644cce0229f213dde48d2ae0ae5eb5becf7feb", size = 426391871, upload-time = "2026-05-13T14:52:14.989Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/e9/1a0b575d98d0afedd8f157d23fa3d2759421483660448e60d0a4b10b6daa/torch-2.12.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:6a7512adfdd7f6732e40de1c620831e3c75b39b98cef60b11d0c5f0a76473ec5", size = 532192241, upload-time = "2026-05-13T14:51:07.795Z" },
-    { url = "https://files.pythonhosted.org/packages/88/21/afadd25ecd81b3cea1e11c73cf1ab41a983a50271548c3ec7ec3b9efc3e9/torch-2.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5f96b63f8287f66a005dd1b5a6abba2920f11156c5e5c4d815f3e2050fd1aa16", size = 123231092, upload-time = "2026-05-13T14:51:18.854Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/8b/69e3008d78e5cee2b30183340cc425081b78afc5eff3d080daab0adda9aa/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b5866312ee6e52ea625cd211dcb97d6a2cdc1131a5f15cc0d87eec948f6dd34", size = 80606338, upload-time = "2026-03-23T18:11:34.781Z" },
+    { url = "https://files.pythonhosted.org/packages/13/16/42e5915ebe4868caa6bac83a8ed59db57f12e9a61b7d749d584776ed53d5/torch-2.11.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f99924682ef0aa6a4ab3b1b76f40dc6e273fca09f367d15a524266db100a723f", size = 419731115, upload-time = "2026-03-23T18:11:06.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c9/82638ef24d7877510f83baf821f5619a61b45568ce21c0a87a91576510aa/torch-2.11.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0f68f4ac6d95d12e896c3b7a912b5871619542ec54d3649cf48cc1edd4dd2756", size = 530712279, upload-time = "2026-03-23T18:10:31.481Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ff/6756f1c7ee302f6d202120e0f4f05b432b839908f9071157302cedfc5232/torch-2.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:fbf39280699d1b869f55eac536deceaa1b60bd6788ba74f399cc67e60a5fab10", size = 114556047, upload-time = "2026-03-23T18:10:55.931Z" },
+    { url = "https://files.pythonhosted.org/packages/87/89/5ea6722763acee56b045435fb84258db7375c48165ec8be7880ab2b281c5/torch-2.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e6debd97ccd3205bbb37eb806a9d8219e1139d15419982c09e23ef7d4369d18", size = 80606801, upload-time = "2026-03-23T18:10:18.649Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d1/8ed2173589cbfe744ed54e5a73efc107c0085ba5777ee93a5f4c1ab90553/torch-2.11.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:63a68fa59de8f87acc7e85a5478bb2dddbb3392b7593ec3e78827c793c4b73fd", size = 419732382, upload-time = "2026-03-23T18:08:30.835Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e1/b73f7c575a4b8f87a5928f50a1e35416b5e27295d8be9397d5293e7e8d4c/torch-2.11.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cc89b9b173d9adfab59fd227f0ab5e5516d9a52b658ae41d64e59d2e55a418db", size = 530711509, upload-time = "2026-03-23T18:08:47.213Z" },
+    { url = "https://files.pythonhosted.org/packages/66/82/3e3fcdd388fbe54e29fd3f991f36846ff4ac90b0d0181e9c8f7236565f82/torch-2.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:4dda3b3f52d121063a731ddb835f010dc137b920d7fec2778e52f60d8e4bf0cd", size = 114555842, upload-time = "2026-03-23T18:09:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/db/38/8ac78069621b8c2b4979c2f96dc8409ef5e9c4189f6aac629189a78677ca/torch-2.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8b394322f49af4362d4f80e424bcaca7efcd049619af03a4cf4501520bdf0fb4", size = 80959574, upload-time = "2026-03-23T18:10:14.214Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/6c/56bfb37073e7136e6dd86bfc6af7339946dd684e0ecf2155ac0eee687ae1/torch-2.11.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2658f34ce7e2dabf4ec73b45e2ca68aedad7a5be87ea756ad656eaf32bf1e1ea", size = 419732324, upload-time = "2026-03-23T18:09:36.604Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f4/1b666b6d61d3394cca306ea543ed03a64aad0a201b6cd159f1d41010aeb1/torch-2.11.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:98bb213c3084cfe176302949bdc360074b18a9da7ab59ef2edc9d9f742504778", size = 530596026, upload-time = "2026-03-23T18:09:20.842Z" },
+    { url = "https://files.pythonhosted.org/packages/48/6b/30d1459fa7e4b67e9e3fe1685ca1d8bb4ce7c62ef436c3a615963c6c866c/torch-2.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a97b94bbf62992949b4730c6cd2cc9aee7b335921ee8dc207d930f2ed09ae2db", size = 114793702, upload-time = "2026-03-23T18:09:47.304Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0d/8603382f61abd0db35841148ddc1ffd607bf3100b11c6e1dab6d2fc44e72/torch-2.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01018087326984a33b64e04c8cb5c2795f9120e0d775ada1f6638840227b04d7", size = 80573442, upload-time = "2026-03-23T18:09:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/86/7cd7c66cb9cec6be330fff36db5bd0eef386d80c031b581ec81be1d4b26c/torch-2.11.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:2bb3cc54bd0dea126b0060bb1ec9de0f9c7f7342d93d436646516b0330cd5be7", size = 419749385, upload-time = "2026-03-23T18:07:33.77Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e8/b98ca2d39b2e0e4730c0ee52537e488e7008025bc77ca89552ff91021f7c/torch-2.11.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4dc8b3809469b6c30b411bb8c4cad3828efd26236153d9beb6a3ec500f211a60", size = 530716756, upload-time = "2026-03-23T18:07:50.02Z" },
+    { url = "https://files.pythonhosted.org/packages/78/88/d4a4cda8362f8a30d1ed428564878c3cafb0d87971fbd3947d4c84552095/torch-2.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:2b4e811728bd0cc58fb2b0948fe939a1ee2bf1422f6025be2fca4c7bd9d79718", size = 114552300, upload-time = "2026-03-23T18:09:05.617Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/46/4419098ed6d801750f26567b478fc185c3432e11e2cad712bc6b4c2ab0d0/torch-2.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8245477871c3700d4370352ffec94b103cfcb737229445cf9946cddb7b2ca7cd", size = 80959460, upload-time = "2026-03-23T18:09:00.818Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/66/54a56a4a6ceaffb567231994a9745821d3af922a854ed33b0b3a278e0a99/torch-2.11.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:ab9a8482f475f9ba20e12db84b0e55e2f58784bdca43a854a6ccd3fd4b9f75e6", size = 419735835, upload-time = "2026-03-23T18:07:18.974Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e7/0b6665f533aa9e337662dc190425abc0af1fe3234088f4454c52393ded61/torch-2.11.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:563ed3d25542d7e7bbc5b235ccfacfeb97fb470c7fee257eae599adb8005c8a2", size = 530613405, upload-time = "2026-03-23T18:08:07.014Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/bf/c8d12a2c86dbfd7f40fb2f56fbf5a505ccf2d9ce131eb559dfc7c51e1a04/torch-2.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b2a43985ff5ef6ddd923bbcf99943e5f58059805787c5c9a2622bf05ca2965b0", size = 114792991, upload-time = "2026-03-23T18:08:19.216Z" },
 ]
 
 [[package]]
@@ -1587,7 +1586,7 @@ wheels = [
 
 [[package]]
 name = "torchvision"
-version = "0.27.0"
+version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -1595,26 +1594,26 @@ dependencies = [
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/c8/5cd91932f7f3671b0743dc4ae1a4c16b1d0b45bf4087976277d325bda718/torchvision-0.27.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:1a6dd742a150645126df9e0b2e449874c1d635897c773b322c2e067e98382dfe", size = 1758824, upload-time = "2026-05-13T14:57:15.227Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/36/7fb7d19477b3d93283b52fea11fa8ee30ab9064a08c97b4a6b91445e26cb/torchvision-0.27.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:65772ff3ec4f4f5d680e30019835555dd239e7fefee4b0a846375fe1cb1592ef", size = 7831034, upload-time = "2026-05-13T14:57:06.483Z" },
-    { url = "https://files.pythonhosted.org/packages/62/43/dfd894c3f8b01b5b33fde990f0159c1926ebc7b6e2c4193e2efb7da3c4cb/torchvision-0.27.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7a9966a088d06b4cf6c610e03be62de469efa6f2cd2e7c7eed8e925ed6af59ac", size = 7579774, upload-time = "2026-05-13T14:56:59.337Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0c/722e989f9cf026e97ef7cb24a9bb1859e099f72d247ae35388fb89729f73/torchvision-0.27.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c037709072ca9b19750c0cbe9e8bb6f91c9a1be1befa26df33e281deccbd8c7", size = 4021073, upload-time = "2026-05-13T14:57:00.848Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/ae/36547812e6e047c1d80bcacd1b17a340612b08a6e876e0aabf3d0b9228b0/torchvision-0.27.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:41d6dae73e1af09fa82ded597ae57f2a2314285acde54b25890a8f8e51b999d7", size = 1758826, upload-time = "2026-05-13T14:57:05.262Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/30/32c4ea842738728a14e3df8c576c62dedcf5ae5cb6a5c984c6429ebe7524/torchvision-0.27.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:70f071c6f74b60d5fe8851636d8d4cd5f4fa29d57fd9348a87a6f17b990b95ba", size = 7789501, upload-time = "2026-05-13T14:56:57.786Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/24/4d0d48684251bd0673f87d633d5d88ab00227983b00591156eed2f86c8d5/torchvision-0.27.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:aaafa6962c9d91f42503de1957d6fa349907d028c06f335bd95da7a5bc57147d", size = 7579868, upload-time = "2026-05-13T14:56:41.618Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/da/e6edd051d2ba25adf23b120fa97f458dff888d098c51e84724f17d2d1470/torchvision-0.27.0-cp313-cp313-win_amd64.whl", hash = "sha256:aee384a2782c89517c4ab9061d2720ba59fd2ffe5ef89d0a149cc2d43abdf521", size = 4092700, upload-time = "2026-05-13T14:57:09.729Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/23/95dfa40431360f42ca949bf861434bed51164adfa8fb9801e05bf3194f50/torchvision-0.27.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:c5121f1b9ab09a7f73e837871deb8321551f7eaeb19d87aa00de9191968eae44", size = 1845008, upload-time = "2026-05-13T14:57:03.768Z" },
-    { url = "https://files.pythonhosted.org/packages/23/b9/9dbdf76b2b49a75ba8088df6f7c755bdb520afb6c6dbac0102b46cde5e99/torchvision-0.27.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:1c01f0d1091ae22b9dfc082b0a0fe5faaf053686a29b4fb082ba7691375c73cf", size = 7791430, upload-time = "2026-05-13T14:56:56.206Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/6a/e4a16cf2f3310c2ea7760dc5d9054496844391e0f4c1fae87fefac2f3d9e/torchvision-0.27.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:dadea3c5ecfd05bbb2a3312ab0374f213c58bf6459cb059122e2f4dfe13d10ed", size = 7668441, upload-time = "2026-05-13T14:57:02.127Z" },
-    { url = "https://files.pythonhosted.org/packages/00/70/01b6461117a6a94b5af3f8ee166bb0f045056f3cf187750c110dabfdfffa/torchvision-0.27.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a49e55055a39a8506fe7e59850522cab004efb2c3839f6057658889c1d69c815", size = 4141602, upload-time = "2026-05-13T14:56:53.449Z" },
-    { url = "https://files.pythonhosted.org/packages/92/22/c0633677b3b3f3e69554a21ac087bf705f829c40cd5e3783507b8c006681/torchvision-0.27.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:c1fac0fc2a7adf29481fc1938a0e7845c57ba1147a986784109c4d98f434ea8c", size = 1758818, upload-time = "2026-05-13T14:56:54.988Z" },
-    { url = "https://files.pythonhosted.org/packages/48/e8/55f9d9667b56dae470e69e31beac9b00d458ea393feec1aae95cc4f3f1c9/torchvision-0.27.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:cbf89764fc76f3f17fbf80c12d5a89c691e91cb9d82c38412aaf0568655ffb19", size = 7789667, upload-time = "2026-05-13T14:56:48.858Z" },
-    { url = "https://files.pythonhosted.org/packages/00/bc/6f8681daf3bbc4c315bb0005110f99d28e3ecd675bf9c8f2c0d393fbac7a/torchvision-0.27.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:91f61b9865423037c327eb56afa207cc72de874e458c361840db9dcf5ce0c0eb", size = 7579848, upload-time = "2026-05-13T14:56:38.209Z" },
-    { url = "https://files.pythonhosted.org/packages/19/6c/8d8020e6bd1e46c53e487c9c4e9457a07f2ee28931028fb5d71e2da40adc/torchvision-0.27.0-cp314-cp314-win_amd64.whl", hash = "sha256:5bb82fc3c55daf1788621e504310b0a286f1069627a8742f692aebb075ef25a7", size = 4119284, upload-time = "2026-05-13T14:56:46.625Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/7e/e78c48662a8d551606efdbe11c6b9c1d6d2391b92cd0e4591b9e6a2412b8/torchvision-0.27.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:2c4099a15150143b9b034730b404a56d572efe0b79489b4c765d929cb4eac7f3", size = 1758828, upload-time = "2026-05-13T14:56:52.293Z" },
-    { url = "https://files.pythonhosted.org/packages/21/dd/d03ee9f9ee7bf11a8c7c776fb8e7fd6102f59c013791a2a4e5175bd6cba7/torchvision-0.27.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b4c6bb0a670dcba017b3643e21902c9b8a1cc1c127d602f1488fa29ec3c6e865", size = 7790618, upload-time = "2026-05-13T14:56:44.721Z" },
-    { url = "https://files.pythonhosted.org/packages/39/08/4002336a74742be70728603ec1769feb2b55e0d19c532c9ec9f92008de76/torchvision-0.27.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1c2db4bde82bc48ebff73436a6adf34d4f809448268a70d9a1285f5c8f92313d", size = 7580217, upload-time = "2026-05-13T14:56:43.274Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/cb/4dd4783eb3565f526ba6e64b6f6ca26c00eacc924cdfe60455db9d91b84b/torchvision-0.27.0-cp314-cp314t-win_amd64.whl", hash = "sha256:72bf547e58ddb948689734eed6f4b6a2031f979dba4fb08e3690688b392e929f", size = 4226392, upload-time = "2026-05-13T14:56:40.235Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e7/56b47cc3b132aea90ccce22bcb8975dec688b002150012acc842846039d0/torchvision-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c409e1c3fdebec7a3834465086dbda8bf7680eff79abf7fd2f10c6b59520a7a4", size = 1863502, upload-time = "2026-03-23T18:12:57.326Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ec/5c31c92c08b65662fe9604a4067ae8232582805949f11ddc042cebe818ed/torchvision-0.26.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:406557718e62fdf10f5706e88d8a5ec000f872da913bf629aab9297622585547", size = 7767944, upload-time = "2026-03-23T18:12:42.805Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d8/cb6ccda1a1f35a6597645818641701207b3e8e13553e75fce5d86bac74b2/torchvision-0.26.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d61a5abb6b42a0c0c311996c2ac4b83a94418a97182c83b055a2a4ae985e05aa", size = 7522205, upload-time = "2026-03-23T18:12:54.654Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a9/c272623a0f735c35f0f6cd6dc74784d4f970e800cf063bb76687895a2ab9/torchvision-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:7993c01648e7c61d191b018e84d38fe0825c8fcb2720cd0f37caf7ba14404aa1", size = 4255155, upload-time = "2026-03-23T18:12:32.652Z" },
+    { url = "https://files.pythonhosted.org/packages/da/80/0762f77f53605d10c9477be39bb47722cc8e383bbbc2531471ce0e396c07/torchvision-0.26.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5d63dd43162691258b1b3529b9041bac7d54caa37eae0925f997108268cbf7c4", size = 1860809, upload-time = "2026-03-23T18:12:47.629Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/81/0b3e58d1478c660a5af4268713486b2df7203f35abd9195fea87348a5178/torchvision-0.26.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a39c7a26538c41fda453f9a9692b5ff9b35a5437db1d94f3027f6f509c160eac", size = 7727494, upload-time = "2026-03-23T18:12:46.062Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/dc/d9ab5d29115aa05e12e30f1397a3eeae1d88a511241dc3bce48dc4342675/torchvision-0.26.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:b7e6213620bbf97742e5f79832f9e9d769e6cf0f744c5b53dad80b76db633691", size = 7521747, upload-time = "2026-03-23T18:12:36.815Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/1b/f1bc86a918c5f6feab1eeff11982e2060f4704332e96185463d27855bdf5/torchvision-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:4280c35ec8cba1fcc8294fb87e136924708726864c379e4c54494797d86bc474", size = 4319880, upload-time = "2026-03-23T18:12:38.168Z" },
+    { url = "https://files.pythonhosted.org/packages/66/28/b4ad0a723ed95b003454caffcc41894b34bd8379df340848cae2c33871de/torchvision-0.26.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:358fc4726d0c08615b6d83b3149854f11efb2a564ed1acb6fce882e151412d23", size = 1951973, upload-time = "2026-03-23T18:12:48.781Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e2/7a89096e6cf2f3336353b5338ba925e0addf9d8601920340e6bdf47e8eb3/torchvision-0.26.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:3daf9cc149cf3cdcbd4df9c59dae69ffca86c6823250442c3bbfd63fc2e26c61", size = 7728679, upload-time = "2026-03-23T18:12:26.196Z" },
+    { url = "https://files.pythonhosted.org/packages/69/1d/4e1eebc17d18ce080a11dcf3df3f8f717f0efdfa00983f06e8ba79259f61/torchvision-0.26.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:82c3965eca27e86a316e31e4c3e5a16d353e0bcbe0ef8efa2e66502c54493c4b", size = 7609138, upload-time = "2026-03-23T18:12:35.327Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a4/f1155e943ae5b32400d7000adc81c79bb0392b16ceb33bcf13e02e48cced/torchvision-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ebc043cc5a4f0bf22e7680806dbba37ffb19e70f6953bbb44ed1a90aeb5c9bea", size = 4248202, upload-time = "2026-03-23T18:12:41.423Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c8/9bffa9c7f7bdf95b2a0a2dc535c290b9f1cc580c3fb3033ab1246ffffdeb/torchvision-0.26.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:eb61804eb9dbe88c5a2a6c4da8dec1d80d2d0a6f18c999c524e32266cb1ebcd3", size = 1860813, upload-time = "2026-03-23T18:12:39.636Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ac/48f28ffd227991f2e14f4392dde7e8dc14352bb9428c1ef4a4bbf5f7ed85/torchvision-0.26.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:9a904f2131cbfadab4df828088a9f66291ad33f49ff853872aed1f86848ef776", size = 7727777, upload-time = "2026-03-23T18:12:22.549Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/21/a2266f7f1b0e58e624ff15fd6f01041f59182c49551ece0db9a183071329/torchvision-0.26.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:0f3e572efe62ad645017ea847e0b5e4f2f638d4e39f05bc011d1eb9ac68d4806", size = 7522174, upload-time = "2026-03-23T18:12:29.565Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ba/1666f90bc0bdd77aaa11dcc42bb9f621a9c3668819c32430452e3d404730/torchvision-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:114bec0c0e98aa4ba446f63e2fe7a2cbca37b39ac933987ee4804f65de121800", size = 4348469, upload-time = "2026-03-23T18:12:24.44Z" },
+    { url = "https://files.pythonhosted.org/packages/45/8f/1f0402ac55c2ae15651ff831957d083fe70b2d12282e72612a30ba601512/torchvision-0.26.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:b7d3e295624a28b3b1769228ce1345d94cf4d390dd31136766f76f2d20f718da", size = 1860826, upload-time = "2026-03-23T18:12:34.1Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6a/18a582fe3c5ee26f49b5c9fb21ad8016b4d1c06d10178894a58653946fda/torchvision-0.26.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:7058c5878262937e876f20c25867b33724586aa4499e2853b2d52b99a5e51953", size = 7729089, upload-time = "2026-03-23T18:12:31.394Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/9b/f7e119b59499edc00c55c03adc9ec3bd96144d9b81c46852c431f9c64a9a/torchvision-0.26.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:8008474855623c6ba52876589dc52df0aa66e518c25eca841445348e5f79844c", size = 7522704, upload-time = "2026-03-23T18:12:20.301Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/6a/09f3844c10643f6c0de5d95abc863420cfaf194c88c7dffd0ac523e2015f/torchvision-0.26.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e9d0e022c19a78552fb055d0414d47fecb4a649309b9968573daea160ba6869c", size = 4454275, upload-time = "2026-03-23T18:12:27.487Z" },
 ]
 
 [[package]]
@@ -1682,10 +1681,10 @@ requires-dist = [
     { name = "sounddevice", marker = "extra == 'audio'", specifier = ">=0.5" },
     { name = "soundfile", marker = "extra == 'mlx'", specifier = ">=0.12" },
     { name = "soundfile", marker = "extra == 'models'", specifier = ">=0.12" },
-    { name = "torch", marker = "extra == 'models'", specifier = ">=2.9.1" },
-    { name = "torchaudio", marker = "extra == 'models'", specifier = ">=2.5" },
+    { name = "torch", marker = "extra == 'models'", specifier = ">=2.9.1,<2.12" },
+    { name = "torchaudio", marker = "extra == 'models'", specifier = ">=2.9.1,<2.12" },
     { name = "torchcodec", marker = "extra == 'models'", specifier = ">=0.5" },
-    { name = "torchvision", marker = "extra == 'models'", specifier = ">=0.20" },
+    { name = "torchvision", marker = "extra == 'models'", specifier = ">=0.24,<0.27" },
     { name = "transformers", marker = "extra == 'models'", specifier = ">=5.8" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a19" },
 ]
@@ -1713,19 +1712,19 @@ wheels = [
 
 [[package]]
 name = "triton"
-version = "3.7.0"
+version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/13/ec05adfcd87311d532ba61e3af143e8be59fcd26675884c4682841406a20/triton-3.7.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4bf49b00a7a377a68a6da603a876e797614e6455a80e9021669c476a953ad9a", size = 188505104, upload-time = "2026-05-07T19:05:09.843Z" },
-    { url = "https://files.pythonhosted.org/packages/62/7b/468a576e35beef1426e0828e28e9ba9e65f5474d496f16ee126c15646324/triton-3.7.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f111161d49bf903c0eaedde3962353a3d841c08a836839b7cc1025b8426efcf", size = 201457567, upload-time = "2026-05-07T18:46:13.505Z" },
-    { url = "https://files.pythonhosted.org/packages/01/e1/a59a583de59b8f62c495d67c80ee3ea97d09e91ac80c4c6e76456ed8d8ac/triton-3.7.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abdf6beaa89b1bcfb9a43cd990536ce66091a997841a4814b260b7bee4c88c3c", size = 188503209, upload-time = "2026-05-07T19:05:17.935Z" },
-    { url = "https://files.pythonhosted.org/packages/30/b1/b7507bb9815d403927c8dd51d4158ed2e11751a92dbc118a044f247b6848/triton-3.7.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a35d7afe3f3f058e7ec49fcce09794049e0ffc5c59019ac25ec3413741b8c4e7", size = 201453566, upload-time = "2026-05-07T18:46:20.427Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/8f/0bea7a6a0c989315c9135a1d7fb37e41905cfb3a17cbc1f10044ebd4cc3a/triton-3.7.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc1d61c172d257db80ddf42595131fb196ad2e9bdd751e90fe2ef13531734e8b", size = 188612899, upload-time = "2026-05-07T19:05:24.955Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/02/d96f57828d0912aec733b9bc7e0e7dbfd2c6f079a8fa433ac25cb93d1a30/triton-3.7.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70fb9bbdc9f400afc54bbf6eb2670af28829a6ae3996863317964783141daf56", size = 201553816, upload-time = "2026-05-07T18:46:27.49Z" },
-    { url = "https://files.pythonhosted.org/packages/40/fb/82a802dac4689f2a2fb2e69302e6a138eecc3e175bbe976ba3cfc717683a/triton-3.7.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4a44a8476d0d3571eac4e4d1048e1ff75aad81a09ff4602ccfc56c6dea1672e", size = 188507879, upload-time = "2026-05-07T19:05:32.209Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/af/9904ec6d3c93d9b24e5ec360445bbdf758b7f00bfbeedb89cb0eb64eb8bb/triton-3.7.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9b85e72968a9d8bba5ddb24e9b64aaabaf48affb042f2755cb7cfa92b7531ce", size = 201460637, upload-time = "2026-05-07T18:46:34.749Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/f9/4835a8ea746b88727d8899f4e3ccce4f9cacb38abfc3bb0a638266c53111/triton-3.7.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18a160de426fd99f92b0baf509045360afbd3bfaa0b4a5171dde800ec9f09684", size = 188608706, upload-time = "2026-05-07T19:05:39.218Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/68/fa86e5a39608000f645535b2c124920126327ab731f8c4fafd5b07ff8d4b/triton-3.7.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce061073102714b725f3660ec6939d94a1da7984b3aa99c921417cae273672f5", size = 201546766, upload-time = "2026-05-07T18:46:42.088Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5d/08201db32823bdf77a0e2b9039540080b2e5c23a20706ddba942924ebcd6/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4", size = 176128243, upload-time = "2026-01-20T16:16:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/12/34d71b350e89a204c2c7777a9bba0dcf2f19a5bfdd70b57c4dbc5ffd7154/triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448e02fe6dc898e9e5aa89cf0ee5c371e99df5aa5e8ad976a80b93334f3494fd", size = 176133521, upload-time = "2026-01-20T16:16:13.321Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4e/41b0c8033b503fd3cfcd12392cdd256945026a91ff02452bef40ec34bee7/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6", size = 176276087, upload-time = "2026-01-20T16:16:18.989Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
+    { url = "https://files.pythonhosted.org/packages/49/55/5ecf0dcaa0f2fbbd4420f7ef227ee3cb172e91e5fede9d0ecaddc43363b4/triton-3.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5523241e7d1abca00f1d240949eebdd7c673b005edbbce0aca95b8191f1d43", size = 176138577, upload-time = "2026-01-20T16:16:25.426Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
+    { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload-time = "2026-01-20T16:16:31.528Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add platform-aware runtime profiles and settings defaults for Linux CUDA/ROCm and macOS Apple Silicon.
- Add backend catalog dispatch, platform validation, MLX aliases, and cache-aware model prefetch.
- Split ASR audio preparation so MLX paths avoid Torch, add MLX ASR support, and align Granite NAR with the current model card.
- Add backend-aware doctor checks, macOS LaunchAgent/TCC/path handling, Darwin tray failure behavior, macOS CI, eval manifest, and docs.
- Address follow-up review findings around doctor log handling, optional checks, byte decoding, MLX cache roots, model row filtering, MLX API compatibility, resampling, CI smoke coverage, and shortcut log quoting.

## Validation
- `uv run ruff check .`
- `uv run -m compileall transclip scripts tests`
- `uv run python -m unittest discover -s tests -v` (148 tests)
- macOS eval manifest schema/path check
- `uv run -m transclip.cli doctor` no longer crashes in the base env; exits only for expected missing Torch/ASR runtime there
- `VIRTUAL_ENV=$PWD/.venv-gfx1151 uv run --active -m transclip.cli doctor` passes required checks on the local ROCm env

## Follow-up
- Manual Apple Silicon smoke is still needed: `uv sync --extra audio --extra mlx`, model prefetch, `install`, `status`, `doctor`, and `toggle-record --paste` through macOS permissions.
