### PR TITLE
Add voice mode routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ htmlcov/
 # Virtual environments
 .venv
 .venv*/
+.venv-*
 
 # Local-only runtime artifacts
 debug-captures/

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -39,6 +39,31 @@ while improving transcript readability. The policy includes conservative
 punctuation and capitalization behavior, optional model cleanup, output
 validation, and token budgeting for model-backed cleanup.
 
+**Voice mode routing**: The deterministic post-ASR routing step that runs after
+keyword restoration and before cleanup or paste output. It matches only
+case-insensitive leading trigger phrases and returns dictation, cleanup, or
+shell mode with the original payload text preserved for model input.
+
+**Mode trigger**: A configured spoken prefix such as `clean up`, `trans
+cleanup`, `shell command`, `bash command`, or `terminal command`. Triggers are
+prefix-only; the same words in the middle of an ordinary sentence do not change
+dictation mode.
+
+**Literal escape**: The leading `literal` prefix before a configured mode
+trigger. It disables mode routing for that utterance and pastes the trigger text
+itself, for example `literal shell command list files` becomes `shell command
+list files`.
+
+**Model cleanup**: The Qwen-backed cleanup path used for explicit cleanup
+triggers and for normal dictation when `voice_model_cleanup_always_on` is
+enabled. It is separate from the conservative rule cleanup that remains the
+default for normal dictation.
+
+**Shell command generation**: The voice mode that turns a spoken task into Bash
+text using the shared Qwen text model. It validates syntax without execution and
+pastes only command text or commented diagnostics; TransClip does not press
+Enter or submit terminal input.
+
 **Eval gate**: The repeatable evaluation checks used to decide whether a build
 meets the current dictation quality and latency expectations. It covers manifest
 shape, warmup handling, measured cases, metrics, thresholds, and the JSON output

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+.PHONY: help check test lint lint-fix format format-check typecheck compile ruff-check ruff-fix ruff-format ty
+
+UV ?= uv
+
+help:
+	@printf '%s\n' \
+		'Targets:' \
+		'  make check         Run lint, format-check, typecheck, tests, compile, and diff checks' \
+		'  make test          Run the unittest suite' \
+		'  make lint          Run Ruff lint checks' \
+		'  make lint-fix      Run Ruff lint fixes' \
+		'  make format        Format Python files with Ruff' \
+		'  make format-check  Check Ruff formatting without writing' \
+		'  make typecheck     Run ty type checking' \
+		'  make compile       Compile transclip, tests, and scripts' \
+		'  make ruff-check    Alias for lint' \
+		'  make ruff-fix      Alias for lint-fix' \
+		'  make ruff-format   Alias for format' \
+		'  make ty            Alias for typecheck'
+
+check: lint format-check typecheck test compile
+	git diff --check
+
+test:
+	$(UV) run -m unittest discover -v
+
+lint:
+	$(UV) run ruff check .
+
+lint-fix:
+	$(UV) run ruff check . --fix
+
+format:
+	$(UV) run ruff format .
+
+format-check:
+	$(UV) run ruff format . --check
+
+typecheck:
+	$(UV) run ty check
+
+compile:
+	$(UV) run -m compileall transclip tests scripts
+
+ruff-check: lint
+ruff-fix: lint-fix
+ruff-format: format
+ty: typecheck

--- a/README.md
+++ b/README.md
@@ -50,6 +50,28 @@ uv run -m transclip.cli smoke-test
 uv run -m transclip.cli logs
 ```
 
+### Voice Mode Quick Start
+
+With the service running, press the toggle shortcut once to start recording and
+again to stop. Ordinary speech is dictated normally. Start an utterance with one
+of these phrases to choose another mode:
+
+```text
+clean up <text>              -> Qwen model cleanup
+trans cleanup <text>         -> Qwen model cleanup
+shell command <task>         -> Bash command generation
+bash command <task>          -> Bash command generation
+terminal command <task>      -> Bash command generation
+literal shell command <text> -> paste "shell command <text>"
+literal bash command <text>  -> paste "bash command <text>"
+literal clean up <text>      -> paste "clean up <text>"
+```
+
+Trigger matching is case-insensitive and only applies at the beginning of the
+utterance, so a sentence that mentions "shell command" later is still normal
+dictation. Use `literal` when you want to dictate the trigger words themselves
+instead of activating cleanup or shell mode.
+
 Run the Python tray:
 
 ```bash
@@ -86,20 +108,31 @@ uv pip install -e '.[models,audio,llama]'
 ```
 
 On the current Linux `gfx1151` workstation, the V1 latency profile uses AMD's
-TheRock ROCm nightly index plus FlashAttention's Triton AMD backend. Do not use
-the local custom wheel for this app; it fails GPU tensor execution on this host.
+TheRock ROCm nightly index plus FlashAttention's Triton AMD backend. The
+canonical runtime environment is `.venv`; the systemd service and GNOME
+shortcut should point at `.venv/bin/python3`. Do not use the local custom wheel
+for this app; it fails GPU tensor execution on this host.
+
+Use the helper script:
 
 ```bash
-uv venv --python 3.13 .venv-gfx1151
-uv pip install --python .venv-gfx1151/bin/python \
+scripts/setup_gfx1151_env.sh
+```
+
+Or run the setup steps manually:
+
+```bash
+uv venv --python 3.13 .venv
+uv pip install --python .venv/bin/python \
   --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ \
   --pre torch torchaudio torchvision pytorch-triton-rocm
-uv pip install --python .venv-gfx1151/bin/python \
+uv pip install --python .venv/bin/python \
   -e . 'transformers>=4.52.1' 'accelerate>=1.0' 'soundfile>=0.12' 'sounddevice>=0.5'
 FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE MAX_JOBS=4 \
-  uv pip install --python .venv-gfx1151/bin/python --no-deps \
+  uv pip install --python .venv/bin/python --no-deps \
   flash-attn==2.8.3 --no-build-isolation
-uv pip install --python .venv-gfx1151/bin/python einops
+uv pip install --python .venv/bin/python einops
+uv pip install --python .venv/bin/python flash-linear-attention
 ```
 
 The default ASR backend is `ibm-granite/granite-speech-4.1-2b-nar`, selected
@@ -123,7 +156,46 @@ model_cache_dir = "/path/to/local/huggingface/cache"
 ```
 
 Populate the cache before running the service; the app should not download
-models during dictation.
+models during dictation. The helper commands are:
+
+```bash
+uv run -m transclip.cli models list
+uv run -m transclip.cli models doctor
+uv run -m transclip.cli models prefetch --model ibm-granite/granite-speech-4.1-2b-nar
+uv run -m transclip.cli models prefetch --model Qwen/Qwen3.5-4B
+```
+
+Run the helper through the same Python environment that runs the service. On
+the current `gfx1151` workstation, model downloads should use:
+
+```bash
+.venv/bin/python3 -m transclip.cli models prefetch --model ibm-granite/granite-speech-4.1-2b-nar
+.venv/bin/python3 -m transclip.cli models prefetch --model Qwen/Qwen3.5-4B
+```
+
+Voice mode routing runs after ASR and keyword restoration. Ordinary dictation
+keeps the existing cleanup behavior unless a leading trigger phrase is spoken or
+the tray setting enables model cleanup for all dictation. Shell mode validates
+generated Bash with `bash -n -c <command>` when Bash is available and also uses
+ShellCheck when installed and enabled. The shell prompt includes the user's
+default shell from `$SHELL`, falling back to the login shell, while still asking
+for Bash-compatible syntax. Invalid shell output is pasted as commented
+diagnostic text. Valid shell commands are pasted for review only; TransClip
+never presses Enter, executes the command, or auto-submits terminal input.
+
+The tray menu includes `Model cleanup always on`. Enabling it persists
+`voice_model_cleanup_always_on = true` and restarts the service so subsequent
+ordinary dictation uses the shared Qwen text model:
+
+```toml
+voice_mode_routing_enabled = true
+voice_model_cleanup_always_on = false
+voice_mode_shell_enabled = true
+text_model_runtime = "transformers"
+text_model = "Qwen/Qwen3.5-4B"
+shell_syntax_validation_enabled = true
+shellcheck_enabled = true
+```
 
 Then transcribe a WAV:
 
@@ -223,7 +295,7 @@ Then build and run the eval:
 
 ```bash
 TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1 \
-VIRTUAL_ENV=$PWD/.venv-gfx1151 uv run --active scripts/run_real_eval_pipeline.py \
+VIRTUAL_ENV=$PWD/.venv uv run --active scripts/run_real_eval_pipeline.py \
   ~/transclip-real-eval
 ```
 
@@ -232,7 +304,7 @@ VIRTUAL_ENV=$PWD/.venv-gfx1151 uv run --active scripts/run_real_eval_pipeline.py
 ```bash
 uv run -m unittest discover -s tests -v
 uv run -m compileall scripts transclip tests
-VIRTUAL_ENV=$PWD/.venv-gfx1151 uv run --active scripts/check_v1_completion.py
+VIRTUAL_ENV=$PWD/.venv uv run --active scripts/check_v1_completion.py
 ```
 
 On Wayland, `wtype` is only usable when the compositor supports the virtual

--- a/eval/real-usage/prompts.md
+++ b/eval/real-usage/prompts.md
@@ -157,3 +157,49 @@ Keywords: global shortcut
 Leave the transcript on the clipboard when paste simulation fails.
 
 Keywords: clipboard
+
+## Voice mode routing prompts
+
+Read these prompts aloud when checking trigger recognition.
+
+### route_cleanup_01
+
+Clean up the release notes and preserve the command line flag dash dash verbose.
+
+Keywords: cleanup
+
+### route_cleanup_02
+
+Trans cleanup add punctuation but keep slash tmp slash transclip and Qwen exactly.
+
+Keywords: Qwen
+
+### route_shell_01
+
+Shell command list Python files sorted by modified time.
+
+Keywords: shell command
+
+### route_shell_02
+
+Bash command show the current git branch.
+
+Keywords: bash command
+
+### route_shell_03
+
+Terminal command find files larger than one hundred megabytes under downloads.
+
+Keywords: terminal command
+
+### route_literal_01
+
+Literal shell command list files.
+
+Keywords: literal shell command
+
+### route_prefix_only_01
+
+Please write the words shell command in the middle of this sentence.
+
+Keywords: shell command

--- a/plans/2026-05-20-voice-mode-routing.md
+++ b/plans/2026-05-20-voice-mode-routing.md
@@ -1,0 +1,231 @@
+# Voice Mode Routing Plan
+
+Status: decision-complete implementation plan
+Branch: `feature/voice-mode-routing`
+Source: design decisions through 2026-05-20
+Scope: add spoken-prefix routing for normal dictation, model cleanup, and shell-command generation in TransClip
+
+## Context
+
+Current TransClip runtime:
+
+```text
+shortcut -> toggle record -> Python HTTP service -> Granite ASR -> keyword restore -> cleanup -> clipboard -> paste
+```
+
+The feature adds a post-ASR routing layer at the `InferenceEngine.transcribe()`
+choke point. Normal dictation remains unchanged unless a case-insensitive
+leading trigger phrase is present or the tray toggle enables model cleanup for
+all dictation.
+
+The chosen model path is **PyTorch/Transformers**, not llama.cpp/GGUF. Use the
+existing service-hosted model pattern and load the text model lazily in the
+Python service.
+
+## Settled Product Behavior
+
+- Model: use `Qwen/Qwen3.5-4B` as the small dense text model for both explicit
+  cleanup and shell command generation.
+- Runtime: PyTorch/Transformers inside the existing TransClip service process.
+- Trigger matching: case-insensitive, prefix-only, deterministic.
+- Cleanup triggers:
+  - `clean up <text>`
+  - `trans cleanup <text>`
+- Shell triggers:
+  - `shell command <task>`
+  - `bash command <task>`
+  - `terminal command <task>`
+- Literal escape:
+  - `literal clean up <text>` pastes `clean up <text>`
+  - `literal shell command <text>` pastes `shell command <text>`
+  - same rule for all configured triggers
+- Empty trigger payload falls back to normal dictation.
+- Trigger text is not sent to the model; only the payload is processed.
+- If model cleanup is active, use the model cleanup path, not the heuristic rule
+  cleanup path.
+- Shell mode pastes the command text into the terminal, but TransClip never
+  presses Enter or executes it.
+- Shell output may be pasted even when operationally risky. The safety boundary
+  is paste-without-execute plus user review before Enter.
+- Shell output must pass a non-executing syntax check before it is pasted as
+  runnable text. If syntax validation fails, paste a commented diagnostic
+  instead of the command.
+
+## Key Implementation Changes
+
+### Branch and Settings
+
+- Create or switch to `feature/voice-mode-routing` before implementation.
+- Add settings fields:
+
+```toml
+voice_mode_routing_enabled = true
+voice_model_cleanup_always_on = false
+voice_mode_shell_enabled = true
+text_model_runtime = "transformers"
+text_model = "Qwen/Qwen3.5-4B"
+shell_syntax_validation_enabled = true
+shellcheck_enabled = true
+```
+
+- Keep current default dictation behavior unchanged:
+  `voice_model_cleanup_always_on = false`.
+- When `voice_model_cleanup_always_on = true`, normal dictation uses model
+  cleanup even without a spoken cleanup trigger.
+- Preserve strict unknown-field validation and update TOML serialization.
+
+### Mode Routing
+
+- Add a small mode-routing module that returns:
+
+```text
+mode: dictation | cleanup | shell
+payload: str
+trigger: str | None
+literal: bool
+```
+
+- Normalize only for matching; preserve original payload text for model input.
+- Match only at the beginning of the transcript after ASR and keyword restore.
+- Case-insensitive matches must handle capitalization and punctuation such as
+  `Shell command, list files`.
+- Do not add fuzzy aliases in V1. Add aliases only after real ASR evals show a
+  consistent misrecognition pattern.
+
+### Text Model Backend
+
+- Introduce a shared Transformers text-generation backend, loaded lazily and
+  reused for both cleanup and shell generation.
+- Reuse the service process and existing PyTorch/Transformers dependency path.
+- Keep Granite 4.1 Speech NAR as ASR only; do not try to use the speech model
+  for cleanup or shell generation.
+- Default generation should be deterministic for both processors.
+
+### Cleanup Processing
+
+- Keep the existing heuristic cleanup as the normal default when model cleanup
+  is not requested.
+- Explicit `clean up ...` / `trans cleanup ...` always uses Qwen model cleanup.
+- Tray always-on cleanup toggle makes all successful normal dictation pass
+  through Qwen model cleanup.
+- Cleanup prompt contract:
+  - preserve meaning
+  - correct punctuation, capitalization, and paragraphing
+  - remove filler only when clearly filler
+  - preserve technical terms, flags, identifiers, paths, and code-ish text
+  - do not add facts
+
+### Shell Command Processing
+
+- Add a shell command processor that sends the payload to Qwen and expects a
+  structured response internally.
+- Render final pasted text as the shell command only, with no JSON and no
+  explanatory prose.
+- TransClip must not press Enter, execute the command, or add a trailing newline
+  intended to submit the command.
+- Use validation to catch malformed output and strip prose/fences.
+- Validate shell syntax without execution before pasting runnable command text:
+  - run `bash -n -c <command>` when `bash` is available
+  - run `shellcheck -s bash -` when `shellcheck` is available and
+    `shellcheck_enabled = true`
+  - treat Bash parse failure or ShellCheck syntax errors as blocking
+  - treat ShellCheck warnings/style notes as metadata, not blockers
+- Operationally risky but syntactically valid commands may still be pasted in
+  V1 because the workflow is user review before Enter, not automatic execution.
+- If no usable command is returned, or syntax validation fails, render a
+  commented diagnostic such as `# TransClip could not produce valid Bash: ...`
+  so pasted text cannot be accidentally executed as the intended command.
+- Record shell metadata in debug capture/history when available, while keeping
+  the user-facing `text` field as the pasted command.
+
+### Tray Toggle
+
+- Add a tray menu toggle for always-on model cleanup, backed by
+  `voice_model_cleanup_always_on`.
+- The menu label should clearly show state, for example:
+  - `✓ Model cleanup always on`
+  - `Model cleanup always on`
+- Persist the setting using the existing settings file path.
+- Restart or reload the service consistently after toggling so the service uses
+  the new setting for subsequent recordings.
+- Update tray tests to cover label state, persistence, and restart/reload
+  behavior.
+
+### Documentation and Eval Prompts
+
+- Update `CONTEXT.md` with mode routing, mode trigger, literal escape, model
+  cleanup, and shell command generation terms.
+- Update `README.md` with trigger examples, literal escapes, the tray cleanup
+  toggle, and the rule that shell commands are pasted but never executed.
+- Add trigger-recognition eval prompts:
+  - `clean up ...`
+  - `trans cleanup ...`
+  - `shell command ...`
+  - `bash command ...`
+  - `terminal command ...`
+  - `literal shell command ...`
+  - ordinary sentences with trigger phrases in the middle
+
+## Test Plan
+
+- `tests.test_mode_routing`
+  - case-insensitive cleanup and shell trigger matches
+  - prefix-only behavior
+  - literal escape behavior
+  - empty trigger fallback to dictation
+  - original payload preservation
+- `tests.test_service`
+  - normal dictation remains unchanged by default
+  - explicit cleanup trigger uses model cleanup, not heuristic cleanup
+  - always-on model cleanup applies to normal dictation
+  - shell trigger returns command text as top-level `text`
+  - shell mode never asks paste/injection code to execute anything
+- `tests.test_cleanup`
+  - model cleanup prompt contract and output parsing
+  - heuristic cleanup still available for default non-model cleanup
+- `tests.test_settings`
+  - new settings defaults, TOML serialization, set/get coercion, unknown field
+    rejection
+- `tests.test_tray`
+  - tray toggle label state
+  - settings persistence
+  - service restart/reload after toggle
+- `tests.test_shell_command`
+  - structured response parsing
+  - prose/fence stripping
+  - `bash -n` syntax validation pass/fail behavior
+  - optional ShellCheck syntax-error handling when available
+  - ShellCheck warnings do not block paste
+  - command-only render
+  - invalid command renders a commented diagnostic
+  - no submit newline
+
+Full verification before PR:
+
+```bash
+uv run -m unittest discover -v
+```
+
+Optional live eval after unit tests:
+
+```bash
+uv run scripts/record_real_eval_session.py ~/transclip-mode-routing-eval --manual-stop
+```
+
+Use live ASR clips only to decide whether to add future aliases; unit tests are
+the deterministic acceptance gate for V1.
+
+## Assumptions and Non-Goals
+
+- Assume `Qwen/Qwen3.5-4B` is available in the configured local Hugging Face
+  cache or can be prefetched through the existing model workflow.
+- Do not introduce llama.cpp, Vulkan, ROCm/HIP llama.cpp, Ollama, or an external
+  model server in this branch.
+- Do not add a second shell-mode hotkey in this branch.
+- Do not add fuzzy trigger matching in this branch.
+- Do not execute shell commands, simulate Enter, or auto-submit terminal input.
+- Do not treat ShellCheck as the only syntax gate. Bash syntax validation is the
+  mandatory non-executing parse check; ShellCheck is an additional lint/syntax
+  layer when installed.
+- Do not change the Granite ASR backend or normal paste pipeline beyond feeding
+  it the final routed text.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,14 +45,8 @@ line-ending = "lf"
 [tool.ty.environment]
 python-version = "3.12"
 
-[tool.ty.analysis]
-allowed-unresolved-imports = [
-    "flash_attn",
-    "gi",
-    "gi.repository",
-    "llama_cpp",
-    "sounddevice",
-]
+[tool.ty.rules]
+unresolved-import = "ignore"
 
 [tool.ty.src]
 include = ["transclip"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for unittest discovery."""

--- a/tests/service_helpers.py
+++ b/tests/service_helpers.py
@@ -8,6 +8,7 @@ from transclip.asr import TranscriptionResult
 from transclip.cleanup import FaithfulRuleCleanupBackend
 from transclip.service import InferenceEngine, create_server
 from transclip.settings import Settings
+from transclip.text_generation import TextGenerationResult
 
 
 class FakeASR:
@@ -34,6 +35,20 @@ class FakeRecorder:
     def stop_to_wav(self, output_path: Path):
         output_path.write_bytes(b"not really wav")
         return output_path
+
+
+class FakeTextBackend:
+    name = "fake-text"
+    model_name = "fake-model"
+
+    def __init__(self, responses: list[str] | None = None):
+        self.responses = list(responses or ["model output"])
+        self.messages: list[list[dict[str, str]]] = []
+
+    def generate(self, messages: list[dict[str, str]], *, max_new_tokens: int) -> TextGenerationResult:
+        self.messages.append(messages)
+        text = self.responses.pop(0) if self.responses else "model output"
+        return TextGenerationResult(text, {"text_generation": 1.0}, self.name, self.model_name)
 
 
 class FakeRuntime:

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -4,11 +4,15 @@ from transclip.cleanup import (
     FaithfulCleanupPolicy,
     FaithfulRuleCleanupBackend,
     GemmaTransformersCleanupBackend,
+    ModelCleanupPolicy,
+    ModelCleanupProcessor,
     build_cleanup_backend,
     conservative_cleanup,
     faithful_cleanup_messages,
+    model_cleanup_messages,
 )
 from transclip.settings import Settings
+from transclip.text_generation import TextGenerationResult
 
 
 class CleanupTests(unittest.TestCase):
@@ -53,6 +57,40 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(policy.validate_output(" cleaned ", "provider"), "cleaned")
         with self.assertRaisesRegex(RuntimeError, "provider cleanup produced an empty response"):
             policy.validate_output("   ", "provider")
+
+    def test_model_cleanup_prompt_contract_and_output_parsing(self):
+        messages = model_cleanup_messages("um hello --flag /tmp/file")
+
+        self.assertIn("Preserve meaning", messages[0]["content"])
+        self.assertIn("Remove filler only", messages[0]["content"])
+        self.assertIn("flags, identifiers, paths", messages[0]["content"])
+        self.assertIn("Do not add facts", messages[0]["content"])
+        self.assertEqual(messages[1]["content"], "Transcript:\num hello --flag /tmp/file")
+
+    def test_model_cleanup_processor_uses_text_backend(self):
+        backend = FakeTextBackend("Cleaned text")
+        result = ModelCleanupProcessor(backend).cleanup("raw text")
+
+        self.assertEqual(result.text, "Cleaned text")
+        self.assertEqual(result.backend, "fake:qwen")
+        self.assertEqual(backend.messages[0][1]["content"], "Transcript:\nraw text")
+
+    def test_model_cleanup_policy_rejects_empty_output(self):
+        with self.assertRaisesRegex(RuntimeError, "fake cleanup produced an empty response"):
+            ModelCleanupPolicy().validate_output(" ", "fake")
+
+
+class FakeTextBackend:
+    name = "fake"
+    model_name = "qwen"
+
+    def __init__(self, response: str):
+        self.response = response
+        self.messages = []
+
+    def generate(self, messages, *, max_new_tokens):
+        self.messages.append(messages)
+        return TextGenerationResult(self.response, {"text_generation": 1.0}, self.name, self.model_name)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,9 +7,10 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
-from tests.service_helpers import FakeRecorder, serve_test_engine, stop_server
 from transclip.cli import main
 from transclip.settings import Settings, write_settings
+
+from tests.service_helpers import FakeRecorder, serve_test_engine, stop_server
 
 
 class InMemoryClipboard:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -3,7 +3,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from tests.service_helpers import FakeRuntime
 from transclip.daemon import (
     SERVICE_NAME,
     append_toggle_log,
@@ -14,6 +13,8 @@ from transclip.daemon import (
     toggle_log_path,
 )
 from transclip.settings import Settings
+
+from tests.service_helpers import FakeRuntime
 
 
 class DaemonTests(unittest.TestCase):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from tests.service_helpers import FakeRuntime
 from transclip.doctor import (
     Check,
     check_asr_runtime,
@@ -19,6 +18,8 @@ from transclip.doctor import (
 from transclip.gnome_shortcut import GnomeShortcutStatus
 from transclip.models import hf_cache_dir
 from transclip.settings import Settings
+
+from tests.service_helpers import FakeRuntime
 
 
 class DoctorTests(unittest.TestCase):
@@ -39,12 +40,18 @@ class DoctorTests(unittest.TestCase):
             self.assertFalse(check_model_cache(settings).ok)
             (Path(tmp) / "models--local--asr").mkdir()
             (Path(tmp) / "models--local--cleanup").mkdir()
+            (Path(tmp) / "models--Qwen--Qwen3.5-4B").mkdir()
             self.assertTrue(check_model_cache(settings).ok)
 
-    def test_model_cache_skips_rule_cleanup_model(self):
+    def test_model_cache_skips_rule_cleanup_model_but_checks_text_model(self):
         with tempfile.TemporaryDirectory() as tmp:
             settings = Settings(asr_model="local/asr", cleanup_runtime="rule", model_cache_dir=tmp)
             (Path(tmp) / "models--local--asr").mkdir()
+            check = check_model_cache(settings)
+            self.assertFalse(check.ok)
+            self.assertIn("Qwen/Qwen3.5-4B", check.detail)
+            self.assertIn("transclip models prefetch --model Qwen/Qwen3.5-4B", check.detail)
+            (Path(tmp) / "models--Qwen--Qwen3.5-4B").mkdir()
             self.assertTrue(check_model_cache(settings).ok)
 
     def test_nar_asr_runtime_checks_flash_attn(self):

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -99,5 +99,6 @@ class EvalHarnessTests(unittest.TestCase):
         self.assertEqual(result["summary"]["paste_successes"], 1)
         self.assertEqual(result["summary"]["paste_failures"], 0)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gnome_shortcut.py
+++ b/tests/test_gnome_shortcut.py
@@ -1,7 +1,6 @@
 import subprocess
 import unittest
 
-from tests.service_helpers import FakeRuntime
 from transclip.gnome_shortcut import (
     GNOME_CUSTOM_KEYBINDINGS_KEY,
     GNOME_MEDIA_KEYS_SCHEMA,
@@ -19,6 +18,8 @@ from transclip.product import (
     SHORTCUT_ALT_NAME,
     SHORTCUT_ALT_PATH,
 )
+
+from tests.service_helpers import FakeRuntime
 
 
 class FakeGSettings:
@@ -73,7 +74,8 @@ class GnomeShortcutTests(unittest.TestCase):
     def test_installer_removes_legacy_granite_shortcut(self):
         fake = FakeGSettings()
         fake.values[(GNOME_MEDIA_KEYS_SCHEMA, GNOME_CUSTOM_KEYBINDINGS_KEY)] = (
-            "['/custom/keep/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/granite-speach-toggle/']"
+            "['/custom/keep/', "
+            "'/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/granite-speach-toggle/']"
         )
         legacy_schema = (
             "org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:"
@@ -95,7 +97,7 @@ class GnomeShortcutTests(unittest.TestCase):
     def test_command_exists_checks_shell_wrapper_payload(self):
         self.assertFalse(
             command_exists(
-                "/bin/sh -lc 'mkdir -p \"$HOME/.cache/transclip\"; "
+                '/bin/sh -lc \'mkdir -p "$HOME/.cache/transclip"; '
                 "/definitely/missing/python -m transclip.cli toggle-record --paste'"
             )
         )

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -49,6 +49,27 @@ class HistoryTests(unittest.TestCase):
             self.assertEqual(event["duration_ms"], 123.4)
             self.assertEqual(event["asr_backend"], "fake")
 
+    def test_append_transcript_history_includes_voice_and_shell_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "history.jsonl"
+            append_transcript_history(
+                {
+                    "text": "ls -la",
+                    "raw_asr": "shell command list files",
+                    "voice_mode": "shell",
+                    "voice_trigger": "shell command",
+                    "shell": {"command": "ls -la", "valid": True},
+                },
+                Settings(),
+                source="/record/toggle",
+                path=path,
+            )
+
+            event = read_history(path=path)[0]
+            self.assertEqual(event["voice_mode"], "shell")
+            self.assertEqual(event["voice_trigger"], "shell command")
+            self.assertEqual(event["shell"]["command"], "ls -la")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mode_routing.py
+++ b/tests/test_mode_routing.py
@@ -1,0 +1,66 @@
+import unittest
+
+from transclip.mode_routing import route_voice_mode
+
+
+class ModeRoutingTests(unittest.TestCase):
+    def test_case_insensitive_cleanup_and_shell_prefixes(self):
+        cleanup = route_voice_mode("Clean up hello world")
+        shell = route_voice_mode("Shell command, list files")
+
+        self.assertEqual(cleanup.mode, "cleanup")
+        self.assertEqual(cleanup.trigger, "clean up")
+        self.assertEqual(cleanup.payload, "hello world")
+        self.assertEqual(shell.mode, "shell")
+        self.assertEqual(shell.trigger, "shell command")
+        self.assertEqual(shell.payload, "list files")
+
+    def test_all_configured_triggers_match_at_prefix(self):
+        self.assertEqual(route_voice_mode("trans cleanup fix spacing").mode, "cleanup")
+        self.assertEqual(route_voice_mode("bash command show disk usage").mode, "shell")
+        self.assertEqual(route_voice_mode("terminal command list ports").mode, "shell")
+
+    def test_prefix_only_behavior(self):
+        route = route_voice_mode("please run a shell command list files")
+
+        self.assertEqual(route.mode, "dictation")
+        self.assertEqual(route.payload, "please run a shell command list files")
+
+    def test_literal_escape_preserves_configured_trigger_text(self):
+        shell = route_voice_mode("literal shell command, list files")
+        cleanup = route_voice_mode("literal clean up this sentence")
+        trans_cleanup = route_voice_mode("literal trans cleanup this sentence")
+        bash = route_voice_mode("literal bash command show branch")
+        terminal = route_voice_mode("literal terminal command list ports")
+
+        self.assertEqual(shell.mode, "dictation")
+        self.assertTrue(shell.literal)
+        self.assertEqual(shell.payload, "shell command, list files")
+        self.assertEqual(cleanup.payload, "clean up this sentence")
+        self.assertEqual(trans_cleanup.payload, "trans cleanup this sentence")
+        self.assertEqual(bash.payload, "bash command show branch")
+        self.assertEqual(terminal.payload, "terminal command list ports")
+
+    def test_empty_trigger_payload_falls_back_to_dictation(self):
+        cleanup = route_voice_mode("clean up")
+        shell = route_voice_mode("bash command,")
+
+        self.assertEqual(cleanup.mode, "dictation")
+        self.assertEqual(cleanup.payload, "clean up")
+        self.assertEqual(shell.mode, "dictation")
+        self.assertEqual(shell.payload, "bash command,")
+
+    def test_original_payload_preservation(self):
+        route = route_voice_mode("Clean up   keep /tmp/MyFile --flag")
+
+        self.assertEqual(route.payload, "keep /tmp/MyFile --flag")
+
+    def test_disabled_shell_trigger_falls_back_to_dictation(self):
+        route = route_voice_mode("shell command list files", shell_enabled=False)
+
+        self.assertEqual(route.mode, "dictation")
+        self.assertEqual(route.payload, "shell command list files")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,4 @@
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -5,10 +6,12 @@ from unittest.mock import patch
 
 from transclip.models import (
     SUPPORTED_MODELS,
+    SUPPORTED_TEXT_MODELS,
     cache_artifacts_present,
     ensure_disk_space,
     model_rows,
     normalize_asr_backend,
+    prefetch_model,
     required_model_cache_paths,
     validate_asr_model_backend,
 )
@@ -21,6 +24,8 @@ class ModelsTests(unittest.TestCase):
 
         self.assertIn(("granite_nar", "ibm-granite/granite-speech-4.1-2b-nar"), rows)
         self.assertIn(("granite", "ibm-granite/granite-speech-4.1-2b"), rows)
+        text_rows = {(model.backend, model.model_id) for model in SUPPORTED_TEXT_MODELS}
+        self.assertIn(("text_generation", "Qwen/Qwen3.5-4B"), text_rows)
 
     def test_model_catalog_owns_asr_backend_compatibility(self):
         self.assertEqual(normalize_asr_backend("nar"), "granite_nar")
@@ -45,8 +50,10 @@ class ModelsTests(unittest.TestCase):
 
             self.assertTrue(cache_artifacts_present(settings.asr_model, settings))
             current = next(row for row in model_rows(settings) if row["model_id"] == settings.asr_model)
+            text = next(row for row in model_rows(settings) if row["model_id"] == settings.text_model)
             self.assertEqual(current["marker"], "current,default")
             self.assertTrue(current["cached"])
+            self.assertEqual(text["marker"], "current-text,default-text")
 
     def test_required_model_cache_paths_include_cleanup_transformers(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -62,8 +69,40 @@ class ModelsTests(unittest.TestCase):
                 [
                     Path(tmp) / "models--local--asr",
                     Path(tmp) / "models--local--cleanup",
+                    Path(tmp) / "models--Qwen--Qwen3.5-4B",
                 ],
             )
+
+    def test_prefetch_text_model_uses_image_text_to_text_contract(self):
+        calls = []
+
+        class AutoModelForImageTextToText:
+            @staticmethod
+            def from_pretrained(*args, **kwargs):
+                calls.append(("model", args, kwargs))
+
+        class AutoProcessor:
+            @staticmethod
+            def from_pretrained(*args, **kwargs):
+                calls.append(("processor", args, kwargs))
+
+        transformers = type(
+            "TransformersModule",
+            (),
+            {
+                "AutoModelForImageTextToText": AutoModelForImageTextToText,
+                "AutoProcessor": AutoProcessor,
+            },
+        )()
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch.dict(sys.modules, {"transformers": transformers}),
+            patch("transclip.models.ensure_disk_space"),
+        ):
+            path = prefetch_model("Qwen/Qwen3.5-4B", Settings(model_cache_dir=tmp))
+
+        self.assertEqual(path, Path(tmp) / "models--Qwen--Qwen3.5-4B")
+        self.assertEqual([call[0] for call in calls], ["model", "processor"])
 
     def test_disk_space_failure_uses_catalog_estimate(self):
         usage = type("Usage", (), {"free": 1})()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,14 +1,16 @@
 import base64
+import json
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from tests.service_helpers import FakeASR, FakeRecorder, http_json, serve_test_engine, stop_server
 from transclip.cleanup import FaithfulRuleCleanupBackend
 from transclip.history import read_history
 from transclip.service import InferenceEngine
 from transclip.settings import Settings
+
+from tests.service_helpers import FakeASR, FakeRecorder, FakeTextBackend, http_json, serve_test_engine, stop_server
 
 
 class ServiceTests(unittest.TestCase):
@@ -264,6 +266,174 @@ class ServiceTests(unittest.TestCase):
         self.assertEqual(ignored["action"], "ignored")
         self.assertEqual(ignored["reason"], "toggle_cooldown")
         self.assertEqual(ignored["cooldown_ms"], 500)
+
+    def test_normal_dictation_remains_rule_cleanup_by_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            wav = Path(tmp) / "audio.wav"
+            wav.write_bytes(b"not really wav")
+            text_backend = FakeTextBackend(["model cleanup"])
+            engine = InferenceEngine(
+                Settings(cleanup_runtime="test_rule", voice_model_cleanup_always_on=False),
+                asr_backend=FakeASR("hello ,world"),
+                cleanup_backend=FaithfulRuleCleanupBackend(),
+                text_backend=text_backend,
+            )
+
+            result = engine.transcribe(wav)
+
+            self.assertEqual(result["text"], "Hello, world.")
+            self.assertEqual(text_backend.messages, [])
+            self.assertEqual(result["voice_mode"], "dictation")
+
+    def test_normal_dictation_does_not_call_text_model(self):
+        class ExplodingTextBackend:
+            name = "exploding-text"
+            model_name = "should-not-load"
+
+            def generate(self, messages, *, max_new_tokens):
+                raise AssertionError("normal dictation should not call the text model")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            wav = Path(tmp) / "audio.wav"
+            wav.write_bytes(b"not really wav")
+            engine = InferenceEngine(
+                Settings(cleanup_runtime="test_rule", voice_model_cleanup_always_on=False),
+                asr_backend=FakeASR("hello ,world"),
+                cleanup_backend=FaithfulRuleCleanupBackend(),
+                text_backend=ExplodingTextBackend(),
+            )
+
+            result = engine.transcribe(wav)
+
+            self.assertEqual(result["text"], "Hello, world.")
+            self.assertEqual(result["voice_mode"], "dictation")
+            self.assertIsNone(result["shell"])
+
+    def test_explicit_cleanup_trigger_uses_model_cleanup_not_heuristic(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            wav = Path(tmp) / "audio.wav"
+            wav.write_bytes(b"not really wav")
+            text_backend = FakeTextBackend(["Model-cleaned text"])
+            engine = InferenceEngine(
+                Settings(cleanup_runtime="test_rule"),
+                asr_backend=FakeASR("clean up hello ,world"),
+                cleanup_backend=FaithfulRuleCleanupBackend(),
+                text_backend=text_backend,
+            )
+
+            result = engine.transcribe(wav)
+
+            self.assertEqual(result["text"], "Model-cleaned text")
+            self.assertEqual(result["voice_mode"], "cleanup")
+            self.assertEqual(result["voice_trigger"], "clean up")
+            self.assertNotIn("clean up", text_backend.messages[0][1]["content"])
+            self.assertIn("hello ,world", text_backend.messages[0][1]["content"])
+
+    def test_always_on_model_cleanup_applies_to_normal_dictation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            wav = Path(tmp) / "audio.wav"
+            wav.write_bytes(b"not really wav")
+            text_backend = FakeTextBackend(["Model cleaned normal dictation"])
+            engine = InferenceEngine(
+                Settings(cleanup_runtime="test_rule", voice_model_cleanup_always_on=True),
+                asr_backend=FakeASR("hello ,world"),
+                cleanup_backend=FaithfulRuleCleanupBackend(),
+                text_backend=text_backend,
+            )
+
+            result = engine.transcribe(wav)
+
+            self.assertEqual(result["text"], "Model cleaned normal dictation")
+            self.assertEqual(result["voice_mode"], "dictation")
+            self.assertEqual(len(text_backend.messages), 1)
+
+    def test_literal_escape_pastes_trigger_text_without_cleanup(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            wav = Path(tmp) / "audio.wav"
+            wav.write_bytes(b"not really wav")
+            engine = InferenceEngine(
+                Settings(cleanup_runtime="test_rule"),
+                asr_backend=FakeASR("literal shell command list files"),
+                cleanup_backend=FaithfulRuleCleanupBackend(),
+                text_backend=FakeTextBackend(["unused"]),
+            )
+
+            result = engine.transcribe(wav)
+
+            self.assertEqual(result["text"], "shell command list files")
+            self.assertTrue(result["voice_literal"])
+            self.assertIsNone(result["cleanup"])
+
+    def test_shell_trigger_returns_command_text_without_submit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            wav = Path(tmp) / "audio.wav"
+            wav.write_bytes(b"not really wav")
+            engine = InferenceEngine(
+                Settings(cleanup_runtime="test_rule", shellcheck_enabled=False),
+                asr_backend=FakeASR("shell command list files"),
+                cleanup_backend=FaithfulRuleCleanupBackend(),
+                text_backend=FakeTextBackend(['{"command": "ls -la\\n"}']),
+            )
+
+            result = engine.transcribe(wav)
+
+            self.assertEqual(result["text"], "ls -la")
+            self.assertFalse(result["text"].endswith("\n"))
+            self.assertEqual(result["voice_mode"], "shell")
+            self.assertIs(result["submit"], False)
+            self.assertEqual(result["shell"]["command"], "ls -la")
+            self.assertTrue(result["shell"]["valid"])
+
+    def test_shell_trigger_returns_diagnostic_when_text_model_fails(self):
+        class FailingTextBackend:
+            name = "failing-text"
+            model_name = "missing-model"
+
+            def generate(self, messages, *, max_new_tokens):
+                raise RuntimeError("text model unavailable")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            wav = Path(tmp) / "audio.wav"
+            wav.write_bytes(b"not really wav")
+            engine = InferenceEngine(
+                Settings(cleanup_runtime="test_rule", shellcheck_enabled=False),
+                asr_backend=FakeASR("shell command list files"),
+                cleanup_backend=FaithfulRuleCleanupBackend(),
+                text_backend=FailingTextBackend(),
+            )
+
+            result = engine.transcribe(wav)
+
+            self.assertEqual(result["voice_mode"], "shell")
+            self.assertIs(result["submit"], False)
+            self.assertFalse(result["shell"]["valid"])
+            self.assertEqual(result["shell"]["command"], "")
+            self.assertIn("model generation failed", result["shell"]["diagnostics"][0])
+            self.assertTrue(result["text"].startswith("# TransClip could not produce valid Bash"))
+
+    def test_debug_capture_writes_voice_and_shell_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            wav = Path(tmp) / "audio.wav"
+            wav.write_bytes(b"not really wav")
+            engine = InferenceEngine(
+                Settings(
+                    cleanup_runtime="test_rule",
+                    shellcheck_enabled=False,
+                    debug_capture=True,
+                    debug_capture_dir=str(Path(tmp) / "captures"),
+                ),
+                asr_backend=FakeASR("shell command list files"),
+                cleanup_backend=FaithfulRuleCleanupBackend(),
+                text_backend=FakeTextBackend(['{"command": "ls -la"}']),
+            )
+
+            result = engine.transcribe(wav)
+
+            metadata_path = Path(result["debug_capture_dir"]) / "metadata.json"
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            self.assertEqual(metadata["voice_mode"], "shell")
+            self.assertEqual(metadata["voice_trigger"], "shell command")
+            self.assertEqual(metadata["shell"]["command"], "ls -la")
 
 
 if __name__ == "__main__":

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -27,6 +27,13 @@ class SettingsTests(unittest.TestCase):
             self.assertEqual(settings.asr_model, "ibm-granite/granite-speech-4.1-2b-nar")
             self.assertEqual(settings.cleanup_runtime, "rule")
             self.assertEqual(settings.cleanup_model, "google/gemma-4-E2B-it")
+            self.assertTrue(settings.voice_mode_routing_enabled)
+            self.assertFalse(settings.voice_model_cleanup_always_on)
+            self.assertTrue(settings.voice_mode_shell_enabled)
+            self.assertEqual(settings.text_model_runtime, "transformers")
+            self.assertEqual(settings.text_model, "Qwen/Qwen3.5-4B")
+            self.assertTrue(settings.shell_syntax_validation_enabled)
+            self.assertTrue(settings.shellcheck_enabled)
             self.assertTrue(settings.models_local_files_only)
             self.assertEqual(settings.model_cache_dir, "")
 
@@ -55,6 +62,7 @@ class SettingsTests(unittest.TestCase):
 
     def test_setting_type_coercion_and_unknown_field(self):
         self.assertIs(coerce_setting_value("cleanup_enabled", "false"), False)
+        self.assertIs(coerce_setting_value("voice_model_cleanup_always_on", "on"), True)
         self.assertEqual(coerce_setting_value("sample_rate", "22050"), 22050)
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "settings.toml"

--- a/tests/test_shell_command.py
+++ b/tests/test_shell_command.py
@@ -1,0 +1,222 @@
+import subprocess
+import unittest
+from unittest.mock import patch
+
+from transclip.settings import Settings
+from transclip.shell_command import (
+    ShellCommandProcessor,
+    commented_diagnostic,
+    detect_default_shell,
+    parse_shell_command,
+    shell_command_messages,
+    shell_generation_failure_reason,
+    validate_shell_command,
+)
+from transclip.text_generation import TextGenerationResult
+
+from tests.service_helpers import FakeRuntime
+
+
+class FakeTextBackend:
+    name = "fake"
+    model_name = "fake-model"
+
+    def __init__(self, response: str):
+        self.response = response
+        self.messages = []
+        self.max_new_tokens = []
+
+    def generate(self, messages, *, max_new_tokens):
+        self.messages.append(messages)
+        self.max_new_tokens.append(max_new_tokens)
+        return TextGenerationResult(self.response, {"text_generation": 1.0}, self.name, self.model_name)
+
+
+class FailingTextBackend:
+    name = "failing"
+    model_name = "missing-model"
+
+    def generate(self, messages, *, max_new_tokens):
+        raise RuntimeError("transformers dependencies missing")
+
+
+class ShellCommandTests(unittest.TestCase):
+    def test_structured_response_parsing(self):
+        self.assertEqual(parse_shell_command('{"command": "ls -la"}'), "ls -la")
+
+    def test_empty_structured_command_is_rejected(self):
+        self.assertEqual(parse_shell_command('{"command": ""}'), "")
+
+    def test_prose_and_fence_stripping(self):
+        self.assertEqual(parse_shell_command("```bash\nls -la\n```"), "ls -la")
+        self.assertEqual(parse_shell_command("Command: pwd"), "pwd")
+
+    def test_bash_syntax_validation_passes(self):
+        runtime = FakeRuntime(available={"bash": "/usr/bin/bash"}, run_func=lambda _command, **_kwargs: completed(0))
+
+        result = validate_shell_command("ls -la", Settings(), runtime=runtime)
+
+        self.assertTrue(result.ok)
+        self.assertEqual(runtime.run_calls, [["/usr/bin/bash", "-n", "-c", "ls -la"]])
+
+    def test_bash_syntax_validation_fails(self):
+        runtime = FakeRuntime(
+            available={"bash": "/usr/bin/bash"},
+            run_func=lambda _command, **_kwargs: completed(2, stderr="bash: syntax error near unexpected token `fi'\n"),
+        )
+
+        result = validate_shell_command("if true; then echo hi; fi fi", Settings(), runtime=runtime)
+
+        self.assertFalse(result.ok)
+        self.assertIn("syntax error", result.diagnostics[0])
+
+    def test_shellcheck_syntax_errors_block_but_warnings_do_not(self):
+        results = iter(
+            [
+                completed(0),
+                completed(1, stdout="In - line 1:\necho $x\n     ^-- SC2086 (info): Double quote\n"),
+                completed(0),
+                completed(1, stdout="In - line 1:\nif then\n^-- SC1073 (error): Couldn't parse\n"),
+            ]
+        )
+        runtime = FakeRuntime(
+            available={"bash": "/usr/bin/bash", "shellcheck": "/usr/bin/shellcheck"},
+            run_func=lambda _command, **_kwargs: next(results),
+        )
+
+        warning = validate_shell_command("echo $x", Settings(), runtime=runtime)
+        syntax_error = validate_shell_command("if then", Settings(), runtime=runtime)
+
+        self.assertTrue(warning.ok)
+        self.assertFalse(syntax_error.ok)
+        self.assertIn("SC1073", syntax_error.diagnostics[0])
+
+    def test_bash_syntax_validation_timeout_blocks_command(self):
+        runtime = FakeRuntime(
+            available={"bash": "/usr/bin/bash"},
+            run_func=lambda _command, **_kwargs: raise_timeout(["bash"]),
+        )
+
+        result = validate_shell_command("ls -la", Settings(), runtime=runtime)
+
+        self.assertFalse(result.ok)
+        self.assertIn("timed out", result.diagnostics[0])
+        self.assertTrue(result.metadata["bash_timeout"])
+
+    def test_shellcheck_timeout_does_not_block_after_bash_passes(self):
+        results = iter([completed(0), subprocess.TimeoutExpired(["shellcheck"], 2.0)])
+
+        def run(_command, **_kwargs):
+            result = next(results)
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        runtime = FakeRuntime(available={"bash": "/usr/bin/bash", "shellcheck": "/usr/bin/shellcheck"}, run_func=run)
+
+        result = validate_shell_command("ls -la", Settings(), runtime=runtime)
+
+        self.assertTrue(result.ok)
+        self.assertTrue(result.metadata["shellcheck_timeout"])
+
+    @patch("transclip.shell_command.validate_shell_command")
+    def test_processor_renders_command_only_and_no_submit_newline(self, validate):
+        validate.return_value = type("Validation", (), {"ok": True, "diagnostics": [], "metadata": {"bash": True}})()
+        processor = ShellCommandProcessor(Settings(), FakeTextBackend('{"command": "ls -la\\n"}'))
+
+        result = processor.generate("list files")
+
+        self.assertEqual(result.text, "ls -la")
+        self.assertFalse(result.text.endswith("\n"))
+        self.assertTrue(result.valid)
+
+    @patch("transclip.shell_command.validate_shell_command")
+    def test_processor_uses_small_shell_generation_budget(self, validate):
+        validate.return_value = type("Validation", (), {"ok": True, "diagnostics": [], "metadata": {}})()
+        backend = FakeTextBackend('{"command": "pwd"}')
+        processor = ShellCommandProcessor(Settings(), backend)
+
+        processor.generate("print current directory")
+
+        self.assertEqual(backend.max_new_tokens, [64])
+
+    @patch("transclip.shell_command.validate_shell_command")
+    def test_invalid_command_renders_commented_diagnostic(self, validate):
+        validate.return_value = type(
+            "Validation",
+            (),
+            {"ok": False, "diagnostics": ["syntax error"], "metadata": {"bash_returncode": 2}},
+        )()
+        processor = ShellCommandProcessor(Settings(), FakeTextBackend('{"command": "if then"}'))
+
+        result = processor.generate("bad command")
+
+        self.assertFalse(result.valid)
+        self.assertEqual(result.command, "if then")
+        self.assertTrue(result.text.startswith("# TransClip could not produce valid Bash: syntax error"))
+
+    def test_processor_renders_diagnostic_when_model_generation_fails(self):
+        processor = ShellCommandProcessor(Settings(), FailingTextBackend())
+
+        result = processor.generate("list files")
+
+        self.assertFalse(result.valid)
+        self.assertEqual(result.command, "")
+        self.assertEqual(result.backend, "failing")
+        self.assertEqual(result.model, "missing-model")
+        self.assertIn("model generation failed", result.diagnostics[0])
+        self.assertTrue(result.text.startswith("# TransClip could not produce valid Bash: model generation failed"))
+
+    def test_huggingface_cache_failure_is_short_and_actionable(self):
+        reason = shell_generation_failure_reason(
+            RuntimeError(
+                "We couldn't connect to 'https://huggingface.co' to load the files, "
+                "and couldn't find them in the cached files. Check your internet connection "
+                "or see how to run the library in offline mode at "
+                "'https://huggingface.co/docs/transformers/installation#offline-mode'."
+            ),
+            FakeTextBackend("{}"),
+        )
+
+        self.assertIn("fake-model is not available in the local Hugging Face cache", reason)
+        self.assertIn("uv run -m transclip.cli models prefetch --model fake-model", reason)
+        self.assertNotIn("https://huggingface.co", reason)
+
+    def test_prompt_requests_json_command_only(self):
+        messages = shell_command_messages("list files", default_shell_path="/usr/bin/zsh")
+
+        self.assertIn("Return JSON only", messages[0]["content"])
+        self.assertIn('"command"', messages[0]["content"])
+        self.assertIn("zsh (/usr/bin/zsh)", messages[0]["content"])
+        self.assertIn("Bash-compatible", messages[0]["content"])
+        self.assertEqual(messages[1]["content"], "list files")
+
+    @patch.dict("os.environ", {"SHELL": "/bin/fish"}, clear=True)
+    def test_detect_default_shell_prefers_environment_shell(self):
+        self.assertEqual(detect_default_shell(), "/bin/fish")
+
+    @patch("transclip.shell_command.validate_shell_command")
+    @patch.dict("os.environ", {"SHELL": "/usr/bin/zsh"}, clear=True)
+    def test_processor_prompt_includes_default_shell(self, validate):
+        validate.return_value = type("Validation", (), {"ok": True, "diagnostics": [], "metadata": {}})()
+        backend = FakeTextBackend('{"command": "ls -la"}')
+        processor = ShellCommandProcessor(Settings(), backend)
+
+        processor.generate("list files")
+
+        self.assertIn("zsh (/usr/bin/zsh)", backend.messages[0][0]["content"])
+
+    def test_commented_diagnostic_comments_every_line(self):
+        self.assertEqual(commented_diagnostic("first\nsecond"), "# first\n# second")
+
+
+def completed(returncode: int, stdout: str = "", stderr: str = ""):
+    return type("Completed", (), {"returncode": returncode, "stdout": stdout, "stderr": stderr})()
+
+
+def raise_timeout(command: list[str]):
+    raise subprocess.TimeoutExpired(command, 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_text_generation.py
+++ b/tests/test_text_generation.py
@@ -1,0 +1,129 @@
+import sys
+import threading
+import time
+import unittest
+from unittest.mock import patch
+
+from transclip.text_generation import TransformersTextGenerationBackend
+
+
+class TextGenerationTests(unittest.TestCase):
+    def test_transformers_backend_serializes_lazy_load_and_generation(self):
+        state = FakeTransformersState()
+        backend = TransformersTextGenerationBackend("local/text-model")
+
+        with (
+            patch.dict(
+                sys.modules,
+                {
+                    "transformers": state.transformers_module(),
+                    "torch": FakeTorch(),
+                },
+            ),
+            patch("transclip.text_generation.resolve_torch_device", return_value="cpu"),
+        ):
+            threads = [
+                threading.Thread(
+                    target=backend.generate,
+                    args=([{"role": "user", "content": "task"}],),
+                    kwargs={"max_new_tokens": 8},
+                )
+                for _ in range(4)
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+        self.assertEqual(state.tokenizer_loads, 1)
+        self.assertEqual(state.model_loads, 1)
+        self.assertEqual(state.model.max_active_generations, 1)
+
+
+class FakeTransformersState:
+    def __init__(self):
+        self.tokenizer_loads = 0
+        self.model_loads = 0
+        self.tokenizer = FakeTokenizer()
+        self.model = FakeModel()
+
+    def transformers_module(self):
+        state = self
+
+        class AutoTokenizer:
+            @staticmethod
+            def from_pretrained(*_args, **_kwargs):
+                state.tokenizer_loads += 1
+                time.sleep(0.01)
+                return state.tokenizer
+
+        class AutoModelForCausalLM:
+            @staticmethod
+            def from_pretrained(*_args, **_kwargs):
+                state.model_loads += 1
+                time.sleep(0.01)
+                return state.model
+
+        return type(
+            "TransformersModule",
+            (),
+            {
+                "AutoProcessor": AutoTokenizer,
+                "AutoModelForImageTextToText": AutoModelForCausalLM,
+            },
+        )()
+
+
+class FakeTokenizer:
+    eos_token_id = 1
+
+    def apply_chat_template(self, *_args, **_kwargs):
+        return FakeInputs()
+
+    def decode(self, *_args, **_kwargs):
+        return "generated"
+
+
+class FakeInputs(dict):
+    def __init__(self):
+        super().__init__({"input_ids": type("InputIds", (), {"shape": (1, 3)})()})
+
+    def to(self, _device):
+        return self
+
+
+class FakeModel:
+    device = "cpu"
+
+    def __init__(self):
+        self.generation_config = type("GenerationConfig", (), {})()
+        self.active_generations = 0
+        self.max_active_generations = 0
+        self.lock = threading.Lock()
+
+    def eval(self):
+        return None
+
+    def generate(self, **_kwargs):
+        with self.lock:
+            self.active_generations += 1
+            self.max_active_generations = max(self.max_active_generations, self.active_generations)
+        time.sleep(0.01)
+        with self.lock:
+            self.active_generations -= 1
+        return [[0, 1, 2, 3]]
+
+
+class FakeTorch:
+    def inference_mode(self):
+        return self
+
+    def __enter__(self):
+        return None
+
+    def __exit__(self, *_args):
+        return False
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tray.py
+++ b/tests/test_tray.py
@@ -292,6 +292,30 @@ class TrayTests(unittest.TestCase):
                 self.assertIn("ASR model set", indicator.menus[0].children[0].child.text)
                 self.assertEqual(regular_item.child.text, "✓ Keyword-biased ASR - Granite 4.1")
 
+    def test_model_cleanup_toggle_label_persists_and_restarts_service(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            settings_file = Path(tmp) / "settings.toml"
+            settings = Settings(voice_model_cleanup_always_on=False)
+            write_settings(settings, settings_file)
+            with (
+                patch.dict(sys.modules, self.modules),
+                patch("transclip.tray.InferenceClient", FakeClient),
+                patch("transclip.tray.read_history", return_value=[]),
+                patch("transclip.tray.service_action") as service_action,
+            ):
+                service_action.return_value = types.SimpleNamespace(detail="restarted")
+                code = run_python_tray(settings, explicit_settings_path=settings_file)
+                indicator = FakeIndicatorFactory.current
+                cleanup_item = menu_item_by_label(indicator, "Model cleanup always on")
+                cleanup_item.handlers["activate"](cleanup_item)
+
+                self.assertEqual(code, 0)
+                self.assertTrue(settings.voice_model_cleanup_always_on)
+                self.assertTrue(load_settings(settings_file).voice_model_cleanup_always_on)
+                service_action.assert_called_once_with("restart")
+                self.assertEqual(cleanup_item.child.text, "✓ Model cleanup always on")
+                self.assertIn("Model cleanup always on", indicator.menus[0].children[0].child.text)
+
     def test_set_hotkey_preserves_other_current_settings(self):
         FakeDialog.next_response = 1
         FakeDialog.next_text = "<Control><Alt>space"

--- a/transclip/asr.py
+++ b/transclip/asr.py
@@ -71,9 +71,7 @@ class GraniteSpeechTransformersBackend:
             import torch
             from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor
         except ImportError as exc:
-            raise RuntimeError(
-                "transformers, torch, and torchaudio are required. Install transclip[models]."
-            ) from exc
+            raise RuntimeError("transformers, torch, and torchaudio are required. Install transclip[models].") from exc
 
         dtype = torch.bfloat16 if device == "cuda" else torch.float32
         processor = AutoProcessor.from_pretrained(
@@ -153,9 +151,7 @@ class GraniteSpeechNarTransformersBackend:
             import torch
             from transformers import AutoFeatureExtractor, AutoModel
         except ImportError as exc:
-            raise RuntimeError(
-                "transformers, torch, and torchaudio are required. Install transclip[models]."
-            ) from exc
+            raise RuntimeError("transformers, torch, and torchaudio are required. Install transclip[models].") from exc
 
         dtype = _granite_nar_dtype(torch, device)
         _configure_rocm_nar_attention_env(os, torch, device)

--- a/transclip/audio.py
+++ b/transclip/audio.py
@@ -100,7 +100,7 @@ def sounddevice_summary() -> str:
         return "sounddevice unavailable"
     try:
         default = getattr(sd.default, "device", None)
-        input_device = default[0] if isinstance(default, tuple | list) else default
+        input_device = _default_input_device(default)
         if input_device in {None, -1}:
             return f"default input={input_device}"
         info = sd.query_devices(input_device, "input")
@@ -108,6 +108,14 @@ def sounddevice_summary() -> str:
         return f"default input={input_device} {name}"
     except Exception as exc:
         return f"sounddevice query failed: {exc}"
+
+
+def _default_input_device(default: object) -> object:
+    if isinstance(default, tuple):
+        return default[0] if default else None
+    if isinstance(default, list):
+        return default[0] if default else None
+    return default
 
 
 def write_wav(path: Path, pcm16_mono: bytes, sample_rate: int) -> Path:

--- a/transclip/cleanup.py
+++ b/transclip/cleanup.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 from .device import resolve_torch_device
 from .settings import Settings
+from .text_generation import TextGenerationBackend
 from .timing import timed_ms
 
 
@@ -30,6 +31,57 @@ class FaithfulRuleCleanupBackend(CleanupBackend):
         with timed_ms(timings, "cleanup"):
             cleaned = conservative_cleanup(text)
         return CleanupResult(cleaned, timings, self.name)
+
+
+@dataclass(frozen=True, slots=True)
+class ModelCleanupPolicy:
+    max_context_tokens: int = 512
+    min_context_tokens: int = 64
+    tokens_per_word: int = 3
+
+    def token_budget(self, text: str) -> int:
+        return max(self.min_context_tokens, min(self.max_context_tokens, len(text.split()) * self.tokens_per_word))
+
+    def messages(self, text: str) -> list[dict[str, str]]:
+        return [
+            {
+                "role": "system",
+                "content": (
+                    "Clean this ASR transcript faithfully. Preserve meaning. Correct punctuation, "
+                    "capitalization, and paragraphing. Remove filler only when it is clearly filler. "
+                    "Preserve technical terms, flags, identifiers, paths, and code-like text. "
+                    "Do not add facts. Output only the cleaned transcript."
+                ),
+            },
+            {
+                "role": "user",
+                "content": f"Transcript:\n{text}",
+            },
+        ]
+
+    def validate_output(self, cleaned: str, provider: str) -> str:
+        cleaned = cleaned.strip()
+        if not cleaned:
+            raise RuntimeError(f"{provider} cleanup produced an empty response")
+        return cleaned
+
+
+class ModelCleanupProcessor:
+    def __init__(self, text_backend: TextGenerationBackend):
+        self.text_backend = text_backend
+        self.policy = ModelCleanupPolicy()
+
+    def cleanup(self, text: str) -> CleanupResult:
+        result = self.text_backend.generate(
+            self.policy.messages(text),
+            max_new_tokens=self.policy.token_budget(text),
+        )
+        cleaned = self.policy.validate_output(result.text, result.backend)
+        return CleanupResult(
+            cleaned,
+            dict(result.timings_ms),
+            f"{result.backend}:{result.model}",
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -117,9 +169,7 @@ class GemmaTransformersCleanupBackend(CleanupBackend):
         try:
             from transformers import AutoModelForCausalLM, AutoProcessor
         except ImportError as exc:
-            raise RuntimeError(
-                "transformers, torch, and accelerate are required. Install transclip[models]."
-            ) from exc
+            raise RuntimeError("transformers, torch, and accelerate are required. Install transclip[models].") from exc
         processor = AutoProcessor.from_pretrained(
             self.model_name,
             local_files_only=self.local_files_only,
@@ -183,6 +233,10 @@ def build_cleanup_backend(settings: Settings) -> CleanupBackend:
 
 def faithful_cleanup_messages(text: str) -> list[dict[str, str]]:
     return FaithfulCleanupPolicy().messages(text)
+
+
+def model_cleanup_messages(text: str) -> list[dict[str, str]]:
+    return ModelCleanupPolicy().messages(text)
 
 
 def conservative_cleanup(text: str) -> str:

--- a/transclip/debug_capture.py
+++ b/transclip/debug_capture.py
@@ -22,6 +22,7 @@ class DebugCapture:
         cleaned: str,
         timings: dict[str, float],
         model_versions: dict[str, str],
+        metadata: dict[str, Any] | None = None,
     ) -> Path | None:
         if not self.settings.debug_capture:
             return None
@@ -35,6 +36,8 @@ class DebugCapture:
             json.dumps(_jsonable(model_versions), indent=2),
             encoding="utf-8",
         )
+        if metadata:
+            (root / "metadata.json").write_text(json.dumps(_jsonable(metadata), indent=2), encoding="utf-8")
         return root
 
     def write_error(

--- a/transclip/doctor.py
+++ b/transclip/doctor.py
@@ -11,7 +11,7 @@ from .client import InferenceClient
 from .daemon import last_toggle_log_event, service_state, toggle_log_path
 from .device import torch_cuda_usable, torch_mps_available
 from .gnome_shortcut import shortcut_readiness
-from .models import model_cache_root, required_model_cache_paths
+from .models import model_cache_path, model_cache_root, required_model_cache_paths
 from .paste import clipboard_capability, paste_capability
 from .platform_capabilities import session_info
 from .platform_runtime import PlatformRuntime, get_runtime
@@ -198,13 +198,32 @@ def check_model_cache(settings: Settings) -> Check:
     missing = [str(path) for path in required_paths if not path.exists()]
     if not missing:
         return Check("model_cache", True, f"found model artifacts under {cache_root}")
+    commands = _prefetch_commands_for_missing_cache(settings)
+    remediation = "; run: " + "; ".join(commands) if commands else ""
     return Check(
         "model_cache",
         False,
-        "missing local model artifacts: "
-        + ", ".join(missing)
-        + f"; run: transclip models prefetch --model {settings.asr_model}",
+        "missing local model artifacts: " + ", ".join(missing) + remediation,
     )
+
+
+def _prefetch_commands_for_missing_cache(settings: Settings) -> list[str]:
+    model_ids = [settings.asr_model]
+    if settings.cleanup_runtime == "transformers":
+        model_ids.append(settings.cleanup_model)
+    if settings.text_model_runtime == "transformers" and (
+        settings.voice_mode_routing_enabled or settings.voice_model_cleanup_always_on
+    ):
+        model_ids.append(settings.text_model)
+
+    commands = []
+    seen = set()
+    for model_id in model_ids:
+        if model_id in seen or model_cache_path(model_id, settings).exists():
+            continue
+        seen.add(model_id)
+        commands.append(f"transclip models prefetch --model {model_id}")
+    return commands
 
 
 def check_audio_debug(settings: Settings) -> Check:

--- a/transclip/eval_harness.py
+++ b/transclip/eval_harness.py
@@ -67,15 +67,12 @@ class EvalGatePolicy:
         under_700 = int(summary.get("under_700ms", 0))
         under_700_ratio = under_700 / cases
         if under_700_ratio < self.min_under_700_ratio:
-            raise ValueError(
-                f"under-700ms ratio {under_700_ratio:.3f} is below {self.min_under_700_ratio:.3f}"
-            )
+            raise ValueError(f"under-700ms ratio {under_700_ratio:.3f} is below {self.min_under_700_ratio:.3f}")
 
         keyword_score = summary.get("mean_keyword_preservation")
         if keyword_score is not None and float(keyword_score) < self.min_keyword_preservation:
             raise ValueError(
-                f"mean keyword preservation {float(keyword_score):.3f} is below "
-                f"{self.min_keyword_preservation:.3f}"
+                f"mean keyword preservation {float(keyword_score):.3f} is below {self.min_keyword_preservation:.3f}"
             )
 
         mean_wer = summary.get("mean_wer")
@@ -85,8 +82,7 @@ class EvalGatePolicy:
         cleanup_drift_failures = int(summary.get("cleanup_semantic_drift_failures", 0))
         if cleanup_drift_failures > self.max_cleanup_drift_failures:
             raise ValueError(
-                f"cleanup semantic drift failures {cleanup_drift_failures} exceed "
-                f"{self.max_cleanup_drift_failures}"
+                f"cleanup semantic drift failures {cleanup_drift_failures} exceed {self.max_cleanup_drift_failures}"
             )
 
         paste_failures = int(summary.get("paste_failures", 0))

--- a/transclip/history.py
+++ b/transclip/history.py
@@ -51,6 +51,14 @@ def append_transcript_history(
         "cleanup_backend": result.get("cleanup_backend") or settings.cleanup_runtime,
         "cleanup_enabled": bool(result.get("cleanup_enabled", settings.cleanup_enabled)),
     }
+    if result.get("voice_mode"):
+        event["voice_mode"] = result.get("voice_mode")
+    if result.get("voice_trigger"):
+        event["voice_trigger"] = result.get("voice_trigger")
+    if result.get("voice_literal"):
+        event["voice_literal"] = bool(result.get("voice_literal"))
+    if result.get("shell"):
+        event["shell"] = result.get("shell")
     if duration_ms is None:
         duration_ms = result.get("duration_ms")
     if duration_ms is not None:

--- a/transclip/mode_routing.py
+++ b/transclip/mode_routing.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+VoiceMode = Literal["dictation", "cleanup", "shell"]
+
+CLEANUP_TRIGGERS = ("clean up", "trans cleanup")
+SHELL_TRIGGERS = ("shell command", "bash command", "terminal command")
+TRIGGERS = CLEANUP_TRIGGERS + SHELL_TRIGGERS
+LITERAL_PREFIX = "literal"
+
+
+@dataclass(frozen=True, slots=True)
+class VoiceModeRoute:
+    mode: VoiceMode
+    payload: str
+    trigger: str | None = None
+    literal: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class _TriggerMatch:
+    payload: str
+    trigger: str
+
+
+def route_voice_mode(
+    transcript: str,
+    *,
+    routing_enabled: bool = True,
+    shell_enabled: bool = True,
+) -> VoiceModeRoute:
+    if not routing_enabled:
+        return VoiceModeRoute("dictation", transcript)
+
+    literal = _match_trigger(transcript, (LITERAL_PREFIX,))
+    if literal is not None:
+        escaped = _match_trigger(literal.payload, TRIGGERS)
+        if escaped is not None and escaped.payload:
+            return VoiceModeRoute("dictation", literal.payload, escaped.trigger, literal=True)
+        return VoiceModeRoute("dictation", transcript)
+
+    cleanup = _match_trigger(transcript, CLEANUP_TRIGGERS)
+    if cleanup is not None:
+        if cleanup.payload:
+            return VoiceModeRoute("cleanup", cleanup.payload, cleanup.trigger)
+        return VoiceModeRoute("dictation", transcript)
+
+    shell = _match_trigger(transcript, SHELL_TRIGGERS)
+    if shell is not None:
+        if shell.payload and shell_enabled:
+            return VoiceModeRoute("shell", shell.payload, shell.trigger)
+        return VoiceModeRoute("dictation", transcript)
+
+    return VoiceModeRoute("dictation", transcript)
+
+
+def _match_trigger(text: str, triggers: tuple[str, ...]) -> _TriggerMatch | None:
+    stripped = text.lstrip()
+    for trigger in triggers:
+        pattern = re.compile(rf"^{re.escape(trigger)}(?:$|[\s,.:;!?-]+)", re.IGNORECASE)
+        match = pattern.match(stripped)
+        if not match:
+            continue
+        payload = stripped[match.end() :].lstrip(" \t\r\n,.:;!?-")
+        return _TriggerMatch(payload, trigger)
+    return None

--- a/transclip/models.py
+++ b/transclip/models.py
@@ -31,6 +31,14 @@ SUPPORTED_MODELS = [
     ),
 ]
 
+SUPPORTED_TEXT_MODELS = [
+    SupportedModel(
+        "Qwen/Qwen3.5-4B",
+        "text_generation",
+        10 * GIB,
+    ),
+]
+
 ASR_BACKEND_ALIASES = {
     "granite_nar": "granite_nar",
     "granite-nar": "granite_nar",
@@ -41,10 +49,10 @@ ASR_BACKEND_ALIASES = {
 
 
 def model_by_id(model_id: str) -> SupportedModel:
-    for model in SUPPORTED_MODELS:
+    for model in SUPPORTED_MODELS + SUPPORTED_TEXT_MODELS:
         if model.model_id == model_id:
             return model
-    supported = ", ".join(model.model_id for model in SUPPORTED_MODELS)
+    supported = ", ".join(model.model_id for model in SUPPORTED_MODELS + SUPPORTED_TEXT_MODELS)
     raise ValueError(f"Unsupported model: {model_id}. Supported models: {supported}")
 
 
@@ -92,6 +100,12 @@ def required_model_cache_paths(settings: Settings) -> list[Path]:
         paths.append(Path(settings.cleanup_model_path).expanduser())
     elif settings.cleanup_runtime == "transformers":
         paths.append(model_cache_path(settings.cleanup_model, settings))
+    if settings.text_model_runtime == "transformers" and (
+        settings.voice_mode_routing_enabled or settings.voice_model_cleanup_always_on
+    ):
+        text_path = model_cache_path(settings.text_model, settings)
+        if text_path not in paths:
+            paths.append(text_path)
     return paths
 
 
@@ -108,12 +122,16 @@ def cache_artifacts_present(model_id: str, settings: Settings) -> bool:
 def model_rows(settings: Settings) -> list[dict[str, Any]]:
     default = Settings()
     rows = []
-    for model in SUPPORTED_MODELS:
+    for model in SUPPORTED_MODELS + SUPPORTED_TEXT_MODELS:
         markers = []
         if model.model_id == settings.asr_model:
             markers.append("current")
+        if model.model_id == settings.text_model:
+            markers.append("current-text")
         if model.model_id == default.asr_model:
             markers.append("default")
+        if model.model_id == default.text_model:
+            markers.append("default-text")
         rows.append(
             {
                 "model_id": model.model_id,
@@ -145,7 +163,23 @@ def prefetch_model(model_id: str, settings: Settings) -> Path:
     model = model_by_id(model_id)
     ensure_disk_space(settings, model)
     cache_dir = str(model_cache_root(settings)) if settings.model_cache_dir else None
-    if model.backend == "granite_nar":
+    if model.backend == "text_generation":
+        try:
+            from transformers import AutoModelForImageTextToText, AutoProcessor
+        except ImportError as exc:
+            raise RuntimeError("transformers is required. Install transclip[models].") from exc
+        AutoModelForImageTextToText.from_pretrained(
+            model.model_id,
+            dtype="auto",
+            local_files_only=False,
+            cache_dir=cache_dir,
+        )
+        AutoProcessor.from_pretrained(
+            model.model_id,
+            local_files_only=False,
+            cache_dir=cache_dir,
+        )
+    elif model.backend == "granite_nar":
         try:
             from transformers import AutoFeatureExtractor, AutoModel
         except ImportError as exc:

--- a/transclip/platform_runtime.py
+++ b/transclip/platform_runtime.py
@@ -5,7 +5,7 @@ import platform
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 SESSION_ENV_KEYS = (
     "XDG_SESSION_TYPE",
@@ -50,10 +50,10 @@ class DefaultPlatformRuntime:
         return shutil.which(program)
 
     def run(self, command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(command, **kwargs)
+        return cast(subprocess.CompletedProcess[str], subprocess.run(command, **kwargs))
 
     def check_output(self, command: list[str], **kwargs: Any) -> str:
-        return subprocess.check_output(command, **kwargs)
+        return cast(str, subprocess.check_output(command, **kwargs))
 
 
 default_platform_runtime = DefaultPlatformRuntime()

--- a/transclip/service.py
+++ b/transclip/service.py
@@ -10,13 +10,16 @@ from urllib.parse import urlparse
 
 from .asr import ASRBackend, build_asr_backend
 from .audio import AudioRecorder
-from .cleanup import CleanupBackend, build_cleanup_backend
+from .cleanup import CleanupBackend, ModelCleanupProcessor, build_cleanup_backend
 from .debug_capture import DebugCapture
 from .dictation_session import DictationSession
 from .history import append_transcript_history
 from .keyword_restore import restore_keywords
+from .mode_routing import route_voice_mode
 from .service_routes import dispatch_get, dispatch_post
 from .settings import Settings, load_settings
+from .shell_command import ShellCommandProcessor, ShellCommandResult
+from .text_generation import TextGenerationBackend, build_text_generation_backend
 
 
 class InferenceEngine:
@@ -25,10 +28,14 @@ class InferenceEngine:
         settings: Settings,
         asr_backend: ASRBackend | None = None,
         cleanup_backend: CleanupBackend | None = None,
+        text_backend: TextGenerationBackend | None = None,
     ):
         self.settings = settings
         self.asr_backend = asr_backend or build_asr_backend(settings)
         self.cleanup_backend = cleanup_backend or build_cleanup_backend(settings)
+        self.text_backend = text_backend or build_text_generation_backend(settings)
+        self.model_cleanup = ModelCleanupProcessor(self.text_backend)
+        self.shell_command = ShellCommandProcessor(settings, self.text_backend)
         self.debug_capture = DebugCapture(settings)
         self.dictation_session = DictationSession(
             settings,
@@ -45,6 +52,11 @@ class InferenceEngine:
             "cleanup_backend": self.cleanup_backend.name,
             "cleanup_model": self.settings.cleanup_model,
             "cleanup_enabled": self.settings.cleanup_enabled,
+            "voice_mode_routing_enabled": self.settings.voice_mode_routing_enabled,
+            "voice_model_cleanup_always_on": self.settings.voice_model_cleanup_always_on,
+            "voice_mode_shell_enabled": self.settings.voice_mode_shell_enabled,
+            "text_model_runtime": self.settings.text_model_runtime,
+            "text_model": self.settings.text_model,
             "language": self.settings.language,
             "max_recording_seconds": self.settings.max_recording_seconds,
             "min_recording_ms": self.settings.min_recording_ms,
@@ -105,14 +117,32 @@ class InferenceEngine:
         asr_result = self.asr_backend.transcribe(wav_path, keywords=keywords)
         should_cleanup = self.settings.cleanup_enabled if cleanup is None else cleanup
         raw_asr = restore_keywords(asr_result.text, keywords or [])
-        cleaned = raw_asr
+        route = route_voice_mode(
+            raw_asr,
+            routing_enabled=self.settings.voice_mode_routing_enabled,
+            shell_enabled=self.settings.voice_mode_shell_enabled,
+        )
+        cleaned = route.payload if route.literal else raw_asr
         cleanup_result = None
+        shell_result = None
         timings = dict(asr_result.timings_ms)
-        if should_cleanup:
-            cleanup_result = self.cleanup_backend.cleanup(raw_asr)
+        if route.mode == "cleanup":
+            cleanup_result = self.model_cleanup.cleanup(route.payload)
+            cleaned = cleanup_result.text
+            timings.update(cleanup_result.timings_ms)
+        elif route.mode == "shell":
+            shell_result = self.shell_command.generate(route.payload)
+            cleaned = shell_result.text
+            timings.update(shell_result.timings_ms)
+        elif should_cleanup and not route.literal:
+            if self.settings.voice_model_cleanup_always_on:
+                cleanup_result = self.model_cleanup.cleanup(raw_asr)
+            else:
+                cleanup_result = self.cleanup_backend.cleanup(raw_asr)
             cleaned = cleanup_result.text
             timings.update(cleanup_result.timings_ms)
         timings["end_to_end"] = round((perf_counter() - start) * 1000, 3)
+        shell_metadata = _shell_metadata(shell_result)
         capture_dir = self.debug_capture.write(
             wav_path=wav_path,
             raw_asr=asr_result.text,
@@ -123,12 +153,25 @@ class InferenceEngine:
                 "asr_model": asr_result.model,
                 "cleanup_backend": self.cleanup_backend.name,
                 "cleanup_model": self.settings.cleanup_model,
+                "text_model_runtime": self.settings.text_model_runtime,
+                "text_model": self.settings.text_model,
+            },
+            metadata={
+                "voice_mode": route.mode,
+                "voice_trigger": route.trigger,
+                "voice_literal": route.literal,
+                "shell": shell_metadata,
             },
         )
         result = {
             "text": cleaned,
             "raw_asr": raw_asr,
             "cleanup": asdict(cleanup_result) if cleanup_result else None,
+            "voice_mode": route.mode,
+            "voice_trigger": route.trigger,
+            "voice_literal": route.literal,
+            "shell": shell_metadata,
+            "submit": False if route.mode == "shell" else None,
             "timings_ms": timings,
             "debug_capture_dir": str(capture_dir) if capture_dir else None,
             "asr_backend": asr_result.backend,
@@ -159,7 +202,7 @@ def create_server(
     engine: InferenceEngine | None = None,
 ) -> ThreadingHTTPServer:
     settings = settings or load_settings()
-    engine = engine or InferenceEngine(settings)
+    active_engine = engine or InferenceEngine(settings)
 
     class Handler(BaseHTTPRequestHandler):
         def do_OPTIONS(self) -> None:
@@ -168,17 +211,17 @@ def create_server(
             self.end_headers()
 
         def do_GET(self) -> None:
-            response = dispatch_get(engine, urlparse(self.path).path)
+            response = dispatch_get(active_engine, urlparse(self.path).path)
             self._json(response.status, response.payload)
 
         def do_POST(self) -> None:
             path = urlparse(self.path).path
             try:
                 body = self._read_json()
-                response = dispatch_post(engine, path, body)
+                response = dispatch_post(active_engine, path, body)
                 self._json(response.status, response.payload)
             except Exception as exc:
-                capture_dir = engine.debug_capture.write_error(
+                capture_dir = active_engine.debug_capture.write_error(
                     "http_request",
                     exc,
                     {"path": path},
@@ -220,8 +263,26 @@ def run_server(settings: Settings | None = None) -> None:
     server.serve_forever()
 
 
-def _append_transcript_history(result: dict[str, Any], settings: Settings, **kwargs: Any) -> None:
+def _append_transcript_history(
+    result: dict[str, Any],
+    settings: Settings,
+    source: str,
+    duration_ms: float | None = None,
+) -> None:
     try:
-        append_transcript_history(result, settings, **kwargs)
+        append_transcript_history(result, settings, source=source, duration_ms=duration_ms)
     except Exception as exc:
         result["history_error"] = str(exc)
+
+
+def _shell_metadata(shell_result: ShellCommandResult | None) -> dict[str, Any] | None:
+    if shell_result is None:
+        return None
+    return {
+        "command": shell_result.command,
+        "valid": shell_result.valid,
+        "diagnostics": shell_result.diagnostics,
+        "backend": shell_result.backend,
+        "model": shell_result.model,
+        "validation": shell_result.validation,
+    }

--- a/transclip/settings.py
+++ b/transclip/settings.py
@@ -21,6 +21,13 @@ class Settings:
     cleanup_enabled: bool = True
     cleanup_runtime: str = "rule"
     cleanup_model_path: str = ""
+    voice_mode_routing_enabled: bool = True
+    voice_model_cleanup_always_on: bool = False
+    voice_mode_shell_enabled: bool = True
+    text_model_runtime: str = "transformers"
+    text_model: str = "Qwen/Qwen3.5-4B"
+    shell_syntax_validation_enabled: bool = True
+    shellcheck_enabled: bool = True
     models_local_files_only: bool = True
     model_cache_dir: str = ""
     restore_clipboard_after_paste: bool = False
@@ -79,6 +86,13 @@ def settings_to_toml(settings: Settings) -> str:
             "cleanup_enabled",
             "cleanup_runtime",
             "cleanup_model_path",
+            "voice_mode_routing_enabled",
+            "voice_model_cleanup_always_on",
+            "voice_mode_shell_enabled",
+            "text_model_runtime",
+            "text_model",
+            "shell_syntax_validation_enabled",
+            "shellcheck_enabled",
             "models_local_files_only",
             "model_cache_dir",
         ),

--- a/transclip/shell_command.py
+++ b/transclip/shell_command.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import json
+import os
+import pwd
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .platform_runtime import PlatformRuntime, get_runtime
+from .settings import Settings
+from .text_generation import TextGenerationBackend
+
+SHELL_SYNTAX_ERROR_CODES = ("SC107", "SC108")
+SHELL_VALIDATION_TIMEOUT_SECONDS = 2.0
+
+
+@dataclass(frozen=True, slots=True)
+class ShellValidationResult:
+    ok: bool
+    diagnostics: list[str]
+    metadata: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class ShellCommandResult:
+    text: str
+    command: str
+    valid: bool
+    diagnostics: list[str]
+    timings_ms: dict[str, float]
+    backend: str
+    model: str
+    validation: dict[str, Any]
+
+
+class ShellCommandProcessor:
+    def __init__(
+        self,
+        settings: Settings,
+        text_backend: TextGenerationBackend,
+        runtime: PlatformRuntime | None = None,
+    ):
+        self.settings = settings
+        self.text_backend = text_backend
+        self.runtime = get_runtime(runtime)
+
+    def generate(self, task: str) -> ShellCommandResult:
+        try:
+            generation = self.text_backend.generate(shell_command_messages(task), max_new_tokens=64)
+        except Exception as exc:
+            reason = shell_generation_failure_reason(exc, self.text_backend)
+            diagnostic = commented_diagnostic("TransClip could not produce valid Bash: " + reason)
+            return ShellCommandResult(
+                diagnostic,
+                "",
+                False,
+                [reason],
+                {},
+                getattr(self.text_backend, "name", "text-generation"),
+                getattr(self.text_backend, "model_name", ""),
+                {},
+            )
+        command = parse_shell_command(generation.text)
+        if not command:
+            diagnostic = commented_diagnostic("TransClip could not produce valid Bash: empty command")
+            return ShellCommandResult(
+                diagnostic,
+                "",
+                False,
+                ["empty command"],
+                dict(generation.timings_ms),
+                generation.backend,
+                generation.model,
+                {},
+            )
+
+        validation = validate_shell_command(command, self.settings, runtime=self.runtime)
+        if not validation.ok:
+            diagnostic = commented_diagnostic(
+                "TransClip could not produce valid Bash: " + "; ".join(validation.diagnostics)
+            )
+            return ShellCommandResult(
+                diagnostic,
+                command,
+                False,
+                validation.diagnostics,
+                dict(generation.timings_ms),
+                generation.backend,
+                generation.model,
+                validation.metadata,
+            )
+
+        return ShellCommandResult(
+            command.rstrip("\r\n"),
+            command.rstrip("\r\n"),
+            True,
+            validation.diagnostics,
+            dict(generation.timings_ms),
+            generation.backend,
+            generation.model,
+            validation.metadata,
+        )
+
+
+def shell_command_messages(task: str, default_shell_path: str | None = None) -> list[dict[str, str]]:
+    default_shell_path = default_shell_path or detect_default_shell()
+    default_shell_name = Path(default_shell_path).name or default_shell_path
+    return [
+        {
+            "role": "system",
+            "content": (
+                'Return JSON only: {"command":"..."}. Generate one Bash-compatible command for the task. '
+                f"Default shell: {default_shell_name} ({default_shell_path}). No prose or Markdown."
+            ),
+        },
+        {
+            "role": "user",
+            "content": task,
+        },
+    ]
+
+
+def detect_default_shell() -> str:
+    shell = os.environ.get("SHELL", "").strip()
+    if shell:
+        return shell
+    try:
+        shell = pwd.getpwuid(os.getuid()).pw_shell.strip()
+    except (KeyError, OSError):
+        shell = ""
+    return shell or "/bin/sh"
+
+
+def parse_shell_command(response: str) -> str:
+    text = response.strip()
+    if not text:
+        return ""
+    parsed = _parse_json_command(text)
+    if parsed is not None:
+        return parsed.rstrip("\r\n")
+    fenced = _first_fenced_block(text)
+    if fenced is not None:
+        text = fenced.strip()
+        parsed = _parse_json_command(text)
+        if parsed is not None:
+            return parsed.rstrip("\r\n")
+    text = re.sub(r"^\s*(?:command|bash)\s*:\s*", "", text, flags=re.IGNORECASE)
+    return text.strip().rstrip("\r\n")
+
+
+def validate_shell_command(
+    command: str,
+    settings: Settings,
+    runtime: PlatformRuntime | None = None,
+) -> ShellValidationResult:
+    platform_runtime = get_runtime(runtime)
+    metadata: dict[str, Any] = {}
+    diagnostics: list[str] = []
+    if not settings.shell_syntax_validation_enabled:
+        return ShellValidationResult(True, diagnostics, metadata)
+
+    bash = platform_runtime.which("bash")
+    metadata["bash_available"] = bool(bash)
+    if bash:
+        try:
+            completed = platform_runtime.run(
+                [bash, "-n", "-c", command],
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=SHELL_VALIDATION_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            metadata["bash_timeout"] = True
+            diagnostics.append(f"bash syntax check timed out after {SHELL_VALIDATION_TIMEOUT_SECONDS:.1f}s")
+            return ShellValidationResult(False, diagnostics, metadata)
+        metadata["bash_returncode"] = completed.returncode
+        if completed.stderr.strip():
+            metadata["bash_stderr"] = completed.stderr.strip()
+        if completed.returncode != 0:
+            diagnostics.append(_single_line(completed.stderr) or "bash syntax check failed")
+            return ShellValidationResult(False, diagnostics, metadata)
+
+    shellcheck = platform_runtime.which("shellcheck") if settings.shellcheck_enabled else None
+    metadata["shellcheck_available"] = bool(shellcheck)
+    if shellcheck:
+        try:
+            completed = platform_runtime.run(
+                [shellcheck, "-s", "bash", "-"],
+                input=command,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=SHELL_VALIDATION_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            metadata["shellcheck_timeout"] = True
+            return ShellValidationResult(True, diagnostics, metadata)
+        output = "\n".join(part for part in (completed.stdout, completed.stderr) if part.strip())
+        metadata["shellcheck_returncode"] = completed.returncode
+        if output.strip():
+            metadata["shellcheck_output"] = output.strip()
+        if completed.returncode != 0 and _shellcheck_blocks(output):
+            diagnostics.append(_single_line(output) or "ShellCheck syntax check failed")
+            return ShellValidationResult(False, diagnostics, metadata)
+
+    return ShellValidationResult(True, diagnostics, metadata)
+
+
+def commented_diagnostic(message: str) -> str:
+    lines = [line.strip() for line in message.splitlines() if line.strip()]
+    if not lines:
+        lines = ["TransClip could not produce valid Bash"]
+    return "\n".join(f"# {line}" for line in lines)
+
+
+def shell_generation_failure_reason(exc: Exception, text_backend: TextGenerationBackend) -> str:
+    model = getattr(text_backend, "model_name", "")
+    detail = _single_line(str(exc)) or type(exc).__name__
+    lowered = detail.lower()
+    if "cached files" in lowered or "couldn't connect" in lowered or "offline mode" in lowered:
+        if model:
+            return (
+                f"text model {model} is not available in the local Hugging Face cache; "
+                f"run: uv run -m transclip.cli models prefetch --model {model}"
+            )
+        return "text model is not available in the local Hugging Face cache"
+    if "install transclip[models]" in lowered or ("transformers" in lowered and "required" in lowered):
+        return "text model dependencies are missing; install: uv pip install -e '.[models]'"
+    return f"model generation failed: {detail}"
+
+
+def _parse_json_command(text: str) -> str | None:
+    candidates = [text]
+    match = re.search(r"\{.*\}", text, flags=re.DOTALL)
+    if match:
+        candidates.append(match.group(0))
+    for candidate in candidates:
+        try:
+            payload = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            for key in ("command", "cmd", "text"):
+                if key in payload:
+                    command = payload[key]
+                    return command.strip() if isinstance(command, str) else ""
+            return ""
+    return None
+
+
+def _first_fenced_block(text: str) -> str | None:
+    match = re.search(r"```(?:bash|sh|shell)?\s*(.*?)```", text, flags=re.IGNORECASE | re.DOTALL)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def _shellcheck_blocks(output: str) -> bool:
+    lowered = output.lower()
+    return "error:" in lowered or any(code in output for code in SHELL_SYNTAX_ERROR_CODES)
+
+
+def _single_line(text: str) -> str:
+    return " ".join(text.strip().split())

--- a/transclip/text_generation.py
+++ b/transclip/text_generation.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Protocol
+
+from .device import resolve_torch_device
+from .settings import Settings
+from .timing import timed_ms
+
+
+@dataclass(frozen=True, slots=True)
+class TextGenerationResult:
+    text: str
+    timings_ms: dict[str, float]
+    backend: str
+    model: str
+
+
+class TextGenerationBackend(Protocol):
+    name: str
+    model_name: str
+
+    def generate(self, messages: list[dict[str, str]], *, max_new_tokens: int) -> TextGenerationResult: ...
+
+
+class TransformersTextGenerationBackend:
+    name = "transformers"
+
+    def __init__(self, model_name: str, local_files_only: bool = True, cache_dir: str = ""):
+        self.model_name = model_name
+        self.local_files_only = local_files_only
+        self.cache_dir = cache_dir
+        self._loaded = None
+        self._lock = threading.RLock()
+
+    def _load(self):
+        with self._lock:
+            if self._loaded is not None:
+                return self._loaded
+            try:
+                from transformers import AutoModelForImageTextToText, AutoProcessor
+            except ImportError as exc:
+                raise RuntimeError(
+                    "transformers, torch, and accelerate are required. Install transclip[models]."
+                ) from exc
+            processor = AutoProcessor.from_pretrained(
+                self.model_name,
+                local_files_only=self.local_files_only,
+                cache_dir=self.cache_dir or None,
+            )
+            device = resolve_torch_device("auto")
+            model_kwargs = {"device_map": "auto"} if device == "cuda" else {}
+            model = AutoModelForImageTextToText.from_pretrained(
+                self.model_name,
+                dtype="auto",
+                local_files_only=self.local_files_only,
+                cache_dir=self.cache_dir or None,
+                **model_kwargs,
+            )
+            model.eval()
+            self._loaded = (processor, model)
+            return self._loaded
+
+    def generate(self, messages: list[dict[str, str]], *, max_new_tokens: int) -> TextGenerationResult:
+        timings: dict[str, float] = {}
+        with self._lock:
+            processor, model = self._load()
+            with timed_ms(timings, "text_generation"):
+                inputs = processor.apply_chat_template(
+                    _processor_messages(messages),
+                    add_generation_prompt=True,
+                    tokenize=True,
+                    return_dict=True,
+                    return_tensors="pt",
+                )
+                inputs = inputs.to(model.device)
+                input_len = inputs["input_ids"].shape[-1]
+                try:
+                    import torch
+                except ImportError:
+                    outputs = model.generate(
+                        **inputs,
+                        max_new_tokens=max_new_tokens,
+                        do_sample=False,
+                    )
+                else:
+                    with torch.inference_mode():
+                        outputs = model.generate(
+                            **inputs,
+                            max_new_tokens=max_new_tokens,
+                            do_sample=False,
+                        )
+                response = processor.decode(outputs[0][input_len:], skip_special_tokens=True)
+        return TextGenerationResult(response.strip(), timings, self.name, self.model_name)
+
+
+def _processor_messages(messages: list[dict[str, str]]) -> list[dict[str, object]]:
+    return [
+        {
+            "role": message["role"],
+            "content": [{"type": "text", "text": message["content"]}],
+        }
+        for message in messages
+    ]
+
+
+def build_text_generation_backend(settings: Settings) -> TextGenerationBackend:
+    runtime = settings.text_model_runtime.lower()
+    if runtime == "transformers":
+        return TransformersTextGenerationBackend(
+            settings.text_model,
+            local_files_only=settings.models_local_files_only,
+            cache_dir=settings.model_cache_dir,
+        )
+    raise ValueError(f"Unsupported text model runtime: {settings.text_model_runtime}")

--- a/transclip/tray.py
+++ b/transclip/tray.py
@@ -119,6 +119,20 @@ def run_python_tray(settings: Settings, explicit_settings_path: Path | None = No
             state["detail"] = f"ASR model update failed: {exc}"
         update_menu()
 
+    def toggle_model_cleanup(_item=None) -> None:
+        path = explicit_settings_path or settings_path()
+        try:
+            persisted = load_settings(path) if path.exists() else settings
+            next_value = not persisted.voice_model_cleanup_always_on
+            updated = replace(persisted, voice_model_cleanup_always_on=next_value)
+            write_settings(updated, path)
+            settings.voice_model_cleanup_always_on = next_value
+            restart = service_action("restart")
+            state["detail"] = f"Model cleanup always {'on' if next_value else 'off'}; {restart.detail}"
+        except Exception as exc:
+            state["detail"] = f"Model cleanup toggle failed: {exc}"
+        update_menu()
+
     def open_settings(_item=None) -> None:
         path = explicit_settings_path or settings_path()
         write_default_settings(path)
@@ -188,6 +202,11 @@ def run_python_tray(settings: Settings, explicit_settings_path: Path | None = No
         _append_separator(menu)
         _append_item(menu, "Start service", start_service)
         _append_item(menu, "Restart service", restart_service)
+        menu_refs["model_cleanup_item"] = _append_item(
+            menu,
+            _model_cleanup_label(settings),
+            toggle_model_cleanup,
+        )
         model_menu = Gtk.Menu()
         model_item = Gtk.MenuItem(label="ASR model")
         model_item.set_submenu(model_menu)
@@ -214,6 +233,7 @@ def run_python_tray(settings: Settings, explicit_settings_path: Path | None = No
         _set_menu_item_label(menu_refs["status_item"], state["detail"] or f"Service: {state['status']}")
         _set_menu_item_label(menu_refs["toggle_item"], "Stop + paste" if state["recording"] else "Record")
         menu_refs["latest_item"].set_sensitive(bool(state["latest"] or _latest_history_text()))
+        _set_menu_item_label(menu_refs["model_cleanup_item"], _model_cleanup_label(settings))
         for item, model in menu_refs["model_items"]:
             _set_menu_item_label(item, _model_menu_label(model.model_id, model.backend, settings))
 
@@ -271,6 +291,8 @@ def _append_label(menu, label: str):
 
 
 def _set_menu_item_label(item, label: str) -> None:
+    if hasattr(item, "label"):
+        item.label = label
     child = item.get_child()
     if hasattr(child, "set_text"):
         child.set_text(label)
@@ -295,6 +317,11 @@ def _append_separator(menu) -> None:
 def _model_menu_label(model_id: str, backend: str, settings: Settings) -> str:
     prefix = "✓ " if settings.asr_model == model_id and settings.asr_backend == backend else ""
     return prefix + _model_label(model_id, backend)
+
+
+def _model_cleanup_label(settings: Settings) -> str:
+    prefix = "✓ " if settings.voice_model_cleanup_always_on else ""
+    return prefix + "Model cleanup always on"
 
 
 def _model_label(model_id: str, backend: str) -> str:


### PR DESCRIPTION
## Summary
- add post-ASR voice mode routing for dictation, explicit model cleanup, shell command generation, and literal escapes
- add shared local Qwen text generation backend with serialized load/generation and model-cache/prefetch support
- add shell command parsing plus non-executing Bash/ShellCheck validation with timeout handling and commented diagnostics
- add tray toggle for always-on model cleanup, debug/history metadata, eval prompts, docs, and Makefile tooling including Ruff and ty

## Verification
- `make check`
  - `uv run ruff check .`
  - `uv run ruff format . --check`
  - `uv run ty check`
  - `uv run -m unittest discover -v` (171 tests)
  - `uv run -m compileall transclip tests scripts`
  - `git diff --check`

## Notes
- normal dictation keeps rule cleanup by default unless an explicit cleanup trigger is spoken or the tray setting enables model cleanup for all dictation
- shell mode pastes command text only and never submits or executes it
- `Qwen/Qwen3.5-4B` uses the current Transformers `AutoProcessor` + `AutoModelForImageTextToText` loading contract
