### PR TITLE
Remove unused max_recording_seconds setting

### DIFF
--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -21,17 +21,20 @@ from transclip.daemon.windows import build_task_scheduler_xml, install_windows_d
 from transclip.desktop.hotkey import build_toggle_invocation, windows_hotkey_setup_message
 from transclip.paths import service_settings_path
 from transclip.product import TASK_SCHEDULER_NAME
-from transclip.settings import Settings
+from transclip.settings import Settings, write_settings
 
 from tests.service_helpers import FakeRuntime, normalize_path_text
 
 
 class DaemonTests(unittest.TestCase):
     def test_systemd_unit_uses_current_python_and_cli_serve(self):
-        unit = build_systemd_unit(Path("/tmp/settings.toml"))
+        with tempfile.TemporaryDirectory() as tmp:
+            settings_path = Path(tmp) / "settings.toml"
+            write_settings(Settings(asr_backend="granite_nar"), settings_path)
+            unit = build_systemd_unit(settings_path)
 
         self.assertIn("Description=TransClip dictation service", unit)
-        settings_path = normalize_path_text(service_settings_path(Path("/tmp/settings.toml")))
+        settings_path = normalize_path_text(service_settings_path(settings_path))
         normalized_unit = normalize_path_text(unit).replace("'", "")
         self.assertIn(f"-m transclip.cli --settings {settings_path} serve", normalized_unit)
         self.assertIn("Restart=on-failure", unit)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -180,7 +180,7 @@ class ServiceTests(unittest.TestCase):
         server, thread, host, port = serve_test_engine(settings, engine)
         base_url = f"http://{host}:{port}"
         try:
-            with patch("transclip.audio.AudioRecorder", FakeRecorder):
+            with patch("transclip.service.engine.AudioRecorder", FakeRecorder):
                 started = http_json("POST", f"{base_url}/record/start", {})
                 health = http_json("GET", f"{base_url}/health")
                 stopped = http_json("POST", f"{base_url}/record/stop", {"cleanup": True})
@@ -203,7 +203,7 @@ class ServiceTests(unittest.TestCase):
         server, thread, host, port = serve_test_engine(settings, engine)
         base_url = f"http://{host}:{port}"
         try:
-            with patch("transclip.audio.AudioRecorder", FakeRecorder):
+            with patch("transclip.service.engine.AudioRecorder", FakeRecorder):
                 http_json("POST", f"{base_url}/record/start", {})
                 stopped = http_json("POST", f"{base_url}/record/stop", {"discard": True})
 
@@ -227,7 +227,7 @@ class ServiceTests(unittest.TestCase):
         server, thread, host, port = serve_test_engine(settings, engine)
         base_url = f"http://{host}:{port}"
         try:
-            with patch("transclip.audio.AudioRecorder", FakeRecorder):
+            with patch("transclip.service.engine.AudioRecorder", FakeRecorder):
                 started = http_json("POST", f"{base_url}/record/toggle", {})
                 stopped = http_json("POST", f"{base_url}/record/toggle", {"cleanup": True})
 
@@ -255,7 +255,7 @@ class ServiceTests(unittest.TestCase):
         server, thread, host, port = serve_test_engine(settings, engine)
         base_url = f"http://{host}:{port}"
         try:
-            with patch("transclip.audio.AudioRecorder", FakeRecorder):
+            with patch("transclip.service.engine.AudioRecorder", FakeRecorder):
                 http_json("POST", f"{base_url}/record/toggle", {})
                 stopped = http_json("POST", f"{base_url}/record/toggle", {})
 
@@ -303,7 +303,7 @@ class ServiceTests(unittest.TestCase):
             asr_backend=FakeASR(),
             cleanup_backend=FaithfulRuleCleanupBackend(),
         )
-        with patch("transclip.audio.AudioRecorder", FakeRecorder):
+        with patch("transclip.service.engine.AudioRecorder", FakeRecorder):
             started = engine.toggle_recording()
             ignored = engine.toggle_recording()
 

--- a/tests/test_service_health.py
+++ b/tests/test_service_health.py
@@ -12,7 +12,7 @@ from transclip.service.client_health import (
 from transclip.service.types import ServiceHealthResponse
 from transclip.settings import Settings
 
-from tests.service_helpers import FakeRuntime, patch_linux_gpu_runtime
+from tests.service_helpers import FakeRuntime, normalize_path_text, patch_linux_gpu_runtime
 
 
 class ServiceHealthTests(unittest.TestCase):
@@ -92,8 +92,8 @@ class GtkTrayReexecTests(unittest.TestCase):
             result = _reexec_with_system_python(None)
 
         self.assertEqual(result, 0)
-        self.assertTrue(captured["pythonpath"].startswith("/repo/root"))
-        self.assertEqual(captured["cwd"], "/repo/root")
+        self.assertTrue(normalize_path_text(captured["pythonpath"]).startswith("/repo/root"))
+        self.assertEqual(normalize_path_text(captured["cwd"]), "/repo/root")
 
 
 if __name__ == "__main__":

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -12,6 +12,7 @@ from transclip.settings import (
     patch_settings,
     set_setting,
     write_default_settings,
+    write_settings,
 )
 
 from tests.service_helpers import FakeRuntime, linux_gpu_runtime, patch_linux_gpu_runtime
@@ -27,7 +28,6 @@ class SettingsTests(unittest.TestCase):
             settings = load_settings(settings_file, runtime=runtime)
 
             self.assertEqual(settings.hotkey_linux, DEFAULT_HOTKEY_LINUX)
-            self.assertEqual(settings.max_recording_seconds, 60)
             self.assertEqual(settings.toggle_cooldown_ms, 500)
             self.assertEqual(settings.asr_backend, "granite_nar")
             self.assertEqual(settings.asr_model, "ibm-granite/granite-speech-4.1-2b-nar")
@@ -47,6 +47,23 @@ class SettingsTests(unittest.TestCase):
             path.write_text('hotkey_linux = "Ctrl+Space"\nwat = true\n', encoding="utf-8")
             with self.assertRaises(ValueError):
                 load_settings(path)
+
+    def test_removed_setting_is_stripped_when_settings_are_rewritten(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "settings.toml"
+            path.write_text(
+                'hotkey_linux = "<Super><Shift>XF86TouchpadOff"\nmax_recording_seconds = 60\n',
+                encoding="utf-8",
+            )
+            write_settings(load_settings(path), path)
+            self.assertNotIn("max_recording_seconds", path.read_text(encoding="utf-8"))
+
+    def test_set_setting_rejects_removed_max_recording_seconds(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "settings.toml"
+            write_default_settings(path)
+            with self.assertRaises(ValueError):
+                set_setting(path, "max_recording_seconds", "60")
 
     def test_platform_helpers_have_defaults(self):
         runtime = FakeRuntime(system="Linux", home=Path("/home/user"))

--- a/transclip/daemon/lifecycle.py
+++ b/transclip/daemon/lifecycle.py
@@ -4,7 +4,7 @@ import subprocess
 from pathlib import Path
 
 from transclip.platform.runtime import PlatformRuntime, get_runtime
-from transclip.settings import Settings, load_settings, write_default_settings
+from transclip.settings import load_settings, write_default_settings
 
 from . import linux as linux_daemon
 from . import macos as macos_daemon

--- a/transclip/service/health.py
+++ b/transclip/service/health.py
@@ -14,7 +14,6 @@ _SETTINGS_HEALTH_FIELDS = (
     "text_model_runtime",
     "text_model",
     "language",
-    "max_recording_seconds",
     "min_recording_ms",
     "toggle_cooldown_ms",
     "clipboard_restore_delay_ms",

--- a/transclip/service/types.py
+++ b/transclip/service/types.py
@@ -18,7 +18,6 @@ class ServiceHealthResponse(TypedDict, total=False):
     text_model_runtime: str
     text_model: str
     language: str
-    max_recording_seconds: int
     min_recording_ms: int
     toggle_cooldown_ms: int
     clipboard_restore_delay_ms: int

--- a/transclip/settings.py
+++ b/transclip/settings.py
@@ -33,7 +33,6 @@ class Settings:
     model_cache_dir: str = ""
     restore_clipboard_after_paste: bool = False
     clipboard_restore_delay_ms: int = 500
-    max_recording_seconds: int = 60
     min_recording_ms: int = 250
     toggle_cooldown_ms: int = 500
     debug_capture: bool = False
@@ -87,6 +86,7 @@ def load_settings(path: Path | None = None, runtime: PlatformRuntime | None = No
     if not path.exists():
         return default_settings(runtime)
     data = tomllib.loads(path.read_text(encoding="utf-8"))
+    data.pop("max_recording_seconds", None)  # removed; tolerate legacy configs
     allowed = {field.name for field in fields(Settings)}
     unknown = sorted(set(data) - allowed)
     if unknown:
@@ -117,7 +117,7 @@ def settings_to_toml(settings: Settings) -> str:
             "model_cache_dir",
         ),
         ("restore_clipboard_after_paste", "clipboard_restore_delay_ms"),
-        ("max_recording_seconds", "min_recording_ms", "toggle_cooldown_ms"),
+        ("min_recording_ms", "toggle_cooldown_ms"),
         ("debug_capture", "debug_capture_dir"),
         ("asr_backend", "asr_device", "sample_rate", "host", "port"),
     ]


### PR DESCRIPTION
## Summary
- Remove `max_recording_seconds` from settings, health payload, and service types — it was exposed in config/health but never enforced in `DictationSession`.
- Tolerate legacy configs on load with a targeted `pop`; rewrite paths strip the key from disk.
- Add migration tests for rewrite stripping and `config set` rejection.

## Test plan
- [x] `uv run -m unittest tests.test_settings tests.test_service -v` (28 tests, all pass)
- [ ] Confirm `/health` no longer includes `max_recording_seconds`
- [ ] Legacy config with `max_recording_seconds = 60` still loads; next settings write drops the key


Made with [Cursor](https://cursor.com)