### PR TITLE
[codex] Re-enable disabled macOS event tap

### DIFF
--- a/tests/test_macos_hotkey.py
+++ b/tests/test_macos_hotkey.py
@@ -72,6 +72,10 @@ class MacOSHotkeyTests(unittest.TestCase):
         self.assertIn("return .labelColor", source)
         self.assertIn("postCommandV", source)
         self.assertIn('writeStateFile("finished", "Pasted")', source)
+        self.assertIn("var activeEventTap: CFMachPort?", source)
+        self.assertIn("activeEventTap = eventTap", source)
+        self.assertIn("CGEvent.tapEnable(tap: tap, enable: true)", source)
+        self.assertIn("event tap re-enabled", source)
         self.assertIn("event tap listening for Option+Space", source)
 
     def test_installer_writes_helper_app_launch_agent_and_wrapper(self):

--- a/transclip/desktop/hotkey/macos.py
+++ b/transclip/desktop/hotkey/macos.py
@@ -471,9 +471,22 @@ if !trusted {
     hotkeyStatus.setStatus("error", "Accessibility required")
 }
 
+var activeEventTap: CFMachPort?
+
+func reenableEventTap() {
+    guard let tap = activeEventTap else {
+        log("event tap re-enable skipped; no active tap")
+        return
+    }
+
+    CGEvent.tapEnable(tap: tap, enable: true)
+    log("event tap re-enabled")
+}
+
 let callback: CGEventTapCallBack = { _, type, event, _ in
     if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
         log("event tap disabled type=\\(type.rawValue)")
+        reenableEventTap()
         return Unmanaged.passUnretained(event)
     }
 
@@ -511,6 +524,7 @@ guard let eventTap = CGEvent.tapCreate(
     exit(0)
 }
 
+activeEventTap = eventTap
 let runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
 CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
 CGEvent.tapEnable(tap: eventTap, enable: true)


### PR DESCRIPTION
## Summary

Fixes the macOS hotkey helper getting stuck after macOS disables its event tap. The helper now keeps a reference to the active `CGEvent` tap and re-enables it when it receives `.tapDisabledByTimeout` or `.tapDisabledByUserInput`.

## Root Cause

`TransClipHotkey` could remain running while its event tap was disabled by macOS. In that state the menu-bar helper looked alive, but `Option+Space` no longer reached TransClip until the LaunchAgent was restarted.

## Impact

This should make the native macOS `Option+Space` hotkey recover automatically instead of silently doing nothing after macOS disables the event tap.

## Validation

- `uv run -m unittest tests.test_macos_hotkey -v`
- `uv run ruff check transclip/desktop/hotkey/macos.py tests/test_macos_hotkey.py`
- `uv run ruff format --check transclip/desktop/hotkey/macos.py tests/test_macos_hotkey.py`
- `uv run python -m tests` (`347 tests`)