### PR TITLE
Add native macOS menu bar tray

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,22 @@ uv run -m transclip.cli smoke-test
 uv run -m transclip.cli logs
 ```
 
-Run the Python tray (Linux only):
+Run the tray/menu bar UI:
 
 ```bash
 transclip tray
 ```
 
-On macOS, `transclip tray` exits with guidance to use a Keyboard Shortcut or
-Shortcuts.app action until a native menu bar UI exists.
+On macOS this uses native AppKit through PyObjC. The UI extra only installs the
+menu bar dependencies; recording also needs the audio backend extras. For Apple
+Silicon installs, use:
+
+```bash
+uv sync --extra audio --extra mlx --extra macos-ui
+```
+
+If you install only `--extra macos-ui`, the tray can launch but recording fails
+with `Install transclip[audio] for microphone capture.`
 
 On Linux this uses PyGObject/Ayatana AppIndicator. When running through `uv`,
 the command hands off to system Python if the project virtual environment does
@@ -86,7 +94,7 @@ uv run -m transclip.cli serve
 Requirements: Apple Silicon, native ARM Python 3.12+, macOS 14+.
 
 ```bash
-uv sync --extra audio --extra mlx
+uv sync --extra audio --extra mlx --extra macos-ui
 uv run -m transclip.cli init-config
 uv run -m transclip.cli models prefetch --model mlx-community/whisper-large-v3-turbo-asr-fp16
 uv run -m transclip.cli install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ build-backend = "hatchling.build"
 audio = ["sounddevice>=0.5", "numpy>=1.26"]
 models = ["transformers>=5.8", "torch>=2.9.1,<2.12", "torchaudio>=2.9.1,<2.12", "torchcodec>=0.5", "torchvision>=0.24,<0.27", "accelerate>=1.0", "soundfile>=0.12", "pillow>=10"]
 mlx = ["mlx-audio[stt]>=0.4.3", "huggingface_hub>=0.27", "soundfile>=0.12"]
-macos-ui = []
+macos-ui = ["pyobjc-framework-Cocoa>=10; sys_platform == 'darwin'"]
 llama = ["llama-cpp-python>=0.3"]
 dev = [
     "coverage[toml]>=7.10",

--- a/tests/test_tray.py
+++ b/tests/test_tray.py
@@ -1,13 +1,16 @@
+import io
 import sys
 import tempfile
 import types
 import unittest
 from pathlib import Path
+from typing import ClassVar
 from unittest.mock import patch
 
 from tests.service_helpers import FakeRuntime
+from transclip.recording_ops import ToggleOutcome
 from transclip.settings import DEFAULT_HOTKEY_LINUX, Settings, load_settings, write_settings
-from transclip.tray import run_python_tray, run_tray
+from transclip.tray import run_macos_tray, run_python_tray, run_tray
 
 
 class FakeLabel:
@@ -151,8 +154,186 @@ class FakeClient:
         return {"status": "ready"}
 
 
+class FakeNSObject:
+    @classmethod
+    def alloc(cls):
+        return cls.__new__(cls)
+
+    def init(self):
+        return self
+
+
+class FakeNSMenuItem:
+    def __init__(self):
+        self.title = ""
+        self.action = None
+        self.target = None
+        self.enabled = True
+        self.submenu = None
+        self.represented = None
+
+    @classmethod
+    def alloc(cls):
+        return cls()
+
+    @classmethod
+    def separatorItem(cls):
+        item = cls()
+        item.title = "---"
+        return item
+
+    def initWithTitle_action_keyEquivalent_(self, title, action, _key):
+        self.title = title
+        self.action = action
+        return self
+
+    def setTarget_(self, target) -> None:
+        self.target = target
+
+    def setTitle_(self, title) -> None:
+        self.title = title
+
+    def setEnabled_(self, enabled) -> None:
+        self.enabled = enabled
+
+    def setSubmenu_(self, menu) -> None:
+        self.submenu = menu
+
+    def setRepresentedObject_(self, value) -> None:
+        self.represented = value
+
+    def representedObject(self):
+        return self.represented
+
+    def activate(self) -> None:
+        method_name = self.action.replace(":", "_")
+        getattr(self.target, method_name)(self)
+
+
+class FakeNSMenu:
+    def __init__(self):
+        self.items = []
+        self.delegate = None
+
+    @classmethod
+    def alloc(cls):
+        return cls()
+
+    def init(self):
+        return self
+
+    def setDelegate_(self, delegate) -> None:
+        self.delegate = delegate
+
+    def addItem_(self, item) -> None:
+        self.items.append(item)
+
+    def itemArray(self):
+        return list(self.items)
+
+    def removeItem_(self, item) -> None:
+        self.items.remove(item)
+
+
+class FakeStatusButton:
+    def __init__(self):
+        self.title = ""
+        self.tooltip = ""
+
+    def setTitle_(self, title) -> None:
+        self.title = title
+
+    def setToolTip_(self, tooltip) -> None:
+        self.tooltip = tooltip
+
+
+class FakeStatusItem:
+    current = None
+
+    def __init__(self):
+        self.button_instance = FakeStatusButton()
+        self.menu = None
+        type(self).current = self
+
+    def button(self):
+        return self.button_instance
+
+    def setMenu_(self, menu) -> None:
+        self.menu = menu
+
+
+class FakeStatusBar:
+    @classmethod
+    def systemStatusBar(cls):
+        return cls()
+
+    def statusItemWithLength_(self, _length):
+        return FakeStatusItem()
+
+
+class FakeNSApplication:
+    current = None
+
+    def __init__(self):
+        self.delegate = None
+        self.ran = False
+        type(self).current = self
+
+    @classmethod
+    def sharedApplication(cls):
+        return cls.current or cls()
+
+    def setActivationPolicy_(self, policy) -> None:
+        self.policy = policy
+
+    def setDelegate_(self, delegate) -> None:
+        self.delegate = delegate
+
+    def run(self) -> None:
+        self.ran = True
+
+    def terminate_(self, _sender) -> None:
+        self.terminated = True
+
+
+class FakeNSApp:
+    terminated = False
+
+    @classmethod
+    def terminate_(cls, _sender) -> None:
+        cls.terminated = True
+
+
+class FakeNSTimer:
+    scheduled: ClassVar[list[tuple]] = []
+
+    @classmethod
+    def scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(cls, *args):
+        cls.scheduled.append(args)
+        return object()
+
+
+def fake_macos_modules():
+    appkit = types.ModuleType("AppKit")
+    appkit.NSApp = FakeNSApp
+    appkit.NSApplication = FakeNSApplication
+    appkit.NSApplicationActivationPolicyAccessory = "accessory"
+    appkit.NSMenu = FakeNSMenu
+    appkit.NSMenuItem = FakeNSMenuItem
+    appkit.NSStatusBar = FakeStatusBar
+    appkit.NSVariableStatusItemLength = -1
+    foundation = types.ModuleType("Foundation")
+    foundation.NSObject = FakeNSObject
+    foundation.NSTimer = FakeNSTimer
+    return {"AppKit": appkit, "Foundation": foundation}
+
+
 class TrayTests(unittest.TestCase):
     def setUp(self):
+        FakeStatusItem.current = None
+        FakeNSApplication.current = None
+        FakeNSTimer.scheduled = []
+        FakeNSApp.terminated = False
         self.runtime_patch = patch("transclip.runtime_profile.get_runtime", return_value=FakeRuntime(system="Linux"))
         self.runtime_patch.start()
         gi = types.ModuleType("gi")
@@ -321,11 +502,171 @@ class TrayTests(unittest.TestCase):
         install_shortcut.assert_not_called()
         self.assertIn("not a valid", indicator.menus[0].children[0].child.text)
 
-    def test_darwin_tray_fails_clearly_without_gtk(self):
-        runtime = FakeRuntime(system="Darwin", home=Path("/Users/test"))
-        with patch("transclip.tray.get_runtime", return_value=runtime):
-            code = run_tray(Settings())
+    def test_darwin_tray_runs_native_menubar(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = FakeRuntime(system="Darwin", home=Path(tmp))
+            with (
+                patch.dict(sys.modules, fake_macos_modules()),
+                patch("transclip.tray.get_runtime", return_value=runtime),
+                patch("transclip.tray.InferenceClient", FakeClient),
+                patch("transclip.tray.read_history", return_value=[]),
+                patch("transclip.runtime_profile.get_runtime", side_effect=lambda value=None: value or runtime),
+                patch("transclip.runtime_profile.machine_architecture", return_value="arm64"),
+            ):
+                code = run_tray(Settings())
+
+        self.assertEqual(code, 0)
+        self.assertTrue(FakeNSApplication.current.ran)
+        menu = FakeStatusItem.current.menu
+        self.assertEqual(status_title(menu), "Service: ready")
+        self.assertEqual(menu_item_by_title(FakeStatusItem.current, "Record").title, "Record")
+        self.assertFalse(menu_item_by_title(FakeStatusItem.current, "Copy latest transcript").enabled)
+
+    def test_macos_tray_reports_missing_pyobjc(self):
+        stderr = io.StringIO()
+        with (
+            patch.dict(sys.modules, {"AppKit": None, "Foundation": None}),
+            patch("sys.stderr", stderr),
+        ):
+            code = run_macos_tray(Settings(), runtime=FakeRuntime(system="Darwin"))
+
         self.assertEqual(code, 1)
+        self.assertIn("PyObjC", stderr.getvalue())
+        self.assertIn("macos-ui", stderr.getvalue())
+
+    def test_macos_record_click_updates_menu_to_stop(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = FakeRuntime(system="Darwin", home=Path(tmp))
+            outcome = ToggleOutcome(True, {"action": "started"}, "http://127.0.0.1:8765")
+            with (
+                patch.dict(sys.modules, fake_macos_modules()),
+                patch("transclip.tray.InferenceClient", FakeClient),
+                patch("transclip.tray.read_history", return_value=[]),
+                patch("transclip.tray.toggle_recording", return_value=outcome),
+                patch("transclip.runtime_profile.get_runtime", side_effect=lambda value=None: value or runtime),
+                patch("transclip.runtime_profile.machine_architecture", return_value="arm64"),
+            ):
+                run_macos_tray(Settings(), runtime=runtime)
+                toggle_item = menu_item_by_title(FakeStatusItem.current, "Record")
+                toggle_item.activate()
+
+        self.assertEqual(toggle_item.title, "Stop + paste")
+        self.assertEqual(FakeStatusItem.current.button().title, "●")
+        self.assertEqual(status_title(FakeStatusItem.current.menu), "Service: recording")
+
+    def test_macos_record_stop_surfaces_paste_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = FakeRuntime(system="Darwin", home=Path(tmp))
+            outcome = ToggleOutcome(
+                True,
+                {"action": "stopped", "text": "hello world"},
+                "http://127.0.0.1:8765",
+                paste_failed_message="Paste failed. The transcript is still on the clipboard. denied",
+            )
+            with (
+                patch.dict(sys.modules, fake_macos_modules()),
+                patch("transclip.tray.InferenceClient", FakeClient),
+                patch("transclip.tray.read_history", return_value=[]),
+                patch("transclip.tray.toggle_recording", return_value=outcome) as toggle,
+                patch("transclip.runtime_profile.get_runtime", side_effect=lambda value=None: value or runtime),
+                patch("transclip.runtime_profile.machine_architecture", return_value="arm64"),
+            ):
+                run_macos_tray(Settings(), runtime=runtime)
+                toggle_item = menu_item_by_title(FakeStatusItem.current, "Record")
+                toggle_item.activate()
+
+        toggle.assert_called_once()
+        self.assertTrue(toggle.call_args.kwargs["paste"])
+        self.assertEqual(toggle_item.target.state["latest"], "hello world")
+        self.assertIn("Paste failed", status_title(FakeStatusItem.current.menu))
+        self.assertIn("denied", status_title(FakeStatusItem.current.menu))
+
+    def test_macos_tray_action_selectors_are_bound_to_controller_methods(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = FakeRuntime(system="Darwin", home=Path(tmp))
+            with (
+                patch.dict(sys.modules, fake_macos_modules()),
+                patch("transclip.tray.InferenceClient", FakeClient),
+                patch("transclip.tray.read_history", return_value=[]),
+                patch("transclip.runtime_profile.get_runtime", side_effect=lambda value=None: value or runtime),
+                patch("transclip.runtime_profile.machine_architecture", return_value="arm64"),
+            ):
+                code = run_macos_tray(Settings(), runtime=runtime)
+
+        self.assertEqual(code, 0)
+        for item in actionable_menu_items(FakeStatusItem.current.menu):
+            method_name = item.action.replace(":", "_")
+            self.assertTrue(hasattr(item.target, method_name), f"missing selector method for {item.action}")
+        timer = FakeNSTimer.scheduled[-1]
+        self.assertTrue(hasattr(timer[1], timer[2].replace(":", "_")))
+
+    def test_macos_asr_model_menu_saves_settings_and_restarts_service(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = FakeRuntime(system="Darwin", home=Path(tmp))
+            settings_file = Path(tmp) / "settings.toml"
+            settings = Settings()
+            write_settings(settings, settings_file)
+            with (
+                patch.dict(sys.modules, fake_macos_modules()),
+                patch("transclip.tray.InferenceClient", FakeClient),
+                patch("transclip.tray.read_history", return_value=[]),
+                patch("transclip.runtime_profile.get_runtime", side_effect=lambda value=None: value or runtime),
+                patch("transclip.runtime_profile.machine_architecture", return_value="arm64"),
+                patch("transclip.tray.service_action") as service_action,
+            ):
+                service_action.return_value = types.SimpleNamespace(detail="restarted")
+                code = run_macos_tray(settings, explicit_settings_path=settings_file, runtime=runtime)
+                model_item = menu_item_by_title(FakeStatusItem.current, "ASR model")
+                mlx_item = submenu_item_by_title(model_item, "mlx-community/whisper-large-v3-turbo-asr-fp16")
+                mlx_item.activate()
+
+                self.assertEqual(code, 0)
+                self.assertEqual(settings.asr_backend, "mlx_audio_whisper")
+                self.assertEqual(settings.asr_model, "mlx-community/whisper-large-v3-turbo-asr-fp16")
+                saved = load_settings(settings_file)
+                self.assertEqual(saved.asr_backend, "mlx_audio_whisper")
+                self.assertEqual(saved.asr_model, "mlx-community/whisper-large-v3-turbo-asr-fp16")
+                service_action.assert_called_once_with("restart")
+                self.assertIn("ASR model set", status_title(FakeStatusItem.current.menu))
+
+    def test_macos_quit_terminates_current_application(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = FakeRuntime(system="Darwin", home=Path(tmp))
+            with (
+                patch.dict(sys.modules, fake_macos_modules()),
+                patch("transclip.tray.InferenceClient", FakeClient),
+                patch("transclip.tray.read_history", return_value=[]),
+                patch("transclip.runtime_profile.get_runtime", side_effect=lambda value=None: value or runtime),
+                patch("transclip.runtime_profile.machine_architecture", return_value="arm64"),
+            ):
+                run_macos_tray(Settings(), runtime=runtime)
+                quit_item = menu_item_by_title(FakeStatusItem.current, "Quit tray")
+                quit_item.activate()
+
+        self.assertTrue(FakeNSApplication.current.terminated)
+
+    def test_macos_copy_latest_uses_history_when_no_recording_in_memory(self):
+        copied = []
+
+        class Clipboard:
+            def write(self, text):
+                copied.append(text)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = FakeRuntime(system="Darwin", home=Path(tmp))
+            with (
+                patch.dict(sys.modules, fake_macos_modules()),
+                patch("transclip.tray.InferenceClient", FakeClient),
+                patch("transclip.tray.read_history", return_value=[{"text": "hello history"}]),
+                patch("transclip.tray.SystemClipboard", return_value=Clipboard()),
+                patch("transclip.runtime_profile.get_runtime", side_effect=lambda value=None: value or runtime),
+                patch("transclip.runtime_profile.machine_architecture", return_value="arm64"),
+            ):
+                run_macos_tray(Settings(), runtime=runtime)
+                menu_item_by_title(FakeStatusItem.current, "Copy latest transcript").activate()
+
+        self.assertEqual(copied, ["hello history"])
+        self.assertEqual(status_title(FakeStatusItem.current.menu), "Copied latest transcript")
 
     def test_linux_tray_filters_macos_only_models(self):
         with (
@@ -353,6 +694,35 @@ def submenu_item_by_label(item, label: str):
         if getattr(child, "label", "") == label or getattr(child.child, "text", "") == label:
             return child
     raise AssertionError(f"missing submenu item: {label}")
+
+
+def status_title(menu):
+    return menu.items[0].title
+
+
+def actionable_menu_items(menu):
+    items = []
+    for item in menu.items:
+        if getattr(item, "action", None):
+            items.append(item)
+        if getattr(item, "submenu", None):
+            items.extend(actionable_menu_items(item.submenu))
+    return items
+
+
+def menu_item_by_title(status_item, title: str):
+    for item in status_item.menu.items:
+        if getattr(item, "title", "") == title:
+            return item
+    raise AssertionError(f"missing menu item: {title}")
+
+
+def submenu_item_by_title(item, title: str):
+    for child in item.submenu.items:
+        child_title = getattr(child, "title", "")
+        if child_title == title or child_title.endswith(title):
+            return child
+    raise AssertionError(f"missing submenu item: {title}")
 
 
 if __name__ == "__main__":

--- a/transclip/tray.py
+++ b/transclip/tray.py
@@ -13,22 +13,258 @@ from .gnome_shortcut import install_shortcut
 from .history import read_history
 from .models import model_rows
 from .paste import SystemClipboard
-from .platform_runtime import get_runtime
-from .product import APP_ID, CLI_COMMAND, DISPLAY_NAME, IMPORT_PACKAGE
+from .platform_runtime import PlatformRuntime, get_runtime
+from .product import APP_ID, DISPLAY_NAME, IMPORT_PACKAGE
 from .recording_ops import toggle_recording
 from .settings import Settings, load_settings, settings_path, write_default_settings, write_settings
 
+_MACOS_TRAY_REFS: list[Any] = []
+
 
 def run_tray(settings: Settings, explicit_settings_path: Path | None = None) -> int:
-    if get_runtime().system() == "Darwin":
+    runtime = get_runtime()
+    if runtime.system() == "Darwin":
+        return run_macos_tray(settings, explicit_settings_path=explicit_settings_path, runtime=runtime)
+    return run_python_tray(settings, explicit_settings_path=explicit_settings_path)
+
+
+def run_macos_tray(
+    settings: Settings,
+    explicit_settings_path: Path | None = None,
+    runtime: PlatformRuntime | None = None,
+) -> int:
+    try:
+        from AppKit import (  # type: ignore[import-not-found]
+            NSApplication,
+            NSApplicationActivationPolicyAccessory,
+            NSMenu,
+            NSMenuItem,
+            NSStatusBar,
+            NSVariableStatusItemLength,
+        )
+        from Foundation import NSObject, NSTimer  # type: ignore[import-not-found]
+    except ImportError:
         print(
-            "Native macOS menu bar UI is not implemented yet. "
-            f"Use a Keyboard Shortcut or Shortcuts.app action for `{CLI_COMMAND} toggle-record --paste`, "
-            f"and `{CLI_COMMAND} status` / `{CLI_COMMAND} doctor` for service state.",
+            "macOS menu bar UI requires PyObjC. Install with: "
+            "uv sync --extra macos-ui or pip install 'transclip[macos-ui]'",
             file=sys.stderr,
         )
         return 1
-    return run_python_tray(settings, explicit_settings_path=explicit_settings_path)
+
+    platform_runtime = runtime or get_runtime()
+
+    class MacOSTrayController(NSObject):
+        def initWithSettings_explicitSettingsPath_(self, initial_settings, settings_path_value):
+            self = self.init()
+            self.settings = initial_settings
+            self.explicit_settings_path = settings_path_value
+            self.state = {
+                "status": "starting",
+                "recording": False,
+                "latest": "",
+                "detail": "",
+            }
+            self.menu_refs = {}
+            self.status_item = NSStatusBar.systemStatusBar().statusItemWithLength_(NSVariableStatusItemLength)
+            self.status_item.button().setTitle_("🎙")
+            self.status_item.button().setToolTip_(DISPLAY_NAME)
+            self.buildMenu()
+            return self
+
+        def buildMenu(self):
+            menu = NSMenu.alloc().init()
+            menu.setDelegate_(self)
+            self.menu_refs["status_item"] = self.appendLabel_toMenu_(self.state["detail"] or "Service: starting", menu)
+            menu.addItem_(NSMenuItem.separatorItem())
+            self.menu_refs["toggle_item"] = self.appendItem_action_toMenu_("Record", "toggleRecord:", menu)
+            self.menu_refs["latest_item"] = self.appendItem_action_toMenu_(
+                "Copy latest transcript",
+                "copyLatest:",
+                menu,
+            )
+            menu.addItem_(NSMenuItem.separatorItem())
+            history_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_("Recent transcripts", None, "")
+            history_menu = NSMenu.alloc().init()
+            history_item.setSubmenu_(history_menu)
+            menu.addItem_(history_item)
+            self.menu_refs["history_menu"] = history_menu
+            menu.addItem_(NSMenuItem.separatorItem())
+            self.appendItem_action_toMenu_("Start service", "startService:", menu)
+            self.appendItem_action_toMenu_("Restart service", "restartService:", menu)
+            model_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_("ASR model", None, "")
+            model_menu = NSMenu.alloc().init()
+            model_item.setSubmenu_(model_menu)
+            menu.addItem_(model_item)
+            self.menu_refs["model_menu"] = model_menu
+            self.menu_refs["model_items"] = []
+            for row in model_rows(self.settings, platform_runtime):
+                model = {"model_id": row["model_id"], "backend": row["backend"]}
+                item = self.appendItem_action_toMenu_(
+                    _model_menu_label(model["model_id"], model["backend"], self.settings),
+                    "setASRModel:",
+                    model_menu,
+                )
+                item.setRepresentedObject_(model)
+                self.menu_refs["model_items"].append(item)
+            self.appendItem_action_toMenu_("Open settings", "openSettings:", menu)
+            menu.addItem_(NSMenuItem.separatorItem())
+            self.appendItem_action_toMenu_("Quit tray", "quitTray:", menu)
+            self.refreshHistoryMenu()
+            self.updateMenu()
+            self.status_item.setMenu_(menu)
+
+        def appendItem_action_toMenu_(self, title, action, menu):
+            item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(title, action, "")
+            item.setTarget_(self)
+            menu.addItem_(item)
+            return item
+
+        def appendLabel_toMenu_(self, title, menu):
+            item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(title, None, "")
+            item.setEnabled_(False)
+            menu.addItem_(item)
+            return item
+
+        def refreshHealth(self):
+            try:
+                health = InferenceClient(self.settings).health()
+                status = str(health.get("status", "unknown"))
+                self.state["status"] = status
+                self.state["recording"] = status == "recording"
+                self.state["detail"] = f"Service: {status}"
+                self.status_item.button().setTitle_("●" if self.state["recording"] else "🎙")
+            except Exception as exc:
+                self.state["status"] = "offline"
+                self.state["recording"] = False
+                self.state["detail"] = f"Service: offline ({exc})"
+                self.status_item.button().setTitle_("⚠")
+            self.updateMenu()
+            return True
+
+        def refreshHealth_(self, _timer):
+            return self.refreshHealth()
+
+        def updateMenu(self):
+            self.menu_refs["status_item"].setTitle_(self.state["detail"] or f"Service: {self.state['status']}")
+            self.menu_refs["toggle_item"].setTitle_("Stop + paste" if self.state["recording"] else "Record")
+            self.menu_refs["latest_item"].setEnabled_(bool(self.state["latest"] or _latest_history_text()))
+            for item in self.menu_refs["model_items"]:
+                model = item.representedObject()
+                item.setTitle_(_model_menu_label(model["model_id"], model["backend"], self.settings))
+
+        def refreshHistoryMenu(self):
+            history_menu = self.menu_refs["history_menu"]
+            for item in list(history_menu.itemArray()):
+                history_menu.removeItem_(item)
+            events = read_history(limit=5)
+            if events:
+                for event in events:
+                    text = str(event.get("text") or "")
+                    item = self.appendItem_action_toMenu_(_preview(text), "copyHistoryItem:", history_menu)
+                    item.setRepresentedObject_(text)
+            else:
+                self.appendLabel_toMenu_("No recent transcripts", history_menu)
+
+        def menuWillOpen_(self, _menu):
+            self.refreshHistoryMenu()
+            self.refreshHealth()
+
+        def toggleRecord_(self, _item):
+            outcome = toggle_recording(self.settings, paste=True)
+            if not outcome.ok:
+                self.state["detail"] = f"Toggle failed: {outcome.error_message}"
+                self.updateMenu()
+                return
+            if outcome.latest_transcript:
+                self.state["latest"] = outcome.latest_transcript
+                self.refreshHistoryMenu()
+            action = outcome.payload.get("action")
+            detail = outcome.paste_failed_message
+            self.refreshHealth()
+            if action == "started":
+                self.state["status"] = "recording"
+                self.state["recording"] = True
+                self.state["detail"] = "Service: recording"
+                self.status_item.button().setTitle_("●")
+            elif action == "stopped":
+                self.state["recording"] = False
+                if not detail:
+                    self.state["detail"] = "Service: ready"
+                self.status_item.button().setTitle_("🎙")
+            if detail:
+                self.state["detail"] = detail
+            self.updateMenu()
+
+        def copyLatest_(self, _item):
+            latest = self.state["latest"] or _latest_history_text()
+            if not latest:
+                self.state["detail"] = "No transcript available"
+                self.updateMenu()
+                return
+            self.copyText_(latest)
+
+        def copyHistoryItem_(self, item):
+            self.copyText_(str(item.representedObject() or ""))
+
+        def copyText_(self, text):
+            try:
+                SystemClipboard().write(text)
+                self.state["detail"] = "Copied latest transcript"
+            except Exception as exc:
+                self.state["detail"] = f"Copy failed: {exc}"
+            self.updateMenu()
+
+        def startService_(self, _item):
+            result = service_action("start")
+            self.refreshHealth()
+            self.state["detail"] = result.detail
+            self.updateMenu()
+
+        def restartService_(self, _item):
+            result = service_action("restart")
+            self.refreshHealth()
+            self.state["detail"] = result.detail
+            self.updateMenu()
+
+        def setASRModel_(self, item):
+            model = item.representedObject()
+            path = self.explicit_settings_path or settings_path()
+            try:
+                persisted = load_settings(path) if path.exists() else self.settings
+                updated = replace(persisted, asr_model=model["model_id"], asr_backend=model["backend"])
+                write_settings(updated, path)
+                self.settings.asr_model = model["model_id"]
+                self.settings.asr_backend = model["backend"]
+                restart = service_action("restart")
+                label = _model_label(model["model_id"], model["backend"])
+                self.state["detail"] = f"ASR model set to {label}; {restart.detail}"
+            except Exception as exc:
+                self.state["detail"] = f"ASR model update failed: {exc}"
+            self.updateMenu()
+
+        def openSettings_(self, _item):
+            path = self.explicit_settings_path or settings_path()
+            write_default_settings(path)
+            _open_path(path)
+
+        def quitTray_(self, _item):
+            NSApplication.sharedApplication().terminate_(self)
+
+    app = NSApplication.sharedApplication()
+    app.setActivationPolicy_(NSApplicationActivationPolicyAccessory)
+    controller = MacOSTrayController.alloc().initWithSettings_explicitSettingsPath_(settings, explicit_settings_path)
+    app.setDelegate_(controller)
+    timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
+        3.0,
+        controller,
+        "refreshHealth:",
+        None,
+        True,
+    )
+    _MACOS_TRAY_REFS[:] = [controller, controller.status_item, timer]
+    controller.refreshHealth()
+    app.run()
+    return 0
 
 
 def run_python_tray(settings: Settings, explicit_settings_path: Path | None = None) -> int:

--- a/uv.lock
+++ b/uv.lock
@@ -1086,6 +1086,35 @@ wheels = [
 ]
 
 [[package]]
+name = "pyobjc-core"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/b6/d5612eb40be4fd5ef88c259339e6313f46ba67577a95d86c3470b951fce0/pyobjc_core-12.1.tar.gz", hash = "sha256:2bb3903f5387f72422145e1466b3ac3f7f0ef2e9960afa9bcd8961c5cbf8bd21", size = 1000532, upload-time = "2025-11-14T10:08:28.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/5a/6b15e499de73050f4a2c88fff664ae154307d25dc04da8fb38998a428358/pyobjc_core-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:818bcc6723561f207e5b5453efe9703f34bc8781d11ce9b8be286bb415eb4962", size = 678335, upload-time = "2025-11-14T09:32:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/d2/29e5e536adc07bc3d33dd09f3f7cf844bf7b4981820dc2a91dd810f3c782/pyobjc_core-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:01c0cf500596f03e21c23aef9b5f326b9fb1f8f118cf0d8b66749b6cf4cbb37a", size = 677370, upload-time = "2025-11-14T09:33:05.273Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/f0/4b4ed8924cd04e425f2a07269943018d43949afad1c348c3ed4d9d032787/pyobjc_core-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:177aaca84bb369a483e4961186704f64b2697708046745f8167e818d968c88fc", size = 719586, upload-time = "2025-11-14T09:33:53.302Z" },
+    { url = "https://files.pythonhosted.org/packages/25/98/9f4ed07162de69603144ff480be35cd021808faa7f730d082b92f7ebf2b5/pyobjc_core-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:844515f5d86395b979d02152576e7dee9cc679acc0b32dc626ef5bda315eaa43", size = 670164, upload-time = "2025-11-14T09:34:37.458Z" },
+    { url = "https://files.pythonhosted.org/packages/62/50/dc076965c96c7f0de25c0a32b7f8aa98133ed244deaeeacfc758783f1f30/pyobjc_core-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:453b191df1a4b80e756445b935491b974714456ae2cbae816840bd96f86db882", size = 712204, upload-time = "2025-11-14T09:35:24.148Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cocoa"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/bf/ee4f27ec3920d5c6fc63c63e797c5b2cc4e20fe439217085d01ea5b63856/pyobjc_framework_cocoa-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:547c182837214b7ec4796dac5aee3aa25abc665757b75d7f44f83c994bcb0858", size = 384590, upload-time = "2025-11-14T09:41:17.336Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/31/0c2e734165abb46215797bd830c4bdcb780b699854b15f2b6240515edcc6/pyobjc_framework_cocoa-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5a3dcd491cacc2f5a197142b3c556d8aafa3963011110102a093349017705118", size = 384689, upload-time = "2025-11-14T09:41:41.478Z" },
+    { url = "https://files.pythonhosted.org/packages/23/3b/b9f61be7b9f9b4e0a6db18b3c35c4c4d589f2d04e963e2174d38c6555a92/pyobjc_framework_cocoa-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:914b74328c22d8ca261d78c23ef2befc29776e0b85555973927b338c5734ca44", size = 388843, upload-time = "2025-11-14T09:42:05.719Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/f777cc9e775fc7dae77b569254570fe46eb842516b3e4fe383ab49eab598/pyobjc_framework_cocoa-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:03342a60fc0015bcdf9b93ac0b4f457d3938e9ef761b28df9564c91a14f0129a", size = 384932, upload-time = "2025-11-14T09:42:29.771Z" },
+    { url = "https://files.pythonhosted.org/packages/58/27/b457b7b37089cad692c8aada90119162dfb4c4a16f513b79a8b2b022b33b/pyobjc_framework_cocoa-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6ba1dc1bfa4da42d04e93d2363491275fb2e2be5c20790e561c8a9e09b8cf2cc", size = 388970, upload-time = "2025-11-14T09:42:53.964Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1650,6 +1679,9 @@ dev = [
 llama = [
     { name = "llama-cpp-python" },
 ]
+macos-ui = [
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+]
 mlx = [
     { name = "huggingface-hub" },
     { name = "mlx-audio", extra = ["stt"] },
@@ -1676,6 +1708,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'audio'", specifier = ">=1.26" },
     { name = "pillow", marker = "extra == 'models'", specifier = ">=10" },
     { name = "playwright", marker = "extra == 'chatgpt-ui'", specifier = ">=1.52" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin' and extra == 'macos-ui'", specifier = ">=10" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.11" },
     { name = "sounddevice", marker = "extra == 'audio'", specifier = ">=0.5" },


### PR DESCRIPTION
 ## Summary
   - Add native macOS AppKit/PyObjC menu bar tray for TransClip
   - Keep existing Linux AppIndicator tray path unchanged
   - Add macOS tray actions for service status, record/stop + paste, latest transcript, recent transcripts, service restart, ASR model selection, settings, and quit
   - Add optional `macos-ui` extra with PyObjC dependency
   - Document required macOS install extras for recording: `audio + mlx + macos-ui`

   ## Testing
   - `uv run -m unittest tests.test_tray -v`
   - `uv run ruff check transclip/tray.py tests/test_tray.py`
   - `uv run ruff format --check transclip/tray.py tests/test_tray.py`
   - `uv lock --locked`
   - `git diff --check`

   ## Notes
   - `macos-ui` alone only installs menu bar dependencies; recording still requires `audio` and the selected ASR backend extra.
   - Verified real local recording after installing `audio + mlx + macos-ui`.