### PR TITLE
Close PR #32 review follow-ups: stop/start race, bucket pre-warm, AR token cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,13 @@ changes because committed audio is physically removed from the buffer.
 incremental_transcription = true        # opt-in; defaults to false
 incremental_commit_threshold_s = 10.0   # uncommitted audio that triggers a background pass
 streaming_chunk_ms = 500                # mic chunk size fed to the session
+warm_bucket_shapes_s = 16               # pre-warm NAR bucket shapes up to this length after startup (0 disables)
 ```
+
+After the service reports ready, the remaining NAR tensor-bucket shapes (4 s
+through `warm_bucket_shapes_s`, in 2 s steps) are compiled in a background
+thread that yields whenever a recording is active, so the first long utterance
+after a restart does not pay a multi-second ROCm shape compile.
 
 | Platform | Batch default | Incremental | Notes |
 |----------|---------------|-------------|-------|

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -1,4 +1,5 @@
 import unittest
+from contextlib import nullcontext
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -133,6 +134,85 @@ class ASRTests(unittest.TestCase):
         _configure_rocm_nar_attention_env(os_module, torch, "cpu")
 
         self.assertEqual(environ, {})
+
+    def test_granite_ar_scales_max_new_tokens_with_audio_length(self):
+        short = self._run_granite_ar_transcribe(audio_seconds=5)
+        long = self._run_granite_ar_transcribe(audio_seconds=300)
+
+        self.assertEqual(short["max_new_tokens"], 200)
+        self.assertEqual(long["max_new_tokens"], 3064)
+
+    def test_granite_ar_warns_when_generation_hits_token_cap(self):
+        with self.assertLogs("transclip.asr", level="WARNING") as logs:
+            result = self._run_granite_ar_transcribe(audio_seconds=5, output_tokens=200)
+
+        self.assertEqual(result["max_new_tokens"], 200)
+        self.assertIn("hit max_new_tokens=200", "\n".join(logs.output))
+
+    def _run_granite_ar_transcribe(self, *, audio_seconds, output_tokens=10):
+        class FakeModelInputs(dict):
+            def to(self, device):
+                del device
+                return self
+
+        class FakeTokens:
+            def __init__(self, length):
+                self.shape = (1, length)
+
+            def unsqueeze(self, dim):
+                del dim
+                return self
+
+        class FakeModelOutput:
+            def __init__(self, length):
+                self.length = length
+
+            def __getitem__(self, item):
+                row, token_slice = item
+                del row, token_slice
+                return FakeTokens(self.length)
+
+        class FakeModel:
+            def __init__(self):
+                self.max_new_tokens = None
+
+            def generate(self, **kwargs):
+                self.max_new_tokens = kwargs["max_new_tokens"]
+                return FakeModelOutput(output_tokens)
+
+        class FakeTokenizer:
+            def apply_chat_template(self, *args, **kwargs):
+                del args, kwargs
+                return "templated"
+
+            def batch_decode(self, *args, **kwargs):
+                del args, kwargs
+                return ["decoded transcript"]
+
+        class FakeProcessor:
+            def __call__(self, *args, **kwargs):
+                del args, kwargs
+                return FakeModelInputs({"input_ids": SimpleNamespace(shape=(1, 5))})
+
+        model = FakeModel()
+        backend = GraniteSpeechTransformersBackend("ibm-granite/granite-speech-4.1-2b")
+        backend._device = lambda: "cpu"
+        backend._loaded = (FakeProcessor(), FakeTokenizer(), model)
+        backend.audio_preparer = SimpleNamespace(
+            prepare=lambda _path: SimpleNamespace(
+                wav=SimpleNamespace(shape=(1, int(audio_seconds * 16_000))),
+                sample_rate=16_000,
+            )
+        )
+        fake_torch = SimpleNamespace(inference_mode=lambda: nullcontext())
+
+        with patch.dict("sys.modules", {"torch": fake_torch}):
+            transcript = backend.transcribe(Path("audio.wav"))
+
+        return {
+            "max_new_tokens": model.max_new_tokens,
+            "transcript": transcript.text,
+        }
 
     def test_granite_nar_pads_waveform_to_stable_bucket(self):
         waveform = np.ones(int(1.2 * 16000), dtype=np.float32)

--- a/tests/test_dictation_session.py
+++ b/tests/test_dictation_session.py
@@ -1,7 +1,10 @@
 import unittest
 from pathlib import Path
+from threading import Event, Thread
 from unittest.mock import patch
 
+from transclip.asr import TranscriptionResult
+from transclip.asr_streaming import PartialTranscript
 from transclip.service import DictationSession
 from transclip.service.streaming import StreamingDictationAdapter
 from transclip.settings import Settings
@@ -15,6 +18,37 @@ class StepClock:
 
     def __call__(self):
         return self.values.pop(0)
+
+
+class SequencedStreamingFactory:
+    def __init__(self, sessions):
+        self.sessions = list(sessions)
+
+    def __call__(self):
+        return self.sessions.pop(0)
+
+
+class BlockingStreamingASR:
+    name = "blocking-streaming"
+    model = "blocking-streaming-model"
+
+    def __init__(self, final_text):
+        self.final_text = final_text
+        self.chunks = []
+        self.closed = False
+
+    @property
+    def partial_text(self):
+        return PartialTranscript("")
+
+    def feed(self, pcm16_mono):
+        self.chunks.append(pcm16_mono)
+
+    def finish(self):
+        return TranscriptionResult(self.final_text, {}, self.name, self.model)
+
+    def close(self):
+        self.closed = True
 
 
 class DictationSessionTests(unittest.TestCase):
@@ -112,6 +146,131 @@ class DictationSessionTests(unittest.TestCase):
         result = session.stop_recording()
         self.assertEqual(result["text"], "streamed final")
         self.assertEqual(transcribe_calls, [])
+
+    def test_streaming_stop_finish_does_not_use_new_recording_session(self):
+        first_stop_entered = Event()
+        first_stop_release = Event()
+        first_streaming = BlockingStreamingASR("first transcript")
+        second_streaming = BlockingStreamingASR("second transcript")
+        factory = SequencedStreamingFactory([first_streaming, second_streaming])
+        settings = Settings(min_recording_ms=0, toggle_cooldown_ms=0)
+
+        def process_asr_result(asr_result, *, cleanup, source, **kwargs):
+            return {
+                "text": asr_result.text,
+                "raw_asr": asr_result.text,
+                "status": "ready",
+                "cleanup": {},
+                "cleanup_enabled": True,
+                "timings_ms": asr_result.timings_ms,
+            }
+
+        adapter = StreamingDictationAdapter(settings, factory, process_asr_result)
+
+        class FakeChunkedRecorder(FakeRecorder):
+            created = 0
+
+            def __init__(self, recorder_settings, *, on_chunk=None, **kwargs):
+                super().__init__(recorder_settings)
+                self.on_chunk = on_chunk
+                type(self).created += 1
+                self.index = type(self).created
+
+            def stop_capture(self):
+                if self.index == 1:
+                    first_stop_entered.set()
+                    first_stop_release.wait(timeout=2)
+                self.on_chunk(f"chunk-{self.index}".encode())
+                super().stop_capture()
+
+        session = DictationSession(
+            settings,
+            transcribe=lambda *_args: {"text": "batch should not run"},
+            streaming=adapter,
+            clock=lambda: 1.0,
+        )
+
+        with patch("transclip.service.streaming.ChunkedAudioRecorder", FakeChunkedRecorder):
+            session.start_recording()
+            stopped = {}
+
+            def stop_first():
+                stopped.update(session.stop_recording())
+
+            stop_thread = Thread(target=stop_first)
+            stop_thread.start()
+            self.assertTrue(first_stop_entered.wait(timeout=2))
+
+            session.start_recording()
+            first_stop_release.set()
+            stop_thread.join(timeout=2)
+            second_result = session.stop_recording()
+
+        self.assertEqual(stopped["text"], "first transcript")
+        self.assertEqual(second_result["text"], "second transcript")
+        self.assertEqual(first_streaming.chunks, [b"chunk-1"])
+        self.assertEqual(second_streaming.chunks, [b"chunk-2"])
+        self.assertFalse(first_streaming.closed)
+
+    def test_streaming_stop_failure_closes_detached_session(self):
+        streaming = BlockingStreamingASR("unused")
+        settings = Settings(min_recording_ms=0, toggle_cooldown_ms=0)
+        adapter = StreamingDictationAdapter(
+            settings,
+            SequencedStreamingFactory([streaming]),
+            lambda asr_result, **_kwargs: {"text": asr_result.text, "status": "ready"},
+        )
+
+        class FailingStopRecorder(FakeRecorder):
+            def __init__(self, recorder_settings, *, on_chunk=None, **kwargs):
+                super().__init__(recorder_settings)
+
+            def stop_capture(self):
+                raise RuntimeError("audio stop failed")
+
+        session = DictationSession(
+            settings,
+            transcribe=lambda *_args: {"text": "batch should not run"},
+            streaming=adapter,
+            clock=StepClock([1.0, 1.1]),
+        )
+
+        with patch("transclip.service.streaming.ChunkedAudioRecorder", FailingStopRecorder):
+            session.start_recording()
+            with self.assertRaisesRegex(RuntimeError, "audio stop failed"):
+                session.stop_recording()
+
+        self.assertTrue(streaming.closed)
+
+    def test_streaming_discard_failure_still_closes_session(self):
+        streaming = BlockingStreamingASR("unused")
+        settings = Settings(min_recording_ms=0, toggle_cooldown_ms=0)
+        adapter = StreamingDictationAdapter(
+            settings,
+            SequencedStreamingFactory([streaming]),
+            lambda asr_result, **_kwargs: {"text": asr_result.text, "status": "ready"},
+        )
+
+        class FailingDiscardRecorder(FakeRecorder):
+            def __init__(self, recorder_settings, *, on_chunk=None, **kwargs):
+                super().__init__(recorder_settings)
+
+            def discard(self):
+                raise RuntimeError("audio discard failed")
+
+        session = DictationSession(
+            settings,
+            transcribe=lambda *_args: {"text": "batch should not run"},
+            streaming=adapter,
+            clock=StepClock([1.0, 1.1]),
+        )
+
+        with patch("transclip.service.streaming.ChunkedAudioRecorder", FailingDiscardRecorder):
+            session.start_recording()
+            with self.assertRaisesRegex(RuntimeError, "audio discard failed"):
+                session.stop_recording(discard=True)
+
+        self.assertTrue(streaming.closed)
 
 
 if __name__ == "__main__":

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import tempfile
+import threading
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -11,6 +12,35 @@ from transclip.service import InferenceEngine
 from transclip.settings import Settings
 
 from tests.service_helpers import FakeASR, FakeRecorder, FakeTextBackend, http_json, serve_test_engine, stop_server
+
+
+class FakeWaveformASR(FakeASR):
+    def __init__(self):
+        super().__init__()
+        self.waveform_lengths = []
+        self.waveform_sample_rates = []
+
+    def transcribe_waveform(self, waveform, sample_rate=16000):
+        self.waveform_lengths.append(len(waveform))
+        self.waveform_sample_rates.append(sample_rate)
+        return self.transcribe(Path("waveform.wav"), keywords=[])
+
+
+class FakeStopEvent:
+    def __init__(self):
+        self.wait_calls = 0
+        self._set = False
+
+    def wait(self, timeout):
+        del timeout
+        self.wait_calls += 1
+        return self._set
+
+    def is_set(self):
+        return self._set
+
+    def set(self):
+        self._set = True
 
 
 class ServiceTests(unittest.TestCase):
@@ -66,6 +96,61 @@ class ServiceTests(unittest.TestCase):
 
         self.assertEqual(len(warm_asr.calls), 1)
         self.assertEqual(warm_asr.keywords, [])
+
+    def test_engine_warms_remaining_bucket_shapes(self):
+        asr = FakeWaveformASR()
+        engine = InferenceEngine(
+            Settings(sample_rate=16000, warm_bucket_shapes_s=8),
+            asr_backend=asr,
+            cleanup_backend=FaithfulRuleCleanupBackend(),
+        )
+
+        engine.warm_bucket_shapes(threading.Event())
+
+        self.assertEqual(asr.waveform_lengths, [64_000, 96_000, 128_000])
+        self.assertEqual(asr.waveform_sample_rates, [16_000, 16_000, 16_000])
+
+    def test_bucket_warmup_waits_while_recording(self):
+        asr = FakeWaveformASR()
+        engine = InferenceEngine(
+            Settings(sample_rate=16000, warm_bucket_shapes_s=4),
+            asr_backend=asr,
+            cleanup_backend=FaithfulRuleCleanupBackend(),
+        )
+        statuses = ["recording", "ready"]
+        engine.dictation_session.status = lambda: statuses.pop(0) if statuses else "ready"
+        stop_event = FakeStopEvent()
+
+        engine.warm_bucket_shapes(stop_event)
+
+        self.assertEqual(stop_event.wait_calls, 1)
+        self.assertEqual(asr.waveform_lengths, [64_000])
+
+    def test_bucket_warmup_exits_when_stopped(self):
+        asr = FakeWaveformASR()
+        engine = InferenceEngine(
+            Settings(sample_rate=16000, warm_bucket_shapes_s=4),
+            asr_backend=asr,
+            cleanup_backend=FaithfulRuleCleanupBackend(),
+        )
+        stop_event = threading.Event()
+        stop_event.set()
+
+        engine.warm_bucket_shapes(stop_event)
+
+        self.assertEqual(asr.waveform_lengths, [])
+
+    def test_bucket_warmup_skips_file_only_asr_backend(self):
+        asr = FakeASR()
+        engine = InferenceEngine(
+            Settings(sample_rate=16000, warm_bucket_shapes_s=4),
+            asr_backend=asr,
+            cleanup_backend=FaithfulRuleCleanupBackend(),
+        )
+
+        engine.warm_bucket_shapes(threading.Event())
+
+        self.assertEqual(asr.calls, [])
 
     def test_cleanup_text_uses_model_cleanup_when_always_on(self):
         text_backend = FakeTextBackend(["Model cleaned via /cleanup"])

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -45,7 +45,7 @@ class SettingsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "settings.toml"
             path.write_text('hotkey_linux = "Ctrl+Space"\nwat = true\n', encoding="utf-8")
-            with self.assertRaises(ValueError):
+            with self.assertRaisesRegex(ValueError, str(path)):
                 load_settings(path)
 
     def test_removed_setting_is_stripped_when_settings_are_rewritten(self):
@@ -78,31 +78,11 @@ class SettingsTests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 set_setting(path, "max_recording_seconds", "60")
 
-    def test_legacy_qwen_streaming_keys_migrate_and_drop(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "settings.toml"
-            path.write_text(
-                "qwen_streaming_chunk_ms = 400\n"
-                "qwen_streaming_chunk_size_sec = 2.0\n"
-                "qwen_streaming_unfixed_chunk_num = 2\n"
-                "qwen_streaming_unfixed_token_num = 5\n"
-                "qwen_streaming_gpu_memory_utilization = 0.8\n"
-                "qwen_streaming_max_new_tokens = 32\n",
-                encoding="utf-8",
-            )
-
-            settings = load_settings(path)
-            write_settings(settings, path)
-
-            text = path.read_text(encoding="utf-8")
-            self.assertEqual(settings.streaming_chunk_ms, 400)
-            self.assertIn("streaming_chunk_ms = 400", text)
-            self.assertNotIn("qwen_streaming", text)
-
     def test_incremental_transcription_defaults(self):
         settings = Settings()
         self.assertFalse(settings.incremental_transcription)
         self.assertEqual(settings.incremental_commit_threshold_s, 10.0)
+        self.assertEqual(settings.warm_bucket_shapes_s, 16)
         self.assertEqual(settings.streaming_chunk_ms, 500)
 
     def test_platform_helpers_have_defaults(self):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,3 +1,4 @@
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -45,7 +46,8 @@ class SettingsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "settings.toml"
             path.write_text('hotkey_linux = "Ctrl+Space"\nwat = true\n', encoding="utf-8")
-            with self.assertRaisesRegex(ValueError, str(path)):
+            # re.escape: Windows paths contain backslashes that are invalid regex escapes.
+            with self.assertRaisesRegex(ValueError, re.escape(str(path))):
                 load_settings(path)
 
     def test_removed_setting_is_stripped_when_settings_are_rewritten(self):

--- a/transclip/asr.py
+++ b/transclip/asr.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import math
 import platform as py_platform
 import tempfile
@@ -19,6 +20,11 @@ from .models import (
 )
 from .settings import Settings
 from .timing import timed_ms
+
+logger = logging.getLogger(__name__)
+
+AR_TOKENS_PER_AUDIO_SECOND = 10
+AR_MIN_NEW_TOKENS = 200
 
 
 @dataclass(slots=True)
@@ -164,6 +170,11 @@ class GraniteSpeechTransformersBackend:
 
             processor, tokenizer, model = self._load(device)
             audio = self.audio_preparer.prepare(wav_path)
+            audio_seconds = audio.wav.shape[-1] / audio.sample_rate
+            max_new_tokens = max(
+                AR_MIN_NEW_TOKENS,
+                int(audio_seconds * AR_TOKENS_PER_AUDIO_SECOND) + 64,
+            )
             prompt = granite_user_prompt(keywords)
             chat = [{"role": "user", "content": f"<|audio|>{prompt}"}]
             templated = tokenizer.apply_chat_template(
@@ -180,12 +191,18 @@ class GraniteSpeechTransformersBackend:
             with torch.inference_mode():
                 model_outputs = model.generate(
                     **model_inputs,
-                    max_new_tokens=200,
+                    max_new_tokens=max_new_tokens,
                     do_sample=False,
                     num_beams=1,
                 )
             num_input_tokens = model_inputs["input_ids"].shape[-1]
             new_tokens = model_outputs[0, num_input_tokens:].unsqueeze(0)
+            if new_tokens.shape[-1] >= max_new_tokens:
+                logger.warning(
+                    "AR generation hit max_new_tokens=%d for %.0fs of audio; transcript may be truncated",
+                    max_new_tokens,
+                    audio_seconds,
+                )
             decoded = tokenizer.batch_decode(
                 new_tokens,
                 add_special_tokens=False,
@@ -195,6 +212,7 @@ class GraniteSpeechTransformersBackend:
 
 
 GRANITE_NAR_SAMPLE_RATE = 16000
+GRANITE_NAR_BUCKET_SECONDS = 2.0
 
 
 class GraniteSpeechNarTransformersBackend:
@@ -381,7 +399,11 @@ def build_asr_backend(
     return backend
 
 
-def _pad_nar_waveform_to_bucket(waveform: Any, sample_rate: int, bucket_seconds: float = 2.0) -> Any:
+def _pad_nar_waveform_to_bucket(
+    waveform: Any,
+    sample_rate: int,
+    bucket_seconds: float = GRANITE_NAR_BUCKET_SECONDS,
+) -> Any:
     """Pad NAR inputs to stable tensor buckets to avoid first-use shape compiles."""
     bucket_samples = max(1, int(sample_rate * bucket_seconds))
     length = int(waveform.shape[-1] if hasattr(waveform, "shape") else len(waveform))

--- a/transclip/asr_incremental.py
+++ b/transclip/asr_incremental.py
@@ -15,7 +15,7 @@ import threading
 from collections.abc import Callable
 from typing import Any
 
-from transclip.asr import TranscriptionResult
+from transclip.asr import GRANITE_NAR_BUCKET_SECONDS, TranscriptionResult
 from transclip.asr_streaming import PartialTranscript
 from transclip.audio import pcm16_to_float32
 from transclip.platform.runtime import PlatformRuntime
@@ -23,7 +23,7 @@ from transclip.settings import Settings
 
 # ROCm/Triton recompiles novel tensor shapes at 1.9-8.7 s; padding audio with
 # trailing silence to fixed bucket multiples keeps pass times stable.
-BUCKET_S = 2.0
+BUCKET_S = GRANITE_NAR_BUCKET_SECONDS
 # Never commit into the most recent audio; the model needs trailing context.
 COMMIT_MIN_TAIL_S = 2.0
 # Only cut at silences so a commit boundary cannot split a word.

--- a/transclip/service/engine.py
+++ b/transclip/service/engine.py
@@ -4,8 +4,14 @@ import logging
 import tempfile
 from pathlib import Path
 from time import perf_counter
+from typing import Any, Protocol
 
-from transclip.asr import ASRBackend, TranscriptionResult, build_asr_backend
+from transclip.asr import (
+    GRANITE_NAR_BUCKET_SECONDS,
+    ASRBackend,
+    TranscriptionResult,
+    build_asr_backend,
+)
 from transclip.asr_incremental import IncrementalNarSession, incremental_transcription_enabled
 from transclip.audio import AudioRecorder, write_wav
 from transclip.best_effort import best_effort
@@ -34,6 +40,16 @@ from .types import (
     ServiceHealthResponse,
     TranscribeResponse,
 )
+
+
+class StopSignal(Protocol):
+    def wait(self, timeout: float) -> bool: ...
+
+    def is_set(self) -> bool: ...
+
+
+class WaveformTranscriber(Protocol):
+    def __call__(self, waveform: Any, sample_rate: int = 16000) -> TranscriptionResult: ...
 
 
 class InferenceEngine:
@@ -179,6 +195,33 @@ class InferenceEngine:
             wav_path = write_wav(Path(tmp) / "warmup.wav", pcm16_silence, sample_rate)
             self.asr_backend.transcribe(wav_path, keywords=[])
 
+    def warm_bucket_shapes(self, stop_event: StopSignal) -> None:
+        """Compile remaining NAR bucket shapes in the background after readiness."""
+        transcribe_waveform = _waveform_transcriber(self.asr_backend)
+        max_seconds = max(0, int(self.settings.warm_bucket_shapes_s))
+        if transcribe_waveform is None or max_seconds <= 0:
+            return
+
+        import numpy as np
+
+        logger = logging.getLogger(__name__)
+        sample_rate = max(1, self.settings.sample_rate)
+        for seconds in _bucket_warm_seconds(max_seconds):
+            while self.dictation_session.status() == "recording":
+                if stop_event.wait(1.0):
+                    return
+            if stop_event.is_set():
+                return
+            try:
+                transcribe_waveform(
+                    np.zeros(seconds * sample_rate, dtype=np.float32),
+                    sample_rate=sample_rate,
+                )
+                logger.info("Pre-warmed ASR bucket shape at %ss", seconds)
+            except Exception:
+                logger.exception("Bucket pre-warm failed at %ss; aborting pre-warm", seconds)
+                return
+
     def process_asr_result(
         self,
         asr_result: TranscriptionResult,
@@ -253,7 +296,7 @@ class InferenceEngine:
     def _build_incremental_adapter(self) -> StreamingDictationAdapter | None:
         if not incremental_transcription_enabled(self.settings):
             return None
-        transcribe_waveform = getattr(self.asr_backend, "transcribe_waveform", None)
+        transcribe_waveform = _waveform_transcriber(self.asr_backend)
         if transcribe_waveform is None:
             return None
         settings = self.settings
@@ -274,6 +317,18 @@ class InferenceEngine:
             )
 
         return StreamingDictationAdapter(settings, session_factory, self.process_asr_result)
+
+
+def _waveform_transcriber(backend: ASRBackend) -> WaveformTranscriber | None:
+    transcribe_waveform = getattr(backend, "transcribe_waveform", None)
+    if not callable(transcribe_waveform):
+        return None
+    return transcribe_waveform
+
+
+def _bucket_warm_seconds(max_seconds: int) -> range:
+    bucket_step_s = max(1, int(GRANITE_NAR_BUCKET_SECONDS))
+    return range(bucket_step_s * 2, max_seconds + 1, bucket_step_s)
 
 
 def _with_optional_history(

--- a/transclip/service/server.py
+++ b/transclip/service/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ipaddress
 import json
+import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 from urllib.parse import urlsplit
@@ -12,6 +13,32 @@ from .engine import InferenceEngine
 from .routes import dispatch_get, dispatch_post
 
 _LOOPBACK_HOSTNAMES = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+class TransclipHTTPServer(ThreadingHTTPServer):
+    def __init__(
+        self,
+        server_address: tuple[str, int],
+        request_handler: type[BaseHTTPRequestHandler],
+        bind_and_activate: bool = True,
+    ):
+        super().__init__(server_address, request_handler, bind_and_activate)
+        self._shutdown_events: list[threading.Event] = []
+
+    def add_shutdown_event(self, event: threading.Event) -> None:
+        self._shutdown_events.append(event)
+
+    def shutdown(self) -> None:
+        self._signal_shutdown_events()
+        super().shutdown()
+
+    def server_close(self) -> None:
+        self._signal_shutdown_events()
+        super().server_close()
+
+    def _signal_shutdown_events(self) -> None:
+        for event in self._shutdown_events:
+            event.set()
 
 
 def _hostname(value: str, *, has_scheme: bool) -> str | None:
@@ -132,7 +159,16 @@ def create_server(
             self.send_header("access-control-allow-methods", "GET, POST, OPTIONS")
             self.send_header("access-control-allow-headers", "content-type")
 
-    return ThreadingHTTPServer((settings.host, settings.port), Handler)
+    stop_event = threading.Event()
+    server = TransclipHTTPServer((settings.host, settings.port), Handler)
+    server.add_shutdown_event(stop_event)
+    threading.Thread(
+        target=active_engine.warm_bucket_shapes,
+        args=(stop_event,),
+        name="transclip-bucket-warm",
+        daemon=True,
+    ).start()
+    return server
 
 
 def run_server(settings: Settings | None = None) -> None:

--- a/transclip/service/session.py
+++ b/transclip/service/session.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import tempfile
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock
 from time import perf_counter
@@ -11,7 +12,7 @@ from transclip.asr_streaming import PartialTranscript
 from transclip.audio import AudioRecorder
 from transclip.settings import Settings
 
-from .streaming import StreamingDictationAdapter
+from .streaming import StreamingCapture, StreamingDictationAdapter
 from .types import RecordSessionResponse, TranscribeResponse
 
 
@@ -30,6 +31,90 @@ Transcriber = Callable[[Path, bool | None, str], TranscribeResponse]
 Clock = Callable[[], float]
 
 
+class RecordingHandle(Protocol):
+    def start(self) -> None: ...
+
+    def stop(
+        self,
+        *,
+        cleanup: bool | None,
+        source: str,
+    ) -> TranscribeResponse: ...
+
+    def discard(self) -> None: ...
+
+
+@dataclass(slots=True)
+class BatchRecording:
+    recorder: Recorder
+    transcribe: Transcriber
+
+    def start(self) -> None:
+        self.recorder.start()
+
+    def stop(
+        self,
+        *,
+        cleanup: bool | None,
+        source: str,
+    ) -> TranscribeResponse:
+        with tempfile.TemporaryDirectory() as tmp:
+            wav_path = self.recorder.stop_to_wav(Path(tmp) / "recording.wav")
+            return self.transcribe(wav_path, cleanup, source)
+
+    def discard(self) -> None:
+        self.recorder.discard()
+
+
+@dataclass(slots=True)
+class StreamingRecording:
+    adapter: StreamingDictationAdapter
+    capture: StreamingCapture
+    debug_capture: bool
+
+    def start(self) -> None:
+        try:
+            self.capture.recorder.start()
+        except Exception:
+            self.adapter.discard_session(self.capture.session)
+            raise
+
+    def stop(
+        self,
+        *,
+        cleanup: bool | None,
+        source: str,
+    ) -> TranscribeResponse:
+        self.adapter.detach_session(self.capture.session)
+        try:
+            if self.debug_capture:
+                with tempfile.TemporaryDirectory() as tmp:
+                    wav_path = self.capture.recorder.stop_to_wav(Path(tmp) / "recording.wav")
+                    return self.adapter.finish_session(
+                        self.capture.session,
+                        cleanup,
+                        source,
+                        wav_path=wav_path,
+                    )
+            self.capture.recorder.stop_capture()
+            return self.adapter.finish_session(self.capture.session, cleanup, source)
+        except Exception:
+            self.adapter.discard_session(self.capture.session)
+            raise
+
+    def discard(self) -> None:
+        try:
+            self.capture.recorder.discard()
+        finally:
+            self.adapter.discard_session(self.capture.session)
+
+
+@dataclass(slots=True)
+class ActiveRecording:
+    handle: RecordingHandle
+    started_at: float
+
+
 class DictationSession:
     def __init__(
         self,
@@ -45,13 +130,12 @@ class DictationSession:
         self._streaming = streaming
         self._clock = clock
         self._lock = Lock()
-        self._recorder: Recorder | None = None
-        self._recording_started_at = 0.0
+        self._active: ActiveRecording | None = None
         self._last_toggle_accepted_at = 0.0
 
     def status(self) -> str:
         with self._lock:
-            return "recording" if self._recorder else "ready"
+            return "recording" if self._active else "ready"
 
     def partial_text(self) -> PartialTranscript:
         if self._streaming is None:
@@ -60,12 +144,11 @@ class DictationSession:
 
     def start_recording(self) -> RecordSessionResponse:
         with self._lock:
-            if self._recorder is not None:
+            if self._active is not None:
                 return {"status": "recording", "already_recording": True}
-            recorder = self._create_recorder()
-            self._start_or_cleanup(recorder)
-            self._recorder = recorder
-            self._recording_started_at = self._clock()
+            handle = self._create_recording()
+            handle.start()
+            self._active = ActiveRecording(handle, self._clock())
         return {"status": "recording", "already_recording": False}
 
     def stop_recording(
@@ -75,15 +158,9 @@ class DictationSession:
         source: str = "/record/stop",
     ) -> RecordSessionResponse:
         with self._lock:
-            if self._recorder is None:
-                raise RuntimeError("Recorder is not running")
-            recorder = self._recorder
-            started_at = self._recording_started_at
-            self._recorder = None
-            self._recording_started_at = 0.0
+            active = self._pop_active()
         return self._finish_recording(
-            recorder,
-            started_at,
+            active,
             cleanup=cleanup,
             discard=discard,
             source=source,
@@ -102,33 +179,28 @@ class DictationSession:
                 and now - self._last_toggle_accepted_at < cooldown_seconds
             ):
                 return {
-                    "status": "recording" if self._recorder is not None else "ready",
+                    "status": "recording" if self._active is not None else "ready",
                     "action": "ignored",
                     "reason": "toggle_cooldown",
                     "cooldown_ms": self.settings.toggle_cooldown_ms,
                 }
             self._last_toggle_accepted_at = now
-            if self._recorder is None:
-                recorder = self._create_recorder()
-                self._start_or_cleanup(recorder)
-                self._recorder = recorder
-                self._recording_started_at = now
+            if self._active is None:
+                handle = self._create_recording()
+                handle.start()
+                self._active = ActiveRecording(handle, now)
                 return {"status": "recording", "action": "started", "already_recording": False}
 
-            recorder = self._recorder
-            started_at = self._recording_started_at
-            self._recorder = None
-            self._recording_started_at = 0.0
+            active = self._pop_active()
 
-        duration_ms = (self._clock() - started_at) * 1000
+        duration_ms = (self._clock() - active.started_at) * 1000
         over_maximum = (
             self.settings.max_recording_ms > 0
             and duration_ms > self.settings.max_recording_ms
         )
         discard = duration_ms < self.settings.min_recording_ms or over_maximum
         result = self._finish_recording(
-            recorder,
-            started_at,
+            active,
             cleanup=cleanup,
             discard=discard,
             discard_reason="max_recording_duration" if over_maximum else None,
@@ -140,51 +212,42 @@ class DictationSession:
 
     def _finish_recording(
         self,
-        recorder: Recorder,
-        started_at: float,
+        active: ActiveRecording,
         *,
         cleanup: bool | None,
         discard: bool,
         discard_reason: str | None = None,
         source: str,
     ) -> RecordSessionResponse:
-        duration_ms = round((self._clock() - started_at) * 1000, 3)
+        duration_ms = round((self._clock() - active.started_at) * 1000, 3)
         if discard:
-            recorder.discard()
-            if self._streaming is not None:
-                self._streaming.on_discard()
+            active.handle.discard()
             result: RecordSessionResponse = {"status": "ready", "duration_ms": duration_ms, "discarded": True}
             if discard_reason:
                 result["reason"] = discard_reason
                 result["max_recording_ms"] = self.settings.max_recording_ms
             return result
-        if self._streaming is not None:
-            if self.settings.debug_capture:
-                with tempfile.TemporaryDirectory() as tmp:
-                    wav_path = recorder.stop_to_wav(Path(tmp) / "recording.wav")
-                    result = dict(self._streaming.finish_transcription(cleanup, source, wav_path=wav_path))
-            else:
-                recorder.stop_capture()
-                result = dict(self._streaming.finish_transcription(cleanup, source))
-        else:
-            with tempfile.TemporaryDirectory() as tmp:
-                wav_path = recorder.stop_to_wav(Path(tmp) / "recording.wav")
-                result = dict(self._transcribe(wav_path, cleanup, source))
+        result = dict(
+            active.handle.stop(
+                cleanup=cleanup,
+                source=source,
+            )
+        )
         result["duration_ms"] = duration_ms
         return result
 
-    def _create_recorder(self) -> Recorder:
-        if self._streaming is not None:
-            return self._streaming.create_recorder()
-        return self._recorder_factory(self.settings)
+    def _pop_active(self) -> ActiveRecording:
+        if self._active is None:
+            raise RuntimeError("Recorder is not running")
+        active = self._active
+        self._active = None
+        return active
 
-    def _start_or_cleanup(self, recorder: Recorder) -> None:
-        # create_recorder may have installed a streaming session (with a live
-        # worker thread); if the mic fails to start, close it instead of
-        # leaking one orphaned session per retry.
-        try:
-            recorder.start()
-        except Exception:
-            if self._streaming is not None:
-                self._streaming.on_discard()
-            raise
+    def _create_recording(self) -> RecordingHandle:
+        if self._streaming is not None:
+            return StreamingRecording(
+                self._streaming,
+                self._streaming.create_recording(),
+                self.settings.debug_capture,
+            )
+        return BatchRecording(self._recorder_factory(self.settings), self._transcribe)

--- a/transclip/service/streaming.py
+++ b/transclip/service/streaming.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock
 from time import perf_counter
@@ -11,6 +13,14 @@ from transclip.audio import ChunkedAudioRecorder
 from transclip.settings import Settings
 
 from .types import TranscribeResponse
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class StreamingCapture:
+    recorder: ChunkedAudioRecorder
+    session: StreamingASRSession
 
 
 class ProcessAsrResult(Protocol):
@@ -40,36 +50,40 @@ class StreamingDictationAdapter:
         self._session_factory = session_factory
         self._process_asr_result = process_asr_result
         self._lock = Lock()
-        self._session: StreamingASRSession | None = None
+        self._current: StreamingASRSession | None = None
 
-    def create_recorder(self) -> ChunkedAudioRecorder:
+    def create_recording(self) -> StreamingCapture:
+        session = self._session_factory()
         with self._lock:
-            previous = self._session
-            self._session = self._session_factory()
+            previous = self._current
+            self._current = session
         if previous is not None:
             # A leftover session means the prior recording never finished
             # cleanly; close it so its worker thread does not leak.
+            logger.warning("Closing leftover streaming session before starting a new recording")
             previous.close()
-        return ChunkedAudioRecorder(self._settings, on_chunk=self._feed_chunk)
+        return StreamingCapture(ChunkedAudioRecorder(self._settings, on_chunk=session.feed), session)
 
     def partial_text(self) -> PartialTranscript:
         with self._lock:
-            session = self._session
+            session = self._current
             if session is None:
                 return PartialTranscript("")
             return session.partial_text
 
-    def finish_transcription(
+    def detach_session(self, session: StreamingASRSession) -> None:
+        with self._lock:
+            if self._current is session:
+                self._current = None
+
+    def finish_session(
         self,
+        session: StreamingASRSession,
         cleanup: bool | None,
         source: str,
         wav_path: Path | None = None,
     ) -> TranscribeResponse:
-        with self._lock:
-            session = self._session
-            self._session = None
-        if session is None:
-            raise RuntimeError("Streaming session is not active")
+        self.detach_session(session)
         start = perf_counter()
         asr_result = session.finish()
         return self._process_asr_result(
@@ -80,15 +94,6 @@ class StreamingDictationAdapter:
             wav_path=wav_path,
         )
 
-    def on_discard(self) -> None:
-        with self._lock:
-            session = self._session
-            self._session = None
-        if session is not None:
-            session.close()
-
-    def _feed_chunk(self, pcm16_mono: bytes) -> None:
-        with self._lock:
-            session = self._session
-        if session is not None:
-            session.feed(pcm16_mono)
+    def discard_session(self, session: StreamingASRSession) -> None:
+        self.detach_session(session)
+        session.close()

--- a/transclip/settings.py
+++ b/transclip/settings.py
@@ -43,6 +43,7 @@ class Settings:
     asr_device: str = "auto"
     incremental_transcription: bool = False
     incremental_commit_threshold_s: float = 10.0
+    warm_bucket_shapes_s: int = 16
     streaming_chunk_ms: int = 500
     sample_rate: int = 16000
     host: str = "127.0.0.1"
@@ -94,21 +95,10 @@ def load_settings(path: Path | None = None, runtime: PlatformRuntime | None = No
     legacy_max_recording_seconds = data.pop("max_recording_seconds", None)
     if legacy_max_recording_seconds is not None and "max_recording_ms" not in data:
         data["max_recording_ms"] = int(float(legacy_max_recording_seconds) * 1000)
-    legacy_chunk_ms = data.pop("qwen_streaming_chunk_ms", None)
-    if legacy_chunk_ms is not None and "streaming_chunk_ms" not in data:
-        data["streaming_chunk_ms"] = int(legacy_chunk_ms)
-    for legacy_key in (
-        "qwen_streaming_chunk_size_sec",
-        "qwen_streaming_unfixed_chunk_num",
-        "qwen_streaming_unfixed_token_num",
-        "qwen_streaming_gpu_memory_utilization",
-        "qwen_streaming_max_new_tokens",
-    ):
-        data.pop(legacy_key, None)
     allowed = {field.name for field in fields(Settings)}
     unknown = sorted(set(data) - allowed)
     if unknown:
-        raise ValueError(f"Unknown settings field(s): {', '.join(unknown)}")
+        raise ValueError(f"Unknown settings field(s) in {path}: {', '.join(unknown)}")
     settings = Settings(**data)
     return settings
 
@@ -146,6 +136,7 @@ def settings_to_toml(settings: Settings) -> str:
             "asr_device",
             "incremental_transcription",
             "incremental_commit_threshold_s",
+            "warm_bucket_shapes_s",
             "streaming_chunk_ms",
             "sample_rate",
             "host",


### PR DESCRIPTION
Implements `plans/2026-06-12-post-merge-followups.md` — the four findings confirmed in the PR #32 review but deferred from the merge.

## Stop→start race (correctness)
Streaming sessions are now keyed to their recording instead of a shared adapter slot. `DictationSession` holds a `RecordingHandle` (`BatchRecording` / `StreamingRecording`); the recorder's `on_chunk` binds directly to its own session's `feed`, and `finish_session()` finishes exactly the session the recording started with. Cross-talk between an in-flight finish and a new recording is now structurally impossible — covered by a threading test that blocks the first stop mid-flight, starts a second recording, and asserts both transcripts and both chunk streams stay correctly attributed.

## Multi-bucket pre-warm (latency)
`warm_asr()` only compiled the 2s bucket shape, so the first >2s utterance after every restart still paid a 1.9–8.7s ROCm shape recompile. After the socket binds, a background thread now compiles the 4s..`warm_bucket_shapes_s` (default 16) shapes, yielding whenever a recording is active, and exits on server shutdown via an event wired into `TransclipHTTPServer`. The bucket size is a single shared constant (`GRANITE_NAR_BUCKET_SECONDS`) instead of two independent literals.

## AR max_new_tokens (correctness, Windows/CPU default path)
`max_new_tokens=200` (from IBM's example code) silently truncated AR output past ~1.5 minutes. It now scales with audio duration (10 tok/s + margin, floor 200) and logs a warning when generation hits the cap.

## qwen_streaming_* migration retired
The keys never existed in any shipped commit; the one live config that had them has been cleaned. The unknown-settings error now names the offending file path.

Tests: 341 pass (`uv run python -m tests`), ruff clean. README documents the new setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)