### PR TITLE
[codex] Re-enable macOS event tap and speed up dictation latency

### DIFF
--- a/scripts/bench_audio_recorder_start.py
+++ b/scripts/bench_audio_recorder_start.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from collections import Counter
+from types import SimpleNamespace
+from typing import Any, ClassVar
+
+from transclip.audio import AudioRecorder
+from transclip.settings import Settings
+
+
+class FakeInputStream:
+    instances: ClassVar[list[FakeInputStream]] = []
+    fail_default = False
+
+    def __init__(self, **kwargs: Any):
+        if self.fail_default and "device" not in kwargs:
+            raise RuntimeError("default input failed")
+        self.kwargs = kwargs
+        self.started = False
+        self.stopped = False
+        self.closed = False
+        self.instances.append(self)
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeSoundDevice:
+    default = SimpleNamespace(device=[None, 2])
+    InputStream = FakeInputStream
+    query_delay_s = 0.0
+    query_calls = 0
+
+    @classmethod
+    def query_devices(cls, device=None, kind=None):
+        del kind
+        cls.query_calls += 1
+        if cls.query_delay_s:
+            time.sleep(cls.query_delay_s)
+        devices = [
+            {"name": "MacBook Microphone", "max_input_channels": 1},
+            {"name": "Display Audio", "max_input_channels": 0},
+            {"name": "USB Microphone", "max_input_channels": 1},
+        ]
+        if device is None:
+            return devices
+        return devices[int(device)]
+
+
+def _stats(values: list[float]) -> dict[str, float]:
+    ordered = sorted(values)
+    p90_index = min(len(ordered) - 1, round((len(ordered) - 1) * 0.9))
+    return {
+        "min": round(ordered[0], 3),
+        "median": round(statistics.median(ordered), 3),
+        "mean": round(statistics.fmean(ordered), 3),
+        "p90": round(ordered[p90_index], 3),
+        "max": round(ordered[-1], 3),
+    }
+
+
+def run_benchmark(repetitions: int, warmups: int, query_delay_ms: float, fail_default: bool) -> dict[str, Any]:
+    previous_numpy = sys.modules.get("numpy")
+    previous_sounddevice = sys.modules.get("sounddevice")
+    FakeSoundDevice.query_delay_s = query_delay_ms / 1000
+    FakeSoundDevice.query_calls = 0
+    FakeInputStream.instances = []
+    FakeInputStream.fail_default = fail_default
+    sys.modules["numpy"] = SimpleNamespace(int16="int16")
+    sys.modules["sounddevice"] = FakeSoundDevice
+    try:
+        elapsed_ms: list[float] = []
+        total_runs = repetitions + warmups
+        for index in range(total_runs):
+            recorder = AudioRecorder(Settings())
+            started = time.perf_counter_ns()
+            recorder.start()
+            ended = time.perf_counter_ns()
+            recorder.discard()
+            if index >= warmups:
+                elapsed_ms.append((ended - started) / 1_000_000)
+        devices = [str(stream.kwargs.get("device", "default")) for stream in FakeInputStream.instances[warmups:]]
+        return {
+            "repetitions": repetitions,
+            "warmups": warmups,
+            "query_delay_ms": query_delay_ms,
+            "fail_default": fail_default,
+            "query_devices_calls": FakeSoundDevice.query_calls,
+            "opened_device_counts": dict(Counter(devices)),
+            "recorder_start_ms": _stats(elapsed_ms),
+        }
+    finally:
+        if previous_numpy is None:
+            sys.modules.pop("numpy", None)
+        else:
+            sys.modules["numpy"] = previous_numpy
+        if previous_sounddevice is None:
+            sys.modules.pop("sounddevice", None)
+        else:
+            sys.modules["sounddevice"] = previous_sounddevice
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Benchmark AudioRecorder.start with faked sounddevice latency.")
+    parser.add_argument("--repetitions", type=int, default=100)
+    parser.add_argument("--warmups", type=int, default=10)
+    parser.add_argument("--query-delay-ms", type=float, default=5.0)
+    parser.add_argument("--fail-default", action="store_true")
+    args = parser.parse_args()
+    if args.repetitions <= 0:
+        raise SystemExit("--repetitions must be positive")
+    if args.warmups < 0:
+        raise SystemExit("--warmups must be non-negative")
+    print(
+        json.dumps(
+            run_benchmark(args.repetitions, args.warmups, args.query_delay_ms, args.fail_default),
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_macos_hotkey_latency.py
+++ b/scripts/bench_macos_hotkey_latency.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import shutil
+import statistics
+import subprocess
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+from transclip.desktop.hotkey.macos import build_macos_toggle_wrapper
+from transclip.settings import Settings
+
+
+@dataclass(frozen=True, slots=True)
+class RequestEvent:
+    method: str
+    path: str
+    ns: int
+
+
+class BenchRuntime:
+    def __init__(self, home: Path):
+        self._home = home
+
+    def system(self) -> str:
+        return "Darwin"
+
+    def home_dir(self) -> Path:
+        return self._home
+
+    def environ(self, name: str, default: str | None = None) -> str | None:
+        return os.environ.get(name, default)
+
+    def env_snapshot(self, names=()) -> dict[str, str]:
+        return {name: os.environ.get(name, "") for name in names}
+
+    def which(self, program: str) -> str | None:
+        return shutil.which(program)
+
+    def run(self, command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(command, **kwargs)
+
+    def check_output(self, command: list[str], **kwargs: Any) -> str:
+        kwargs.setdefault("text", True)
+        output = subprocess.check_output(command, **kwargs)
+        return output.decode() if isinstance(output, bytes) else output
+
+
+class FakeTransClipService(ThreadingHTTPServer):
+    def __init__(self):
+        super().__init__(("127.0.0.1", 0), FakeTransClipHandler)
+        self.events: list[RequestEvent] = []
+        self._events_lock = threading.Lock()
+        self.state = "ready"
+
+    def reset(self, state: str) -> None:
+        with self._events_lock:
+            self.events = []
+        self.state = state
+
+    def record_event(self, method: str, path: str) -> None:
+        with self._events_lock:
+            self.events.append(RequestEvent(method, path, time.perf_counter_ns()))
+
+    def snapshot_events(self) -> list[RequestEvent]:
+        with self._events_lock:
+            return list(self.events)
+
+
+class FakeTransClipHandler(BaseHTTPRequestHandler):
+    server: FakeTransClipService
+
+    def do_GET(self) -> None:
+        path = urlsplit(self.path).path
+        self.server.record_event("GET", path)
+        if path == "/health":
+            self._json(200, {"status": self.server.state})
+            return
+        self._json(404, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        path = urlsplit(self.path).path
+        length = int(self.headers.get("content-length", "0"))
+        if length:
+            self.rfile.read(length)
+        self.server.record_event("POST", path)
+        if path == "/record/start":
+            if self.server.state == "recording":
+                self._json(200, {"status": "recording", "already_recording": True})
+                return
+            self.server.state = "recording"
+            self._json(200, {"status": "recording", "already_recording": False})
+            return
+        if path == "/record/stop":
+            self.server.state = "ready"
+            self._json(200, {"status": "ready", "text": "bench transcript"})
+            return
+        if path == "/record/toggle":
+            if self.server.state == "recording":
+                self.server.state = "ready"
+                self._json(200, {"status": "ready", "action": "stopped", "text": "bench transcript"})
+                return
+            self.server.state = "recording"
+            self._json(200, {"status": "recording", "action": "started", "already_recording": False})
+            return
+        self._json(404, {"error": "not found"})
+
+    def log_message(self, _format: str, *_args: Any) -> None:
+        return
+
+    def _json(self, status: int, payload: dict[str, Any]) -> None:
+        encoded = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+def _stats(values: list[float]) -> dict[str, float]:
+    ordered = sorted(values)
+    p90_index = min(len(ordered) - 1, round((len(ordered) - 1) * 0.9))
+    return {
+        "min": round(ordered[0], 3),
+        "median": round(statistics.median(ordered), 3),
+        "mean": round(statistics.fmean(ordered), 3),
+        "p90": round(ordered[p90_index], 3),
+        "max": round(ordered[-1], 3),
+    }
+
+
+def _write_wrapper(path: Path, script: str, lock_path: Path) -> None:
+    safe_script = script.replace("LOCK=/tmp/transclip-toggle.lock", f"LOCK={shlex.quote(str(lock_path))}")
+    path.write_text(safe_script, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _write_fake_pbcopy(path: Path) -> None:
+    path.write_text("#!/bin/sh\ncat >/dev/null\nexit 0\n", encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _first_record_event(events: list[RequestEvent]) -> RequestEvent | None:
+    for event in events:
+        if event.method == "POST" and event.path in {"/record/start", "/record/stop", "/record/toggle"}:
+            return event
+    return None
+
+
+def _first_state_change_event(events: list[RequestEvent], scenario: str) -> RequestEvent | None:
+    target_paths = {"/record/start", "/record/toggle"} if scenario == "start" else {"/record/stop", "/record/toggle"}
+    for event in events:
+        if event.method == "POST" and event.path in target_paths:
+            return event
+    return None
+
+
+def run_benchmark(repetitions: int, warmups: int, scenario: str, timeout: float) -> dict[str, Any]:
+    if shutil.which("curl") is None:
+        raise RuntimeError("curl is required to benchmark the generated macOS wrapper")
+
+    with tempfile.TemporaryDirectory(prefix="transclip-hotkey-bench-") as tmp:
+        root = Path(tmp)
+        fake_bin = root / "bin"
+        fake_bin.mkdir()
+        _write_fake_pbcopy(fake_bin / "pbcopy")
+
+        service = FakeTransClipService()
+        thread = threading.Thread(target=service.serve_forever, daemon=True)
+        thread.start()
+        host, port = service.server_address
+
+        try:
+            runtime = BenchRuntime(root / "home")
+            wrapper = root / "transclip-toggle"
+            _write_wrapper(
+                wrapper,
+                build_macos_toggle_wrapper(Settings(host=host, port=port), runtime=runtime),
+                root / "transclip-toggle.lock",
+            )
+            env = os.environ.copy()
+            env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+
+            record_latencies_ms: list[float] = []
+            state_change_latencies_ms: list[float] = []
+            wrapper_runtime_ms: list[float] = []
+            request_counts: dict[str, int] = {}
+            total_runs = warmups + repetitions
+            initial_state = "recording" if scenario == "stop" else "ready"
+
+            for index in range(total_runs):
+                service.reset(initial_state)
+                started_ns = time.perf_counter_ns()
+                completed = subprocess.run(
+                    [str(wrapper)],
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                    check=False,
+                )
+                ended_ns = time.perf_counter_ns()
+                if completed.returncode != 0:
+                    raise RuntimeError(
+                        f"wrapper exited {completed.returncode}: "
+                        f"stdout={completed.stdout!r} stderr={completed.stderr!r}"
+                    )
+                events = service.snapshot_events()
+                first_record = _first_record_event(events)
+                if first_record is None:
+                    raise RuntimeError(f"wrapper did not reach a record endpoint; events={events!r}")
+                state_change = _first_state_change_event(events, scenario)
+                if state_change is None:
+                    raise RuntimeError(f"wrapper did not reach the {scenario} state-change endpoint; events={events!r}")
+                if index >= warmups:
+                    record_latencies_ms.append((first_record.ns - started_ns) / 1_000_000)
+                    state_change_latencies_ms.append((state_change.ns - started_ns) / 1_000_000)
+                    wrapper_runtime_ms.append((ended_ns - started_ns) / 1_000_000)
+                    for event in events:
+                        request_counts[event.path] = request_counts.get(event.path, 0) + 1
+
+            return {
+                "scenario": scenario,
+                "repetitions": repetitions,
+                "warmups": warmups,
+                "request_counts": request_counts,
+                "shortcut_to_record_request_ms": _stats(record_latencies_ms),
+                "shortcut_to_state_change_request_ms": _stats(state_change_latencies_ms),
+                "wrapper_runtime_ms": _stats(wrapper_runtime_ms),
+            }
+        finally:
+            service.shutdown()
+            service.server_close()
+            thread.join(timeout=5)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Benchmark generated macOS hotkey wrapper latency with a fake service."
+    )
+    parser.add_argument("--repetitions", type=int, default=50)
+    parser.add_argument("--warmups", type=int, default=5)
+    parser.add_argument("--scenario", choices=("start", "stop"), default="start")
+    parser.add_argument("--timeout", type=float, default=10.0)
+    args = parser.parse_args()
+
+    if args.repetitions <= 0:
+        raise SystemExit("--repetitions must be positive")
+    if args.warmups < 0:
+        raise SystemExit("--warmups must be non-negative")
+
+    print(json.dumps(run_benchmark(args.repetitions, args.warmups, args.scenario, args.timeout), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_mlx_txt_latency.py
+++ b/scripts/bench_mlx_txt_latency.py
@@ -1,0 +1,151 @@
+"""Benchmark warm macOS MLX TXT latency with generated WAV cases.
+
+This exercises the in-process ASR plus post-processing path used after a
+recording stops, without requiring live recording, accessibility permissions, or
+the synthetic eval audio assets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import soundfile as sf
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from transclip.service import InferenceEngine  # noqa: E402
+from transclip.settings import load_settings  # noqa: E402
+
+SAMPLE_RATE = 16_000
+DEFAULT_CASES = (
+    ("silence_0_75s", 0.75, "silence"),
+    ("tone_1_50s", 1.50, "tone"),
+    ("chirp_3_00s", 3.00, "chirp"),
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--reps", type=int, default=2)
+    parser.add_argument("--label", default="mlx-txt-latency")
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--skip-warmup", action="store_true")
+    args = parser.parse_args(argv)
+    if args.reps < 1:
+        parser.error("--reps must be at least 1")
+
+    settings = load_settings()
+    engine = InferenceEngine(settings)
+    with tempfile.TemporaryDirectory(prefix="transclip-txt-bench-") as tmp:
+        root = Path(tmp)
+        warmup = None if args.skip_warmup else run_warmup(engine, root)
+        rows = run_cases(engine, root, reps=args.reps)
+
+    payload = {
+        "label": args.label,
+        "settings": {
+            "asr_backend": settings.asr_backend,
+            "asr_model": settings.asr_model,
+            "models_local_files_only": settings.models_local_files_only,
+        },
+        "warmup": warmup,
+        "summary": summarize(rows),
+        "by_case": summarize_by_case(rows),
+        "rows": rows,
+    }
+    encoded = json.dumps(payload, indent=2)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded + "\n", encoding="utf-8")
+    print(encoded)
+    return 0
+
+
+def run_warmup(engine: InferenceEngine, root: Path) -> dict[str, Any]:
+    wav = write_case(root, "warmup_0_25s", 0.25, "silence")
+    start = time.perf_counter()
+    result = engine.transcribe(wav, cleanup=True, keywords=[])
+    return {
+        "wall_ms": round((time.perf_counter() - start) * 1000, 3),
+        "timings_ms": result["timings_ms"],
+        "text_len": len(result["text"]),
+    }
+
+
+def run_cases(engine: InferenceEngine, root: Path, *, reps: int) -> list[dict[str, Any]]:
+    rows = []
+    for rep in range(1, reps + 1):
+        for name, seconds, kind in DEFAULT_CASES:
+            wav = write_case(root, f"{name}_rep{rep}", seconds, kind)
+            start = time.perf_counter()
+            result = engine.transcribe(wav, cleanup=True, keywords=[])
+            rows.append(
+                {
+                    "case": name,
+                    "rep": rep,
+                    "duration_s": seconds,
+                    "wall_ms": round((time.perf_counter() - start) * 1000, 3),
+                    "timings_ms": result["timings_ms"],
+                    "text_len": len(result["text"]),
+                }
+            )
+    return rows
+
+
+def write_case(root: Path, name: str, seconds: float, kind: str) -> Path:
+    path = root / f"{name}.wav"
+    sf.write(str(path), samples(kind, seconds), SAMPLE_RATE)
+    return path
+
+
+def samples(kind: str, seconds: float) -> np.ndarray:
+    n = int(SAMPLE_RATE * seconds)
+    t = np.arange(n, dtype=np.float32) / SAMPLE_RATE
+    if kind == "silence":
+        return np.zeros(n, dtype=np.float32)
+    if kind == "tone":
+        return (0.15 * np.sin(2 * np.pi * 220 * t)).astype(np.float32)
+    if kind == "chirp":
+        freq = 180 + 420 * (t / max(seconds, 1e-6))
+        return (0.12 * np.sin(2 * np.pi * freq * t)).astype(np.float32)
+    raise ValueError(f"unknown generated audio kind: {kind}")
+
+
+def summarize(rows: list[dict[str, Any]]) -> dict[str, float | int]:
+    wall = [row["wall_ms"] for row in rows]
+    end_to_end = [row["timings_ms"].get("end_to_end", 0.0) for row in rows]
+    asr = [row["timings_ms"].get("asr", 0.0) for row in rows]
+    return {
+        "cases": len(rows),
+        "median_wall_ms": round(statistics.median(wall), 3),
+        "mean_wall_ms": round(statistics.mean(wall), 3),
+        "best_wall_ms": round(min(wall), 3),
+        "worst_wall_ms": round(max(wall), 3),
+        "median_end_to_end_ms": round(statistics.median(end_to_end), 3),
+        "median_asr_ms": round(statistics.median(asr), 3),
+    }
+
+
+def summarize_by_case(rows: list[dict[str, Any]]) -> dict[str, dict[str, float]]:
+    by_case = {}
+    for name, *_ in DEFAULT_CASES:
+        values = [row["wall_ms"] for row in rows if row["case"] == name]
+        by_case[name] = {
+            "median_wall_ms": round(statistics.median(values), 3),
+            "best_wall_ms": round(min(values), 3),
+            "worst_wall_ms": round(max(values), 3),
+        }
+    return by_case
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -80,6 +80,39 @@ class ASRTests(unittest.TestCase):
         )
         self.assertIsInstance(backend, MlxAudioASRBackend)
 
+    def test_mlx_audio_reuses_loaded_model_object_across_transcriptions(self):
+        loaded_model = object()
+        load_calls = []
+        generated_models = []
+        backend = MlxAudioASRBackend("mlx-community/example", local_files_only=False)
+        backend.audio_preparer = SimpleNamespace(
+            prepare=lambda path: SimpleNamespace(wav_path=path, sample_rate=16000, temporary=False)
+        )
+
+        def fake_load_model(model_path):
+            load_calls.append(model_path)
+            return loaded_model
+
+        def fake_generate(model, audio_path, output_stem):
+            del audio_path, output_stem
+            generated_models.append(model)
+            return SimpleNamespace(text=f"transcript {len(generated_models)}")
+
+        with (
+            patch("transclip.asr.load_mlx_model", side_effect=fake_load_model),
+            patch("transclip.asr.generate_transcription", side_effect=fake_generate),
+        ):
+            first = backend.transcribe(Path("first.wav"))
+            second = backend.transcribe(Path("second.wav"))
+
+        self.assertEqual(load_calls, ["mlx-community/example"])
+        self.assertEqual(generated_models, [loaded_model, loaded_model])
+        self.assertEqual(first.text, "transcript 1")
+        self.assertEqual(second.text, "transcript 2")
+        self.assertIn("model_load", second.timings_ms)
+        self.assertIn("audio_prepare", second.timings_ms)
+        self.assertIn("generate_write", second.timings_ms)
+
     def test_non_granite_model_is_rejected(self):
         with self.assertRaises(ValueError):
             build_asr_backend(Settings(asr_model="openai/whisper-tiny"))

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -84,7 +84,12 @@ class ASRTests(unittest.TestCase):
         loaded_model = object()
         load_calls = []
         generated_models = []
-        backend = MlxAudioASRBackend("mlx-community/example", local_files_only=False)
+        generated_languages = []
+        backend = MlxAudioASRBackend(
+            "mlx-community/example",
+            Settings(language="en"),
+            local_files_only=False,
+        )
         backend.audio_preparer = SimpleNamespace(
             prepare=lambda path: SimpleNamespace(wav_path=path, sample_rate=16000, temporary=False)
         )
@@ -93,9 +98,10 @@ class ASRTests(unittest.TestCase):
             load_calls.append(model_path)
             return loaded_model
 
-        def fake_generate(model, audio_path, output_stem):
+        def fake_generate(model, audio_path, output_stem, **kwargs):
             del audio_path, output_stem
             generated_models.append(model)
+            generated_languages.append(kwargs["language"])
             return SimpleNamespace(text=f"transcript {len(generated_models)}")
 
         with (
@@ -107,6 +113,7 @@ class ASRTests(unittest.TestCase):
 
         self.assertEqual(load_calls, ["mlx-community/example"])
         self.assertEqual(generated_models, [loaded_model, loaded_model])
+        self.assertEqual(generated_languages, ["en", "en"])
         self.assertEqual(first.text, "transcript 1")
         self.assertEqual(second.text, "transcript 2")
         self.assertIn("model_load", second.timings_ms)

--- a/tests/test_audio_debug.py
+++ b/tests/test_audio_debug.py
@@ -120,6 +120,21 @@ class FakeSoundDevice:
         return devices[int(device)]
 
 
+class DefaultInputSoundDevice:
+    InputStream = FakeInputStream
+    default = SimpleNamespace(device=[None, 2])
+    query_calls = 0
+
+    @classmethod
+    def query_devices(cls, device=None, kind=None):
+        del device, kind
+        cls.query_calls += 1
+        return [
+            {"name": "MacBook Air Microphone", "max_input_channels": 1},
+            {"name": "USB Microphone", "max_input_channels": 1},
+        ]
+
+
 class AudioDebugTests(unittest.TestCase):
     def test_audio_recorder_streams_callback_audio_to_wav_without_copying_chunks(self):
         FakeInputStream.instances = []
@@ -144,6 +159,24 @@ class AudioDebugTests(unittest.TestCase):
         self.assertTrue(stream.stopped)
         self.assertTrue(stream.closed)
         self.assertTrue(raw_audio.closed)
+
+    def test_audio_recorder_opens_default_input_before_enumerating_fallback_devices(self):
+        FakeInputStream.instances = []
+        DefaultInputSoundDevice.query_calls = 0
+        raw_audio = FakeRawAudio()
+        with (
+            patch.dict("sys.modules", {"sounddevice": DefaultInputSoundDevice}),
+            patch("transclip.audio.tempfile.TemporaryFile", return_value=raw_audio),
+        ):
+            recorder = AudioRecorder(Settings())
+            recorder.start()
+            stream = FakeInputStream.instances[-1]
+            self.assertNotIn("device", stream.kwargs)
+            self.assertEqual(DefaultInputSoundDevice.query_calls, 0)
+            recorder.discard()
+
+        self.assertTrue(stream.stopped)
+        self.assertTrue(stream.closed)
 
     def test_audio_recorder_prefers_configured_input_device_when_default_fails(self):
         FailingDefaultInputStream.instances = []

--- a/tests/test_audio_debug.py
+++ b/tests/test_audio_debug.py
@@ -120,6 +120,24 @@ class FakeSoundDevice:
         return devices[int(device)]
 
 
+class DefaultNamedInputSoundDevice:
+    InputStream = FakeInputStream
+    default = SimpleNamespace(device=[1, 2])
+    query_calls: ClassVar[list[tuple[object, object]]] = []
+
+    @classmethod
+    def query_devices(cls, device=None, kind=None):
+        cls.query_calls.append((device, kind))
+        devices = [
+            {"name": "USB Microphone", "max_input_channels": 1},
+            {"name": "MacBook Air Microphone", "max_input_channels": 1},
+            {"name": "MacBook Air Speakers", "max_input_channels": 0},
+        ]
+        if device is None:
+            return devices
+        return devices[int(device)]
+
+
 class DefaultInputSoundDevice:
     InputStream = FakeInputStream
     default = SimpleNamespace(device=[None, 2])
@@ -173,6 +191,24 @@ class AudioDebugTests(unittest.TestCase):
             stream = FakeInputStream.instances[-1]
             self.assertNotIn("device", stream.kwargs)
             self.assertEqual(DefaultInputSoundDevice.query_calls, 0)
+            recorder.discard()
+
+        self.assertTrue(stream.stopped)
+        self.assertTrue(stream.closed)
+
+    def test_audio_recorder_tries_preferred_default_name_before_full_device_enumeration(self):
+        FakeInputStream.instances = []
+        DefaultNamedInputSoundDevice.query_calls = []
+        raw_audio = FakeRawAudio()
+        with (
+            patch.dict("sys.modules", {"sounddevice": DefaultNamedInputSoundDevice}),
+            patch("transclip.audio.tempfile.TemporaryFile", return_value=raw_audio),
+        ):
+            recorder = AudioRecorder(Settings(audio_input_device="MacBook Air Microphone"))
+            recorder.start()
+            stream = FakeInputStream.instances[-1]
+            self.assertEqual(stream.kwargs["device"], 1)
+            self.assertEqual(DefaultNamedInputSoundDevice.query_calls, [(1, "input")])
             recorder.discard()
 
         self.assertTrue(stream.stopped)

--- a/tests/test_macos_hotkey.py
+++ b/tests/test_macos_hotkey.py
@@ -1,4 +1,6 @@
 import io
+import os
+import subprocess
 import tempfile
 import unittest
 from contextlib import redirect_stdout
@@ -15,6 +17,7 @@ from transclip.desktop.hotkey.macos import (
     macos_hotkey_app_path,
     macos_hotkey_launch_agent_path,
     macos_hotkey_source_path,
+    macos_hotkey_state_path,
     macos_toggle_wrapper_path,
     uninstall_macos_hotkey,
 )
@@ -24,6 +27,104 @@ from tests.service_helpers import FakeRuntime, normalize_path_text
 
 
 class MacOSHotkeyTests(unittest.TestCase):
+    def test_toggle_wrapper_start_reaches_recording_without_health_probe(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runtime = FakeRuntime(system="Darwin", home=root / "home")
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            calls_path = root / "curl-calls.txt"
+            fake_curl = fake_bin / "curl"
+            fake_curl.write_text(
+                f"""#!/bin/sh
+printf '%s\\n' "$*" >> {calls_path}
+case "$*" in
+  */record/start*)
+    printf '%s\\n' '{{"status":"recording","already_recording":false}}'
+    ;;
+  */health*)
+    printf '%s\\n' '{{"status":"ready"}}'
+    ;;
+  *)
+    printf '%s\\n' '{{"error":"unexpected endpoint"}}'
+    exit 22
+    ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            fake_curl.chmod(0o755)
+            wrapper = root / "transclip-toggle"
+            script = build_macos_toggle_wrapper(Settings(host="127.0.0.1", port=8765), runtime=runtime)
+            script = script.replace("LOCK=/tmp/transclip-toggle.lock", f"LOCK={root / 'transclip-toggle.lock'}")
+            wrapper.write_text(script, encoding="utf-8")
+            wrapper.chmod(0o755)
+            env = {**os.environ, "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"}
+
+            result = subprocess.run([str(wrapper)], env=env, capture_output=True, text=True, timeout=5, check=False)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            calls = calls_path.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(calls), 1)
+            self.assertIn("/record/start", calls[0])
+            self.assertNotIn("/health", calls[0])
+            self.assertIn("listening\tRecording", macos_hotkey_state_path(runtime).read_text(encoding="utf-8"))
+
+    def test_toggle_wrapper_stop_falls_back_when_start_reports_already_recording(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runtime = FakeRuntime(system="Darwin", home=root / "home")
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            calls_path = root / "curl-calls.txt"
+            paste_path = root / "paste.txt"
+            fake_curl = fake_bin / "curl"
+            fake_curl.write_text(
+                f"""#!/bin/sh
+printf '%s\\n' "$*" >> {calls_path}
+case "$*" in
+  */record/start*)
+    printf '%s\\n' '{{"status":"recording","already_recording":true}}'
+    ;;
+  */record/stop*)
+    printf '%s\\n' '{{"status":"ready","text":"hello pasted"}}'
+    ;;
+  */health*)
+    printf '%s\\n' '{{"status":"recording"}}'
+    ;;
+  *)
+    printf '%s\\n' '{{"error":"unexpected endpoint"}}'
+    exit 22
+    ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            fake_curl.chmod(0o755)
+            fake_pbcopy = fake_bin / "pbcopy"
+            fake_pbcopy.write_text(f"#!/bin/sh\ncat > {paste_path}\n", encoding="utf-8")
+            fake_pbcopy.chmod(0o755)
+            wrapper = root / "transclip-toggle"
+            script = build_macos_toggle_wrapper(Settings(host="127.0.0.1", port=8765), runtime=runtime)
+            script = script.replace("LOCK=/tmp/transclip-toggle.lock", f"LOCK={root / 'transclip-toggle.lock'}")
+            wrapper.write_text(script, encoding="utf-8")
+            wrapper.chmod(0o755)
+            env = {**os.environ, "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"}
+
+            result = subprocess.run([str(wrapper)], env=env, capture_output=True, text=True, timeout=5, check=False)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            calls = calls_path.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(calls), 2)
+            self.assertIn("/record/start", calls[0])
+            self.assertIn("/record/stop", calls[1])
+            self.assertNotIn("/health", "\n".join(calls))
+            self.assertEqual(paste_path.read_text(encoding="utf-8"), "hello pasted")
+            self.assertIn(
+                "paste_requested\tPaste transcript",
+                macos_hotkey_state_path(runtime).read_text(encoding="utf-8"),
+            )
+
     def test_toggle_wrapper_uses_explicit_start_stop_and_lock(self):
         runtime = FakeRuntime(system="Darwin", home=Path("/Users/test"))
         script = build_macos_toggle_wrapper(Settings(host="127.0.0.1", port=8765), runtime=runtime)
@@ -37,12 +138,14 @@ class MacOSHotkeyTests(unittest.TestCase):
         self.assertIn('write_state recovering "Clearing stale action"', script)
         self.assertIn("kill_process_tree", script)
         self.assertIn("STATE=/Users/test/Library/Logs/transclip/hotkey-state.tsv", script)
-        self.assertIn('write_state shortcut "Checking service"', script)
+        self.assertIn('write_state shortcut "Starting recording"', script)
         self.assertIn('write_state listening "Recording"', script)
         self.assertIn('write_state transcribing "Transcribing"', script)
         self.assertIn('write_state paste_requested "Paste transcript"', script)
         self.assertIn('write_state finished "No transcript"', script)
         self.assertIn('write_state error "Stop timed out; restarted"', script)
+        self.assertIn("already_recording", script)
+        self.assertNotIn("$BASE/health", script)
         self.assertNotIn("osascript -e", script)
         self.assertIn("stop failed; restarting service", script)
 

--- a/tests/test_macos_hotkey.py
+++ b/tests/test_macos_hotkey.py
@@ -72,6 +72,10 @@ class MacOSHotkeyTests(unittest.TestCase):
         self.assertIn("return .labelColor", source)
         self.assertIn("postCommandV", source)
         self.assertIn('writeStateFile("finished", "Pasted")', source)
+        self.assertIn("var activeEventTap: CFMachPort?", source)
+        self.assertIn("activeEventTap = eventTap", source)
+        self.assertIn("CGEvent.tapEnable(tap: tap, enable: true)", source)
+        self.assertIn("event tap re-enabled", source)
         self.assertIn("event tap listening for Option+Space", source)
 
     def test_installer_writes_helper_app_launch_agent_and_wrapper(self):

--- a/tests/test_macos_hotkey.py
+++ b/tests/test_macos_hotkey.py
@@ -4,7 +4,7 @@ import subprocess
 import tempfile
 import unittest
 from contextlib import redirect_stdout
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from unittest.mock import patch
 
 from transclip.cli import main
@@ -27,6 +27,7 @@ from tests.service_helpers import FakeRuntime, normalize_path_text
 
 
 class MacOSHotkeyTests(unittest.TestCase):
+    @unittest.skipIf(os.name == "nt", "generated macOS shell wrapper requires a POSIX shell")
     def test_toggle_wrapper_start_reaches_recording_without_health_probe(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -70,6 +71,7 @@ esac
             self.assertNotIn("/health", calls[0])
             self.assertIn("listening\tRecording", macos_hotkey_state_path(runtime).read_text(encoding="utf-8"))
 
+    @unittest.skipIf(os.name == "nt", "generated macOS shell wrapper requires a POSIX shell")
     def test_toggle_wrapper_stop_falls_back_when_start_reports_already_recording(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -148,6 +150,18 @@ esac
         self.assertNotIn("$BASE/health", script)
         self.assertNotIn("osascript -e", script)
         self.assertIn("stop failed; restarting service", script)
+
+    def test_generated_macos_artifacts_use_forward_slash_paths(self):
+        runtime = FakeRuntime(system="Darwin", home=PureWindowsPath("/Users/test"))
+        script = build_macos_toggle_wrapper(Settings(host="127.0.0.1", port=8765), runtime=runtime)
+        source = build_macos_hotkey_source(
+            PureWindowsPath("/Users/test/bin/transclip-toggle"),
+            PureWindowsPath("/Users/test/Library/Logs/transclip/hotkey.log"),
+            PureWindowsPath("/Users/test/Library/Logs/transclip/hotkey-state.tsv"),
+        )
+
+        self.assertIn("STATE=/Users/test/Library/Logs/transclip/hotkey-state.tsv", script)
+        self.assertIn('let statePath = "/Users/test/Library/Logs/transclip/hotkey-state.tsv"', source)
 
     def test_hotkey_source_builds_status_item_from_state_file(self):
         source = build_macos_hotkey_source(

--- a/transclip/asr.py
+++ b/transclip/asr.py
@@ -4,6 +4,7 @@ import logging
 import math
 import platform as py_platform
 import tempfile
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
@@ -11,7 +12,7 @@ from typing import Any, Protocol
 from transclip.platform.runtime import PlatformRuntime
 
 from .device import resolve_torch_device
-from .mlx_audio_compat import generate_transcription
+from .mlx_audio_compat import generate_transcription, load_model as load_mlx_model
 from .models import (
     mlx_snapshot_path,
     model_cache_path,
@@ -313,6 +314,8 @@ class MlxAudioASRBackend:
         self.local_files_only = local_files_only
         self.cache_dir = cache_dir
         self._resolved_path: str | None = None
+        self._loaded_model: Any | None = None
+        self._model_lock = threading.RLock()
         self.audio_preparer = PathAudioPreparer()
         if validate_cache:
             self._model_path()
@@ -337,19 +340,30 @@ class MlxAudioASRBackend:
         self._resolved_path = self.model
         return self._resolved_path
 
+    def _load_model(self) -> Any:
+        with self._model_lock:
+            if self._loaded_model is not None:
+                return self._loaded_model
+            self._loaded_model = load_mlx_model(self._model_path())
+            return self._loaded_model
+
     def transcribe(self, wav_path: Path, keywords: list[str] | None = None) -> TranscriptionResult:
         del keywords
         timings: dict[str, float] = {}
+        audio: PreparedPathAudio | None = None
         with timed_ms(timings, "asr"):
-            model_path = self._model_path()
-            audio = self.audio_preparer.prepare(wav_path)
+            with timed_ms(timings, "model_load"):
+                model = self._load_model()
+            with timed_ms(timings, "audio_prepare"):
+                audio = self.audio_preparer.prepare(wav_path)
             try:
                 with tempfile.TemporaryDirectory(prefix="transclip-mlx-") as tmp:
                     output_stem = str(Path(tmp) / "transcript")
-                    result = generate_transcription(model_path, audio.wav_path, output_stem)
+                    with timed_ms(timings, "generate_write"):
+                        result = generate_transcription(model, audio.wav_path, output_stem)
                     text = getattr(result, "text", None) or str(result)
             finally:
-                if getattr(audio, "temporary", False):
+                if audio is not None and getattr(audio, "temporary", False):
                     audio.wav_path.unlink(missing_ok=True)
         return TranscriptionResult(text.strip(), timings, self.name, self.model)
 

--- a/transclip/asr.py
+++ b/transclip/asr.py
@@ -12,7 +12,8 @@ from typing import Any, Protocol
 from transclip.platform.runtime import PlatformRuntime
 
 from .device import resolve_torch_device
-from .mlx_audio_compat import generate_transcription, load_model as load_mlx_model
+from .mlx_audio_compat import generate_transcription
+from .mlx_audio_compat import load_model as load_mlx_model
 from .models import (
     mlx_snapshot_path,
     model_cache_path,
@@ -360,7 +361,12 @@ class MlxAudioASRBackend:
                 with tempfile.TemporaryDirectory(prefix="transclip-mlx-") as tmp:
                     output_stem = str(Path(tmp) / "transcript")
                     with timed_ms(timings, "generate_write"):
-                        result = generate_transcription(model, audio.wav_path, output_stem)
+                        result = generate_transcription(
+                            model,
+                            audio.wav_path,
+                            output_stem,
+                            language=self.settings.language if self.settings else None,
+                        )
                     text = getattr(result, "text", None) or str(result)
             finally:
                 if audio is not None and getattr(audio, "temporary", False):

--- a/transclip/audio.py
+++ b/transclip/audio.py
@@ -264,19 +264,36 @@ def _candidate_input_devices(sd, preferred: str) -> Iterator[object]:
         return True
 
     preferred = preferred.strip()
-    if preferred:
-        for candidate in _matching_input_devices(sd, preferred):
-            if should_emit(candidate):
-                yield candidate
     default_owner = getattr(sd, "default", None)
     default = _default_input_device(getattr(default_owner, "device", None))
-    if should_emit(default):
+    if preferred:
+        if preferred.isdigit():
+            if should_emit(int(preferred)):
+                yield int(preferred)
+        else:
+            if _default_device_matches_preferred(sd, default, preferred) and should_emit(default):
+                yield default
+            for candidate in _matching_input_devices(sd, preferred):
+                if should_emit(candidate):
+                    yield candidate
+    elif should_emit(default):
         yield default
     for candidate in _all_input_devices(sd):
         if should_emit(candidate):
             yield candidate
     if not emitted:
         yield None
+
+
+def _default_device_matches_preferred(sd, default: object, preferred: str) -> bool:
+    if default in {None, -1}:
+        return False
+    try:
+        info = sd.query_devices(default, "input")
+    except Exception:
+        return False
+    name = str(info.get("name", "") if isinstance(info, dict) else info)
+    return preferred.lower() == name.lower()
 
 
 def _matching_input_devices(sd, preferred: str) -> list[object]:

--- a/transclip/audio.py
+++ b/transclip/audio.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import tempfile
 import time
 import wave
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from contextlib import suppress
 from pathlib import Path
 from typing import Any
@@ -251,23 +251,32 @@ def sounddevice_summary() -> str:
         return f"sounddevice query failed: {exc}"
 
 
-def _candidate_input_devices(sd, preferred: str) -> list[object]:
-    candidates: list[object] = []
+def _candidate_input_devices(sd, preferred: str) -> Iterator[object]:
+    seen: set[object] = set()
+    emitted = False
+
+    def should_emit(candidate: object) -> bool:
+        nonlocal emitted
+        if candidate in seen:
+            return False
+        seen.add(candidate)
+        emitted = True
+        return True
+
     preferred = preferred.strip()
     if preferred:
-        candidates.extend(_matching_input_devices(sd, preferred))
+        for candidate in _matching_input_devices(sd, preferred):
+            if should_emit(candidate):
+                yield candidate
     default_owner = getattr(sd, "default", None)
     default = _default_input_device(getattr(default_owner, "device", None))
-    candidates.append(default)
-    candidates.extend(_all_input_devices(sd))
-    seen: set[object] = set()
-    unique: list[object] = []
-    for candidate in candidates:
-        if candidate in seen:
-            continue
-        seen.add(candidate)
-        unique.append(candidate)
-    return unique or [None]
+    if should_emit(default):
+        yield default
+    for candidate in _all_input_devices(sd):
+        if should_emit(candidate):
+            yield candidate
+    if not emitted:
+        yield None
 
 
 def _matching_input_devices(sd, preferred: str) -> list[object]:

--- a/transclip/desktop/hotkey/macos.py
+++ b/transclip/desktop/hotkey/macos.py
@@ -131,7 +131,7 @@ clear_stale_lock_owner() {{
 }}
 
 printf '%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') wrapper invoked" >> "$LOG"
-write_state shortcut "Checking service"
+write_state shortcut "Starting recording"
 
 if ! mkdir "$LOCK" 2>/dev/null; then
   now=$(date +%s)
@@ -155,16 +155,25 @@ fi
 printf '%s\\n' "$$" > "$LOCK/pid"
 trap 'rm -rf "$LOCK"' EXIT HUP INT TERM
 
-health=$(curl -sS --max-time 5 "$BASE/health" 2>>"$LOG") || {{
-  write_state error "Health check failed"
-  printf '%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') health failed; restarting service" >> "$LOG"
+response=$(curl -sS --max-time 10 -X POST "$BASE/record/start" \
+  -H 'content-type: application/json' --data '{{}}' 2>>"$LOG") || {{
+  write_state error "Start failed"
+  printf '%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') start failed; restarting service" >> "$LOG"
   {restart_command}
   exit 0
 }}
-status=$(printf '%s' "$health" | {python} -c 'import json,sys; print(json.load(sys.stdin).get("status",""))' 2>>"$LOG")
-printf '%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') status=${{status}}" >> "$LOG"
+printf '%s\\n' "$response" >> "$LOG"
+case "$response" in
+  *'"already_recording": true'*|*'"already_recording":true'*)
+    already_recording=1
+    ;;
+  *)
+    already_recording=0
+    ;;
+esac
+printf '%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') start already_recording=${{already_recording}}" >> "$LOG"
 
-if [ "$status" = "recording" ]; then
+if [ "$already_recording" = "1" ]; then
   write_state transcribing "Transcribing"
   response=$(curl -sS --max-time "$MAX_SECONDS" -X POST "$BASE/record/stop" \
     -H 'content-type: application/json' --data '{{}}' 2>>"$LOG") || {{
@@ -185,14 +194,6 @@ if [ "$status" = "recording" ]; then
     printf '%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') stop returned no text" >> "$LOG"
   fi
 else
-  response=$(curl -sS --max-time 10 -X POST "$BASE/record/start" \
-    -H 'content-type: application/json' --data '{{}}' 2>>"$LOG") || {{
-    write_state error "Start failed"
-    printf '%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') start failed; restarting service" >> "$LOG"
-    {restart_command}
-    exit 0
-  }}
-  printf '%s\\n' "$response" >> "$LOG"
   write_state listening "Recording"
 fi
 

--- a/transclip/desktop/hotkey/macos.py
+++ b/transclip/desktop/hotkey/macos.py
@@ -471,9 +471,22 @@ if !trusted {
     hotkeyStatus.setStatus("error", "Accessibility required")
 }
 
+var activeEventTap: CFMachPort?
+
+func reenableEventTap() {
+    guard let tap = activeEventTap else {
+        log("event tap re-enable skipped; no active tap")
+        return
+    }
+
+    CGEvent.tapEnable(tap: tap, enable: true)
+    log("event tap re-enabled")
+}
+
 let callback: CGEventTapCallBack = { _, type, event, _ in
     if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
         log("event tap disabled type=\\(type.rawValue)")
+        reenableEventTap()
         return Unmanaged.passUnretained(event)
     }
 
@@ -511,6 +524,7 @@ guard let eventTap = CGEvent.tapCreate(
     exit(0)
 }
 
+activeEventTap = eventTap
 let runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
 CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
 CGEvent.tapEnable(tap: eventTap, enable: true)

--- a/transclip/desktop/hotkey/macos.py
+++ b/transclip/desktop/hotkey/macos.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePath
 
 from transclip.daemon.common import CommandResult, logs_dir, repo_root
 from transclip.paths import service_settings_path
@@ -84,12 +84,12 @@ def build_macos_toggle_wrapper(
     cli = f"{python} -m {shlex.quote(IMPORT_PACKAGE + '.cli')}"
     if settings_path:
         cli += f" --settings {shlex.quote(service_settings_path(settings_path))}"
-    restart_command = f'cd {shlex.quote(str(repo_root()))} && {cli} restart >> "$LOG" 2>&1'
+    restart_command = f'cd {shlex.quote(_macos_path_text(repo_root()))} && {cli} restart >> "$LOG" 2>&1'
     return f"""#!/bin/sh
 set -u
 
-LOG={shlex.quote(str(log_path))}
-STATE={shlex.quote(str(state_path))}
+LOG={shlex.quote(_macos_path_text(log_path))}
+STATE={shlex.quote(_macos_path_text(state_path))}
 BASE={shlex.quote(base_url)}
 MAX_SECONDS={int(stop_timeout_seconds)}
 STALE_LOCK_SECONDS={int(stale_lock_seconds)}
@@ -536,9 +536,9 @@ if trusted {
 app.run()
 """
     return (
-        source.replace("@@LOG_PATH@@", _swift_string(str(log_path)))
-        .replace("@@WRAPPER_PATH@@", _swift_string(str(wrapper_path)))
-        .replace("@@STATE_PATH@@", _swift_string(str(state_path)))
+        source.replace("@@LOG_PATH@@", _swift_string(_macos_path_text(log_path)))
+        .replace("@@WRAPPER_PATH@@", _swift_string(_macos_path_text(wrapper_path)))
+        .replace("@@STATE_PATH@@", _swift_string(_macos_path_text(state_path)))
     )
 
 
@@ -696,3 +696,7 @@ def _macos_hotkey_info_plist_path(runtime: PlatformRuntime | None = None) -> Pat
 
 def _swift_string(value: str) -> str:
     return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _macos_path_text(path: PurePath) -> str:
+    return path.as_posix()

--- a/transclip/mlx_audio_compat.py
+++ b/transclip/mlx_audio_compat.py
@@ -5,7 +5,18 @@ from pathlib import Path
 from typing import Any
 
 
-def generate_transcription(model_path: str, audio_path: Path, output_stem: str) -> Any:
+def load_model(model_path: str) -> Any:
+    try:
+        from mlx_audio.stt.generate import load_model as mlx_load_model
+    except ImportError as exc:
+        raise RuntimeError(
+            "mlx-audio is required on macOS Apple Silicon. Install transclip[mlx]."
+        ) from exc
+
+    return mlx_load_model(model_path)
+
+
+def generate_transcription(model: Any, audio_path: Path, output_stem: str) -> Any:
     try:
         from mlx_audio.stt.generate import generate_transcription as mlx_generate
     except ImportError as exc:
@@ -19,9 +30,11 @@ def generate_transcription(model_path: str, audio_path: Path, output_stem: str) 
     }
     signature = inspect.signature(mlx_generate)
     if "model" in signature.parameters:
-        kwargs["model"] = model_path
+        kwargs["model"] = model
         kwargs["audio"] = str(audio_path)
     else:
-        kwargs["model_path"] = model_path
+        if not isinstance(model, str):
+            raise RuntimeError("installed mlx-audio generate_transcription does not accept a loaded model")
+        kwargs["model_path"] = model
         kwargs["audio_path"] = str(audio_path)
     return mlx_generate(**kwargs)

--- a/transclip/mlx_audio_compat.py
+++ b/transclip/mlx_audio_compat.py
@@ -16,7 +16,7 @@ def load_model(model_path: str) -> Any:
     return mlx_load_model(model_path)
 
 
-def generate_transcription(model: Any, audio_path: Path, output_stem: str) -> Any:
+def generate_transcription(model: Any, audio_path: Path, output_stem: str, **generate_options: Any) -> Any:
     try:
         from mlx_audio.stt.generate import generate_transcription as mlx_generate
     except ImportError as exc:
@@ -27,6 +27,7 @@ def generate_transcription(model: Any, audio_path: Path, output_stem: str) -> An
     kwargs = {
         "output_path": output_stem,
         "format": "txt",
+        **generate_options,
     }
     signature = inspect.signature(mlx_generate)
     if "model" in signature.parameters:


### PR DESCRIPTION
## Summary

This replaces #35 with one PR that includes the macOS event-tap re-enable work plus the Mac latency improvements from `mac-speed-up`.

- Re-enable the native macOS event-tap hotkey path.
- `TC...`: make the macOS hotkey helper start recording immediately by posting `/record/start` directly instead of probing `/health` first.
- `TC...`: preserve toggle-stop behavior by falling back to `/record/stop` when `/record/start` reports `already_recording`.
- `TC...`: make audio recording try the default input first so the common start path avoids full device enumeration.
- `TXT...`: cache the MLX ASR model across warm transcriptions and pass the configured language through to MLX generation.
- Add benchmark scripts for MLX TXT latency, macOS hotkey wrapper latency, and recorder start latency.

## Benchmark Results

| Area | Benchmark | Before | After | Change | Notes |
| --- | --- | ---: | ---: | ---: | --- |
| TXT | Generated WAV benchmark median wall time | 4762.7 ms | 1041.8 ms | -78.1% | Covers silence, tone, and chirp cases rather than one clip. |
| TXT | Generated WAV benchmark mean wall time | 8456.7 ms | 1402.7 ms | -83.4% | Warm MLX model path after cache + language pass-through. |
| TXT | Generated WAV benchmark worst wall time | 16595.8 ms | 2183.8 ms | -86.8% | Reduces pathological generated-audio tail latency seen before. |
| TC | Shortcut wrapper to `/record/start`, median | 68.6 ms | 29.5 ms | -57.0% | Fake local HTTP service benchmark, no manual accessibility interaction. |
| TC | Toggle/stop fallback path, median | 67.5 ms | 50.0 ms | -25.9% | Starts with `/record/start`; falls back to `/record/stop` on `already_recording`. |
| TC | Recorder default-device start, median | 7.7 ms | 0.1 ms | -98.4% | Avoids device enumeration on the common default-input path. |
| TC | Recorder fallback when default open fails | n/a | 6.4 ms | n/a | Confirms enumeration fallback still works when default input cannot be opened. |

Notes:

- The integrated branch also had a noisy macOS wrapper run with scheduler outliers, so the table uses the cleaner deterministic before/after fake-service benchmark for wrapper deltas.
- The TXT benchmark uses generated WAVs and measures warm end-to-end `InferenceEngine.transcribe` behavior with timing metadata, not a manual hotkey recording.

## Validation

- `uv run -m unittest tests.test_asr -v`
- `uv run --extra audio -m unittest tests.test_audio_debug -v`
- `uv run python -m tests` (`352 tests OK`)
- `uv run --extra dev ruff check transclip/asr.py transclip/mlx_audio_compat.py transclip/audio.py transclip/desktop/hotkey/macos.py tests/test_asr.py tests/test_audio_debug.py tests/test_macos_hotkey.py scripts/bench_mlx_txt_latency.py scripts/bench_macos_hotkey_latency.py scripts/bench_audio_recorder_start.py`

## Local Install Smoke Test

Reinstalled from `mac-speed-up`; daemon and hotkey launch agents are loaded and running locally. macOS Accessibility may still need to be toggled for `~/Applications/TransClipHotkey.app` after the helper was rebuilt/resigned.

Supersedes #35.
