### PR TITLE
Guard long recordings from OOM

### DIFF
--- a/tests/service_helpers.py
+++ b/tests/service_helpers.py
@@ -32,6 +32,7 @@ class FakeRecorder:
     def __init__(self, settings):
         self.settings = settings
         self.started = False
+        self.discarded = False
 
     def start(self):
         self.started = True
@@ -39,6 +40,9 @@ class FakeRecorder:
     def stop_to_wav(self, output_path: Path):
         output_path.write_bytes(b"not really wav")
         return output_path
+
+    def discard(self):
+        self.discarded = True
 
 
 class FakeTextBackend:

--- a/tests/test_audio_debug.py
+++ b/tests/test_audio_debug.py
@@ -1,8 +1,13 @@
+import tempfile
 import unittest
+import wave
+from pathlib import Path
+from types import SimpleNamespace
+from typing import ClassVar
 from unittest.mock import patch
 
 import numpy as np
-from transclip.audio import recording_debug, sounddevice_summary
+from transclip.audio import AudioRecorder, recording_debug, sounddevice_summary
 from transclip.settings import Settings
 
 
@@ -20,7 +25,118 @@ class FakeRecorder:
         return type(self).samples
 
 
+class FakeChunk:
+    def __init__(self, pcm: bytes):
+        self.pcm = pcm
+
+    def copy(self):
+        raise AssertionError("recorder should not retain copied callback chunks")
+
+    def tobytes(self):
+        return self.pcm
+
+
+class FakeInputStream:
+    instances: ClassVar[list["FakeInputStream"]] = []
+
+    def __init__(self, *, callback, **kwargs):
+        del kwargs
+        self.callback = callback
+        self.stopped = False
+        self.closed = False
+        type(self).instances.append(self)
+
+    def start(self):
+        pass
+
+    def stop(self):
+        self.stopped = True
+
+    def close(self):
+        self.closed = True
+
+
+class FakeRawAudio:
+    def __init__(self):
+        self.data = bytearray()
+        self.position = 0
+        self.closed = False
+
+    def write(self, data):
+        self.data.extend(data)
+
+    def seek(self, position):
+        self.position = position
+
+    def read(self, size=-1):
+        if size is None or size < 0:
+            raise AssertionError("WAV output should stream raw audio in bounded chunks")
+        chunk = bytes(self.data[self.position : self.position + size])
+        self.position += len(chunk)
+        return chunk
+
+    def close(self):
+        self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self.close()
+
+
+class FakeStream:
+    def __init__(self):
+        self.stopped = False
+        self.closed = False
+
+    def stop(self):
+        self.stopped = True
+
+    def close(self):
+        self.closed = True
+
+
 class AudioDebugTests(unittest.TestCase):
+    def test_audio_recorder_streams_callback_audio_to_wav_without_copying_chunks(self):
+        FakeInputStream.instances = []
+        raw_audio = FakeRawAudio()
+        with (
+            patch.dict("sys.modules", {"sounddevice": SimpleNamespace(InputStream=FakeInputStream)}),
+            patch("transclip.audio.tempfile.TemporaryFile", return_value=raw_audio),
+        ):
+            recorder = AudioRecorder(Settings(sample_rate=8000))
+            recorder.start()
+            stream = FakeInputStream.instances[-1]
+            stream.callback(FakeChunk(b"\x01\x00\x02\x00"), 2, None, None)
+            stream.callback(FakeChunk(b"\x03\x00"), 1, None, None)
+
+            with tempfile.TemporaryDirectory() as tmp:
+                output = recorder.stop_to_wav(Path(tmp) / "recording.wav")
+                with wave.open(str(output), "rb") as wav:
+                    self.assertEqual(wav.getframerate(), 8000)
+                    self.assertEqual(wav.getnframes(), 3)
+                    self.assertEqual(wav.readframes(3), b"\x01\x00\x02\x00\x03\x00")
+
+        self.assertTrue(stream.stopped)
+        self.assertTrue(stream.closed)
+        self.assertTrue(raw_audio.closed)
+
+    def test_audio_recorder_fails_if_running_stream_has_no_audio_buffer(self):
+        recorder = AudioRecorder(Settings())
+        stream = FakeStream()
+        recorder._stream = stream
+        recorder._raw_audio = None
+
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            self.assertRaisesRegex(RuntimeError, "Recorder audio buffer is not available"),
+        ):
+            recorder.stop_to_wav(Path(tmp) / "recording.wav")
+
+        self.assertTrue(stream.stopped)
+        self.assertTrue(stream.closed)
+
     def test_recording_debug_reports_audio_metrics(self):
         with patch("transclip.audio.time.sleep"):
             result = recording_debug(Settings(sample_rate=3), recorder_cls=FakeRecorder)

--- a/tests/test_dictation_session.py
+++ b/tests/test_dictation_session.py
@@ -32,6 +32,25 @@ class DictationSessionTests(unittest.TestCase):
         self.assertTrue(stopped["discarded"])
         self.assertEqual(stopped["duration_ms"], 100.0)
 
+    def test_toggle_discards_recording_over_maximum_duration_without_transcribing(self):
+        transcribe_calls = []
+
+        session = DictationSession(
+            Settings(max_recording_ms=1_000, min_recording_ms=0, toggle_cooldown_ms=0),
+            transcribe=lambda _wav, _cleanup, _source: transcribe_calls.append(_wav),
+            recorder_factory=FakeRecorder,
+            clock=StepClock([1.0, 1.0, 2.25, 2.25, 2.25]),
+        )
+
+        session.toggle_recording()
+        stopped = session.toggle_recording()
+
+        self.assertEqual(stopped["action"], "discarded")
+        self.assertTrue(stopped["discarded"])
+        self.assertEqual(stopped["reason"], "max_recording_duration")
+        self.assertEqual(stopped["max_recording_ms"], 1_000)
+        self.assertEqual(transcribe_calls, [])
+
     def test_stop_calls_transcriber_with_recorded_wav_and_source(self):
         calls = []
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -70,6 +70,19 @@ class HistoryTests(unittest.TestCase):
             self.assertEqual(event["voice_trigger"], "shell command")
             self.assertEqual(event["shell"]["command"], "ls -la")
 
+    def test_read_history_limit_returns_latest_events(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "history.jsonl"
+            for index in range(200):
+                append_history_event(
+                    {"timestamp": str(index), "text": f"entry-{index}", "source": "/record/toggle"},
+                    path,
+                )
+
+            events = read_history(limit=3, path=path)
+
+            self.assertEqual([event["text"] for event in events], ["entry-199", "entry-198", "entry-197"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -58,6 +58,19 @@ class SettingsTests(unittest.TestCase):
             write_settings(load_settings(path), path)
             self.assertNotIn("max_recording_seconds", path.read_text(encoding="utf-8"))
 
+    def test_legacy_max_recording_seconds_migrates_to_milliseconds(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "settings.toml"
+            path.write_text("max_recording_seconds = 60\n", encoding="utf-8")
+
+            settings = load_settings(path)
+            write_settings(settings, path)
+
+            text = path.read_text(encoding="utf-8")
+            self.assertEqual(settings.max_recording_ms, 60_000)
+            self.assertIn("max_recording_ms = 60000", text)
+            self.assertNotIn("max_recording_seconds", text)
+
     def test_set_setting_rejects_removed_max_recording_seconds(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "settings.toml"

--- a/tests/test_tray.py
+++ b/tests/test_tray.py
@@ -49,6 +49,9 @@ class FakeMenuItem:
     def show_all(self) -> None:
         return None
 
+    def destroy(self) -> None:
+        return None
+
 
 class FakeMenu:
     def __init__(self):
@@ -240,6 +243,34 @@ class TrayTests(unittest.TestCase):
             history_menu.handlers["map"](history_menu)
             self.assertEqual(read_history.call_count, baseline_reads + 1)
             self.assertEqual(len(history_menu.children), 2)
+
+    def test_recent_transcripts_refresh_on_root_menu_map(self):
+        history_events = [{"text": "Latest transcript"}]
+
+        with (
+            patch.dict(sys.modules, self.modules),
+            patch(
+                "transclip.service.client_health.fetch_service_health_result",
+                return_value=({"status": "ready"}, None),
+            ),
+            patch("transclip.history.read_history", side_effect=[[], history_events]) as read_history,
+            patch("transclip.desktop.tray.menu_update.history_file_signature", side_effect=[123, 456]),
+        ):
+            code = run_python_tray(Settings())
+            indicator = FakeIndicatorFactory.current
+            root_menu = indicator.menus[0]
+            latest_item = menu_item_by_label(indicator, "Copy latest transcript")
+            history_menu = menu_item_by_label(indicator, "Recent transcripts").submenu
+            self.assertEqual(code, 0)
+            self.assertIn("map", root_menu.handlers)
+            self.assertFalse(latest_item.sensitive)
+            baseline_reads = read_history.call_count
+
+            root_menu.handlers["map"](root_menu)
+            self.assertEqual(read_history.call_count, baseline_reads + 1)
+            self.assertEqual(len(history_menu.children), 1)
+            self.assertEqual(history_menu.children[0].label, "Latest transcript")
+            self.assertTrue(latest_item.sensitive)
 
     def test_history_file_signature_uses_mtime(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_tray_controller.py
+++ b/tests/test_tray_controller.py
@@ -53,6 +53,7 @@ class TrayControllerTests(unittest.TestCase):
             session = TraySession(Settings(), runtime=FakeRuntime(system="Linux", home="/home/test"))
         view = RecordingView()
         icon_updates: list[str] = []
+        history_refreshes: list[bool] = []
         session.refresh_health = MagicMock()  # type: ignore[method-assign]
         controller = TrayController(
             session,
@@ -61,11 +62,13 @@ class TrayControllerTests(unittest.TestCase):
             history_state=HistoryMenuState(signature=object()),
             on_health_icon=lambda: icon_updates.append(session.health.icon),
         )
+        controller.refresh_history_menu = lambda **kwargs: history_refreshes.append(True)  # type: ignore[method-assign]
 
         controller.refresh_health()
 
         session.refresh_health.assert_called_once()
         self.assertEqual(icon_updates, [session.health.icon])
+        self.assertEqual(history_refreshes, [])
 
     def test_update_menu_enables_copy_latest_from_session_latest(self):
         with patch_linux_gpu_runtime():

--- a/transclip/audio.py
+++ b/transclip/audio.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import tempfile
 import time
 import wave
 from contextlib import suppress
@@ -15,7 +16,7 @@ class AudioRecorder:
         self._sd = None
         self._np = None
         self._stream = None
-        self._frames = []
+        self._raw_audio = None
 
     def start(self) -> None:
         try:
@@ -25,13 +26,15 @@ class AudioRecorder:
             raise RuntimeError("Install transclip[audio] for microphone capture.") from exc
         self._np = np
         self._sd = sd
-        self._frames = []
+        self._raw_audio = tempfile.TemporaryFile()  # noqa: SIM115 - closed by stop_to_wav, stop_samples, or discard.
 
         def callback(indata, frames, time, status):
             del frames, time
             if status:
                 return
-            self._frames.append(indata.copy())
+            raw_audio = self._raw_audio
+            if raw_audio is not None:
+                raw_audio.write(indata.tobytes())
 
         try:
             self._stream = sd.InputStream(
@@ -42,21 +45,59 @@ class AudioRecorder:
             )
             self._stream.start()
         except Exception as exc:
+            with suppress(Exception):
+                self.discard()
             raise _recording_start_error(exc) from exc
 
     def stop_to_wav(self, output_path: Path) -> Path:
-        audio = self.stop_samples()
-        write_wav(output_path, audio.tobytes(), self.settings.sample_rate)
+        raw_audio = self._stop_raw_audio()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with raw_audio, wave.open(str(output_path), "wb") as wav:
+            wav.setnchannels(1)
+            wav.setsampwidth(2)
+            wav.setframerate(self.settings.sample_rate)
+            while chunk := raw_audio.read(1024 * 1024):
+                wav.writeframesraw(chunk)
         return output_path
 
     def stop_samples(self):
         if self._stream is None or self._np is None:
             raise RuntimeError("Recorder is not running")
+        with self._stop_raw_audio() as raw_audio:
+            pcm = raw_audio.read()
+            if not pcm:
+                return self._np.zeros((0, 1), dtype="int16")
+            return self._np.frombuffer(pcm, dtype=self._np.int16).reshape(-1, 1).copy()
+
+    def discard(self) -> None:
+        try:
+            self._stop_stream()
+        finally:
+            self._close_raw_audio()
+
+    def _stop_raw_audio(self):
+        if self._stream is None:
+            raise RuntimeError("Recorder is not running")
+        self._stop_stream()
+        raw_audio = self._raw_audio
+        if raw_audio is None:
+            raise RuntimeError("Recorder audio buffer is not available")
+        self._raw_audio = None
+        raw_audio.seek(0)
+        return raw_audio
+
+    def _stop_stream(self) -> None:
+        if self._stream is None:
+            return
         self._stream.stop()
         self._stream.close()
-        audio = self._np.concatenate(self._frames) if self._frames else self._np.zeros((0, 1), dtype="int16")
         self._stream = None
-        return audio
+
+    def _close_raw_audio(self) -> None:
+        raw_audio = self._raw_audio
+        self._raw_audio = None
+        if raw_audio is not None:
+            raw_audio.close()
 
 
 def _recording_start_error(exc: Exception) -> RuntimeError:

--- a/transclip/desktop/tray/controller.py
+++ b/transclip/desktop/tray/controller.py
@@ -67,6 +67,10 @@ class TrayController:
             force=force,
         )
 
+    def refresh_history_and_update_menu(self, *, force: bool = False) -> None:
+        self.refresh_history_menu(force=force)
+        self.update_menu()
+
     def run_tray_action(
         self,
         action: Callable[[], object],

--- a/transclip/desktop/tray/gtk.py
+++ b/transclip/desktop/tray/gtk.py
@@ -44,8 +44,9 @@ def run_python_tray(settings: Settings, explicit_settings_path: Path | None = No
 
     def rebuild_history(entries) -> None:
         history_menu = menu_refs["history_menu"]
-        for child in history_menu.get_children():
+        for child in list(history_menu.get_children()):
             history_menu.remove(child)
+            child.destroy()
         for preview, full_text in entries:
             if not full_text:
                 item = _append_label(history_menu, preview)
@@ -121,6 +122,7 @@ def run_python_tray(settings: Settings, explicit_settings_path: Path | None = No
 
     def build_menu() -> None:
         menu = Gtk.Menu()
+        menu.connect("map", lambda *_args: controller.refresh_history_and_update_menu())
         materialize_tray_menu(
             tray_menu_nodes("Linux"),
             session,
@@ -134,11 +136,10 @@ def run_python_tray(settings: Settings, explicit_settings_path: Path | None = No
                 set_model=session.set_asr_model,
             ),
             action_callbacks=action_callbacks,
-            on_history_open=controller.refresh_history_menu,
+            on_history_open=controller.refresh_history_and_update_menu,
             history_state=history_state,
         )
-        controller.refresh_history_menu()
-        controller.update_menu()
+        controller.refresh_history_and_update_menu()
         menu.show_all()
         indicator.set_menu(menu)
 

--- a/transclip/history.py
+++ b/transclip/history.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections import deque
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Protocol
@@ -71,26 +72,30 @@ def append_transcript_history(
     append_history_event(event, path=path)
 
 
+def _parse_history_line(line: str) -> dict[str, Any] | None:
+    stripped = line.strip()
+    if not stripped:
+        return None
+    try:
+        event = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+    return event if isinstance(event, dict) else None
+
+
 def read_history(limit: int | None = None, path: Path | None = None) -> list[dict[str, Any]]:
     path = path or history_path()
     if not path.exists():
         return []
-    events: list[dict[str, Any]] = []
+    if limit is not None and limit <= 0:
+        return []
+    events = deque(maxlen=limit) if limit is not None else []
     with path.open("r", encoding="utf-8") as handle:
         for line in handle:
-            stripped = line.strip()
-            if not stripped:
-                continue
-            try:
-                event = json.loads(stripped)
-            except json.JSONDecodeError:
-                continue
-            if isinstance(event, dict):
+            event = _parse_history_line(line)
+            if event is not None:
                 events.append(event)
-    events.reverse()
-    if limit is not None:
-        return events[:limit]
-    return events
+    return list(reversed(events))
 
 
 def history_file_signature(path: Path | None = None) -> int | None:

--- a/transclip/service/health.py
+++ b/transclip/service/health.py
@@ -15,6 +15,7 @@ _SETTINGS_HEALTH_FIELDS = (
     "text_model",
     "language",
     "min_recording_ms",
+    "max_recording_ms",
     "toggle_cooldown_ms",
     "clipboard_restore_delay_ms",
     "restore_clipboard_after_paste",

--- a/transclip/service/session.py
+++ b/transclip/service/session.py
@@ -18,6 +18,8 @@ class Recorder(Protocol):
 
     def stop_to_wav(self, output_path: Path) -> Path: ...
 
+    def discard(self) -> None: ...
+
 
 RecorderFactory = Callable[[Settings], Recorder]
 Transcriber = Callable[[Path, bool | None, str], TranscribeResponse]
@@ -108,12 +110,17 @@ class DictationSession:
             self._recording_started_at = 0.0
 
         duration_ms = (self._clock() - started_at) * 1000
-        discard = duration_ms < self.settings.min_recording_ms
+        over_maximum = (
+            self.settings.max_recording_ms > 0
+            and duration_ms > self.settings.max_recording_ms
+        )
+        discard = duration_ms < self.settings.min_recording_ms or over_maximum
         result = self._finish_recording(
             recorder,
             started_at,
             cleanup=cleanup,
             discard=discard,
+            discard_reason="max_recording_duration" if over_maximum else None,
             source="/record/toggle",
         )
         result["status"] = "ready"
@@ -127,13 +134,19 @@ class DictationSession:
         *,
         cleanup: bool | None,
         discard: bool,
+        discard_reason: str | None = None,
         source: str,
     ) -> RecordSessionResponse:
         duration_ms = round((self._clock() - started_at) * 1000, 3)
+        if discard:
+            recorder.discard()
+            result: RecordSessionResponse = {"status": "ready", "duration_ms": duration_ms, "discarded": True}
+            if discard_reason:
+                result["reason"] = discard_reason
+                result["max_recording_ms"] = self.settings.max_recording_ms
+            return result
         with tempfile.TemporaryDirectory() as tmp:
             wav_path = recorder.stop_to_wav(Path(tmp) / "recording.wav")
-            if discard:
-                return {"status": "ready", "duration_ms": duration_ms, "discarded": True}
             result = dict(self._transcribe(wav_path, cleanup, source))
         result["duration_ms"] = duration_ms
         return result

--- a/transclip/service/types.py
+++ b/transclip/service/types.py
@@ -19,6 +19,7 @@ class ServiceHealthResponse(TypedDict, total=False):
     text_model: str
     language: str
     min_recording_ms: int
+    max_recording_ms: int
     toggle_cooldown_ms: int
     clipboard_restore_delay_ms: int
     restore_clipboard_after_paste: bool
@@ -33,6 +34,7 @@ class RecordSessionResponse(TypedDict, total=False):
     already_recording: bool
     reason: str
     cooldown_ms: int
+    max_recording_ms: int
     history_error: str
     log_error: str
     service_url: str

--- a/transclip/settings.py
+++ b/transclip/settings.py
@@ -34,6 +34,7 @@ class Settings:
     restore_clipboard_after_paste: bool = False
     clipboard_restore_delay_ms: int = 500
     min_recording_ms: int = 250
+    max_recording_ms: int = 300_000
     toggle_cooldown_ms: int = 500
     debug_capture: bool = False
     debug_capture_dir: str = "debug-captures"
@@ -86,7 +87,9 @@ def load_settings(path: Path | None = None, runtime: PlatformRuntime | None = No
     if not path.exists():
         return default_settings(runtime)
     data = tomllib.loads(path.read_text(encoding="utf-8"))
-    data.pop("max_recording_seconds", None)  # removed; tolerate legacy configs
+    legacy_max_recording_seconds = data.pop("max_recording_seconds", None)
+    if legacy_max_recording_seconds is not None and "max_recording_ms" not in data:
+        data["max_recording_ms"] = int(float(legacy_max_recording_seconds) * 1000)
     allowed = {field.name for field in fields(Settings)}
     unknown = sorted(set(data) - allowed)
     if unknown:
@@ -117,7 +120,7 @@ def settings_to_toml(settings: Settings) -> str:
             "model_cache_dir",
         ),
         ("restore_clipboard_after_paste", "clipboard_restore_delay_ms"),
-        ("min_recording_ms", "toggle_cooldown_ms"),
+        ("min_recording_ms", "max_recording_ms", "toggle_cooldown_ms"),
         ("debug_capture", "debug_capture_dir"),
         ("asr_backend", "asr_device", "sample_rate", "host", "port"),
     ]


### PR DESCRIPTION
## TL;DR
Prevents accidental long dictation sessions from pushing TransClip into OOM territory. Audio capture now streams through a temporary raw file, overlong toggle recordings are discarded before ASR, and the tray/history refresh path is kept consistent with the new session behavior.

## Reviewer Map

### 1. Core OOM fix
Start here:
- `transclip/audio.py`
- `transclip/service/session.py`

What changed:
- `AudioRecorder` no longer stores every callback chunk in a Python list.
- `stop_to_wav()` writes WAV output in bounded chunks instead of materializing the whole recording.
- `discard()` is part of the recorder contract so short/overlong recordings can stop capture without WAV conversion.
- Toggle stop discards sessions over `max_recording_ms` before invoking ASR.

### 2. Config and response surface
Review next:
- `transclip/settings.py`
- `transclip/service/health.py`
- `transclip/service/types.py`

What changed:
- Added `max_recording_ms`, defaulting to 5 minutes.
- Legacy `max_recording_seconds` configs migrate to milliseconds on load.
- Health and record responses expose the max duration where relevant.

### 3. Tray/history consistency
Review last:
- `transclip/desktop/tray/controller.py`
- `transclip/desktop/tray/gtk.py`
- `transclip/history.py`

What changed:
- Tray history refresh now updates menu state atomically, so “Copy latest transcript” reflects freshly loaded history.
- GTK history menu children are destroyed after removal.
- History reads use a bounded deque for `limit` instead of reading then slicing the full list.

## Risk Notes
- Main behavioral change: recordings longer than `max_recording_ms` are discarded instead of transcribed. Setting `max_recording_ms = 0` disables the cap.
- `stop_samples()` still materializes audio because it is only used for debug/measurement paths.
- `uv run ty check` still reports pre-existing project-wide diagnostics in shortcut, Windows paste, and tray sink typing. This PR does not address that unrelated type debt.
- Local user config was separately updated to `max_recording_ms = 600000`; that file is outside the repo and is not part of this PR.

## Tests
- `git diff --check`
- `uv run ruff check .`
- `uv run -m unittest tests.test_audio_debug tests.test_dictation_session tests.test_history tests.test_settings tests.test_tray tests.test_tray_controller -v`
- `uv run python -m tests`