### PR TITLE
Thermo-nuclear code-quality pass: decompose macOS hotkey, fix TranscribeResponse contract

### DIFF
--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -6,17 +6,15 @@ from unittest.mock import MagicMock, patch
 from transclip.daemon import (
     SERVICE_NAME,
     append_toggle_log,
-    build_systemd_unit,
     collect_status,
     install_daemon,
-    install_linux_daemon,
-    install_macos_daemon,
     last_toggle_log_event,
     service_action,
     service_state,
     toggle_log_path,
 )
-from transclip.daemon.macos import launch_agent_path
+from transclip.daemon.linux import build_systemd_unit, install_linux_daemon
+from transclip.daemon.macos import install_macos_daemon, launch_agent_path
 from transclip.daemon.windows import build_task_scheduler_xml, install_windows_daemon
 from transclip.desktop.hotkey import build_toggle_invocation, windows_hotkey_setup_message
 from transclip.paths import service_settings_path

--- a/transclip/daemon/__init__.py
+++ b/transclip/daemon/__init__.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from transclip.product import SERVICE_NAME
 
-from . import linux as linux_daemon
-from . import macos as macos_daemon
 from .common import CommandResult, ServiceState, logs_dir, run_command, service_command, toggle_log_path
 from .lifecycle import (
     install_daemon,
@@ -19,20 +17,17 @@ from .status import (
     stream_logs,
 )
 
-build_systemd_unit = linux_daemon.build_systemd_unit
-install_linux_daemon = linux_daemon.install_linux_daemon
-install_macos_daemon = macos_daemon.install_macos_daemon
-
+# Platform-specific installers (build_systemd_unit, install_linux_daemon,
+# install_macos_daemon, …) are intentionally not re-exported here. Import them
+# from their platform submodules (transclip.daemon.linux/macos/windows) for
+# tests and adapter work; the public surface is the dispatch layer below.
 __all__ = [
     "SERVICE_NAME",
     "CommandResult",
     "ServiceState",
     "append_toggle_log",
-    "build_systemd_unit",
     "collect_status",
     "install_daemon",
-    "install_linux_daemon",
-    "install_macos_daemon",
     "last_toggle_log_event",
     "logs_dir",
     "run_command",

--- a/transclip/daemon/windows.py
+++ b/transclip/daemon/windows.py
@@ -5,17 +5,17 @@ import xml.sax.saxutils as saxutils
 from collections.abc import Callable
 from pathlib import Path
 
-from transclip.daemon.common import CommandResult, ServiceState, repo_root, run_command, service_command
+from transclip.daemon.common import CommandResult, ServiceState, logs_dir, repo_root, run_command, service_command
 from transclip.daemon.protocol import PlatformDaemon
-from transclip.platform.runtime import PlatformRuntime, get_runtime, user_log_dir
-from transclip.product import DISPLAY_NAME, LOG_DIR_NAME, TASK_SCHEDULER_NAME
+from transclip.platform.runtime import PlatformRuntime, get_runtime
+from transclip.product import DISPLAY_NAME, TASK_SCHEDULER_NAME
 from transclip.settings import Settings, load_settings
 
 Runner = Callable[..., subprocess.CompletedProcess[str]]
 
 
 def task_scheduler_xml_path(runtime: PlatformRuntime | None = None) -> Path:
-    return user_log_dir(LOG_DIR_NAME, runtime) / f"{TASK_SCHEDULER_NAME}.xml"
+    return logs_dir(runtime) / f"{TASK_SCHEDULER_NAME}.xml"
 
 
 def build_task_scheduler_xml(settings_path: Path | None = None) -> str:
@@ -78,7 +78,7 @@ def install_windows_daemon(
 ) -> list[CommandResult]:
     results: list[CommandResult] = []
     platform_runtime = get_runtime(runtime)
-    log_root = user_log_dir(LOG_DIR_NAME, platform_runtime)
+    log_root = logs_dir(platform_runtime)
     log_root.mkdir(parents=True, exist_ok=True)
     xml_path = task_scheduler_xml_path(platform_runtime)
     xml_path.write_text(build_task_scheduler_xml(settings_path), encoding="utf-16")

--- a/transclip/desktop/hotkey/macos.py
+++ b/transclip/desktop/hotkey/macos.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass
+from functools import cache
+from importlib.resources import files
 from pathlib import Path, PurePath
 
 from transclip.daemon.common import CommandResult, logs_dir, repo_root
@@ -85,120 +87,18 @@ def build_macos_toggle_wrapper(
     if settings_path:
         cli += f" --settings {shlex.quote(service_settings_path(settings_path))}"
     restart_command = f'cd {shlex.quote(_macos_path_text(repo_root()))} && {cli} restart >> "$LOG" 2>&1'
-    return f"""#!/bin/sh
-set -u
-
-LOG={shlex.quote(_macos_path_text(log_path))}
-STATE={shlex.quote(_macos_path_text(state_path))}
-BASE={shlex.quote(base_url)}
-MAX_SECONDS={int(stop_timeout_seconds)}
-STALE_LOCK_SECONDS={int(stale_lock_seconds)}
-LOCK=/tmp/transclip-toggle.lock
-
-mkdir -p "$(dirname "$LOG")"
-mkdir -p "$(dirname "$STATE")"
-
-write_state() {{
-  state=$1
-  detail=$2
-  printf '%s\\t%s\\t%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$state" "$detail" > "$STATE"
-  printf '%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') state=${{state}} ${{detail}}" >> "$LOG"
-}}
-
-kill_process_tree() {{
-  pid=$1
-  for child in $(pgrep -P "$pid" 2>/dev/null || true); do
-    kill_process_tree "$child"
-  done
-  kill "$pid" 2>/dev/null || true
-}}
-
-clear_stale_lock_owner() {{
-  owner_pid=$(cat "$LOCK/pid" 2>/dev/null || true)
-  case "$owner_pid" in
-    ''|*[!0-9]*)
-      return
-      ;;
-  esac
-  owner_command=$(ps -p "$owner_pid" -o command= 2>/dev/null || true)
-  case "$owner_command" in
-    *transclip-toggle*)
-      write_state recovering "Clearing stale action"
-      printf '%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') killing stale TransClip action pid=${{owner_pid}}" >> "$LOG"
-      kill_process_tree "$owner_pid"
-      ;;
-  esac
-}}
-
-printf '%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') wrapper invoked" >> "$LOG"
-write_state shortcut "Starting recording"
-
-if ! mkdir "$LOCK" 2>/dev/null; then
-  now=$(date +%s)
-  lock_mtime=$(stat -f %m "$LOCK" 2>/dev/null || printf '0')
-  lock_age=$((now - lock_mtime))
-  if [ "$lock_age" -lt "$STALE_LOCK_SECONDS" ]; then
-    write_state busy "Previous action still running"
-    printf '%s\\n' \
-      "$(date '+%Y-%m-%dT%H:%M:%S%z') ignored: previous TransClip action still running (${{lock_age}}s)" \
-      >> "$LOG"
-    exit 0
-  fi
-  printf '%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') clearing stale TransClip action lock (${{lock_age}}s)" >> "$LOG"
-  clear_stale_lock_owner
-  rm -rf "$LOCK"
-  if ! mkdir "$LOCK" 2>/dev/null; then
-    printf '%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') ignored: could not acquire TransClip action lock" >> "$LOG"
-    exit 0
-  fi
-fi
-printf '%s\\n' "$$" > "$LOCK/pid"
-trap 'rm -rf "$LOCK"' EXIT HUP INT TERM
-
-response=$(curl -sS --max-time 10 -X POST "$BASE/record/start" \
-  -H 'content-type: application/json' --data '{{}}' 2>>"$LOG") || {{
-  write_state error "Start failed"
-  printf '%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') start failed; restarting service" >> "$LOG"
-  {restart_command}
-  exit 0
-}}
-printf '%s\\n' "$response" >> "$LOG"
-case "$response" in
-  *'"already_recording": true'*|*'"already_recording":true'*)
-    already_recording=1
-    ;;
-  *)
-    already_recording=0
-    ;;
-esac
-printf '%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') start already_recording=${{already_recording}}" >> "$LOG"
-
-if [ "$already_recording" = "1" ]; then
-  write_state transcribing "Transcribing"
-  response=$(curl -sS --max-time "$MAX_SECONDS" -X POST "$BASE/record/stop" \
-    -H 'content-type: application/json' --data '{{}}' 2>>"$LOG") || {{
-    write_state error "Stop timed out; restarted"
-    printf '%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') stop failed; restarting service" >> "$LOG"
-    {restart_command}
-    exit 0
-  }}
-  printf '%s\\n' "$response" >> "$LOG"
-  text=$(printf '%s' "$response" | {python} -c \
-    'import json,sys; print(json.load(sys.stdin).get("text", ""), end="")' 2>>"$LOG")
-  if [ -n "$text" ]; then
-    write_state paste_requested "Paste transcript"
-    printf '%s' "$text" | pbcopy
-    printf '%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') copied transcript chars=${{#text}}" >> "$LOG"
-  else
-    write_state finished "No transcript"
-    printf '%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') stop returned no text" >> "$LOG"
-  fi
-else
-  write_state listening "Recording"
-fi
-
-exit 0
-"""
+    return _render_resource(
+        "toggle_wrapper.sh",
+        {
+            "@@LOG@@": shlex.quote(_macos_path_text(log_path)),
+            "@@STATE@@": shlex.quote(_macos_path_text(state_path)),
+            "@@BASE@@": shlex.quote(base_url),
+            "@@MAX_SECONDS@@": str(int(stop_timeout_seconds)),
+            "@@STALE_LOCK_SECONDS@@": str(int(stale_lock_seconds)),
+            "@@RESTART_COMMAND@@": restart_command,
+            "@@PYTHON@@": python,
+        },
+    )
 
 
 def build_macos_hotkey_source(
@@ -206,339 +106,13 @@ def build_macos_hotkey_source(
     log_path: Path,
     state_path: Path,
 ) -> str:
-    source = """import ApplicationServices
-import AppKit
-import Carbon
-import Foundation
-
-let logPath = "@@LOG_PATH@@"
-let wrapperPath = "@@WRAPPER_PATH@@"
-let statePath = "@@STATE_PATH@@"
-let spaceKeyCode: Int64 = 49
-
-func log(_ message: String) {
-    let formatter = ISO8601DateFormatter()
-    let line = "\\(formatter.string(from: Date())) \\(message)\\n"
-    guard let data = line.data(using: .utf8) else { return }
-
-    if FileManager.default.fileExists(atPath: logPath),
-       let handle = try? FileHandle(forWritingTo: URL(fileURLWithPath: logPath)) {
-        defer { try? handle.close() }
-        _ = try? handle.seekToEnd()
-        _ = try? handle.write(contentsOf: data)
-    } else {
-        try? data.write(to: URL(fileURLWithPath: logPath))
-    }
-}
-
-func writeStateFile(_ state: String, _ detail: String) {
-    let formatter = ISO8601DateFormatter()
-    let line = "\\(formatter.string(from: Date()))\\t\\(state)\\t\\(detail)\\n"
-    try? line.write(to: URL(fileURLWithPath: statePath), atomically: true, encoding: .utf8)
-}
-
-func postCommandV() {
-    let source = CGEventSource(stateID: .hidSystemState)
-    let commandKeyCode: CGKeyCode = 55
-    let vKeyCode: CGKeyCode = 9
-
-    let commandDown = CGEvent(keyboardEventSource: source, virtualKey: commandKeyCode, keyDown: true)
-    commandDown?.flags = .maskCommand
-    commandDown?.post(tap: .cghidEventTap)
-    usleep(20_000)
-
-    let vDown = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true)
-    vDown?.flags = .maskCommand
-    vDown?.post(tap: .cghidEventTap)
-    usleep(20_000)
-
-    let vUp = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false)
-    vUp?.flags = .maskCommand
-    vUp?.post(tap: .cghidEventTap)
-    usleep(20_000)
-
-    let commandUp = CGEvent(keyboardEventSource: source, virtualKey: commandKeyCode, keyDown: false)
-    commandUp?.post(tap: .cghidEventTap)
-}
-
-class HotkeyStatus: NSObject {
-    let statusItem: NSStatusItem
-    let menu = NSMenu()
-    let statusMenuItem: NSMenuItem
-    var lastStateLine = ""
-    var readyResetTimer: Timer?
-
-    override init() {
-        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        statusMenuItem = NSMenuItem(title: "TransClip: Ready", action: nil, keyEquivalent: "")
-        super.init()
-
-        statusMenuItem.isEnabled = false
-        menu.addItem(statusMenuItem)
-        menu.addItem(NSMenuItem.separator())
-
-        let openToggleLog = NSMenuItem(
-            title: "Open toggle log",
-            action: #selector(openToggleLog(_:)),
-            keyEquivalent: ""
-        )
-        openToggleLog.target = self
-        menu.addItem(openToggleLog)
-
-        let openHotkeyLog = NSMenuItem(
-            title: "Open hotkey log",
-            action: #selector(openHotkeyLog(_:)),
-            keyEquivalent: ""
-        )
-        openHotkeyLog.target = self
-        menu.addItem(openHotkeyLog)
-
-        menu.addItem(NSMenuItem.separator())
-        let quit = NSMenuItem(title: "Quit TransClip Hotkey", action: #selector(quit(_:)), keyEquivalent: "q")
-        quit.target = self
-        menu.addItem(quit)
-
-        statusItem.menu = menu
-        setStatus("ready", "Ready")
-    }
-
-    func setStatus(_ state: String, _ detail: String) {
-        if Thread.isMainThread {
-            applyStatus(state, detail)
-        } else {
-            DispatchQueue.main.async {
-                self.applyStatus(state, detail)
-            }
-        }
-    }
-
-    private func applyStatus(_ state: String, _ detail: String) {
-        readyResetTimer?.invalidate()
-        readyResetTimer = nil
-
-        let title: String
-        let fallback: String
-
-        switch state {
-        case "shortcut":
-            title = "TC..."
-            fallback = "Shortcut received"
-        case "busy":
-            title = "TC..."
-            fallback = "Already working"
-        case "recovering":
-            title = "TC..."
-            fallback = "Recovering"
-        case "listening":
-            title = "REC"
-            fallback = "Recording"
-        case "transcribing":
-            title = "TXT..."
-            fallback = "Transcribing"
-        case "pasting":
-            title = "PST..."
-            fallback = "Pasting transcript"
-        case "paste_requested":
-            title = "PST..."
-            fallback = "Paste transcript"
-        case "finished":
-            title = "OK"
-            fallback = "Finished"
-        case "ready":
-            title = "TC"
-            fallback = "Ready"
-        case "error":
-            title = "TC!"
-            fallback = "Error"
-        default:
-            title = "TC"
-            fallback = "Ready"
-        }
-
-        let message = detail.isEmpty ? fallback : detail
-        statusItem.button?.attributedTitle = NSAttributedString(
-            string: title,
-            attributes: [
-                .foregroundColor: color(for: state),
-                .font: NSFont.monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .semibold),
-            ]
-        )
-        statusItem.button?.toolTip = "TransClip: \\(message)"
-        statusMenuItem.title = "TransClip: \\(message)"
-
-        if state == "finished" {
-            readyResetTimer = Timer.scheduledTimer(withTimeInterval: 2.5, repeats: false) { [weak self] _ in
-                self?.setStatus("ready", "Ready")
-            }
-        }
-    }
-
-    private func color(for state: String) -> NSColor {
-        switch state {
-        case "shortcut", "busy", "recovering":
-            return .systemYellow
-        case "listening":
-            return .systemOrange
-        case "transcribing":
-            return .systemPurple
-        case "pasting", "paste_requested":
-            return .systemTeal
-        case "finished":
-            return .systemGreen
-        case "ready":
-            return .labelColor
-        case "error":
-            return .systemRed
-        default:
-            return .labelColor
-        }
-    }
-
-    @objc func pollState(_ timer: Timer) {
-        guard let line = try? String(contentsOfFile: statePath, encoding: .utf8)
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-              !line.isEmpty,
-              line != lastStateLine else {
-            return
-        }
-
-        lastStateLine = line
-        let parts = line.components(separatedBy: "\\t")
-        let state = parts.count > 1 ? parts[1] : "ready"
-        let detail = parts.count > 2 ? parts[2] : state
-        if state == "paste_requested" {
-            performPasteRequest(detail)
-            return
-        }
-        setStatus(state, detail)
-    }
-
-    func performPasteRequest(_ detail: String) {
-        setStatus("pasting", detail.isEmpty ? "Pasting transcript" : detail)
-        log("paste requested by wrapper")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-            postCommandV()
-            log("posted Command+V")
-            writeStateFile("finished", "Pasted")
-            self.setStatus("finished", "Pasted")
-        }
-    }
-
-    @objc func openToggleLog(_ sender: Any?) {
-        let toggleLogPath = logPath.replacingOccurrences(
-            of: "hotkey.log",
-            with: "toggle-record.log"
-        )
-        NSWorkspace.shared.open(URL(fileURLWithPath: toggleLogPath))
-    }
-
-    @objc func openHotkeyLog(_ sender: Any?) {
-        NSWorkspace.shared.open(URL(fileURLWithPath: logPath))
-    }
-
-    @objc func quit(_ sender: Any?) {
-        NSApplication.shared.terminate(nil)
-    }
-}
-
-let app = NSApplication.shared
-app.setActivationPolicy(.accessory)
-let hotkeyStatus = HotkeyStatus()
-Timer.scheduledTimer(
-    timeInterval: 0.25,
-    target: hotkeyStatus,
-    selector: #selector(HotkeyStatus.pollState(_:)),
-    userInfo: nil,
-    repeats: true
-)
-
-func runWrapper() {
-    hotkeyStatus.setStatus("shortcut", "Shortcut received")
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/bin/sh")
-    process.arguments = ["-lc", wrapperPath]
-    do {
-        try process.run()
-        log("launched wrapper pid=\\(process.processIdentifier)")
-    } catch {
-        log("failed to launch wrapper: \\(error)")
-    }
-}
-
-let promptKey = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
-let trusted = AXIsProcessTrustedWithOptions([promptKey: true] as CFDictionary)
-log("event tap starting axTrusted=\\(trusted)")
-if !trusted {
-    hotkeyStatus.setStatus("error", "Accessibility required")
-}
-
-var activeEventTap: CFMachPort?
-
-func reenableEventTap() {
-    guard let tap = activeEventTap else {
-        log("event tap re-enable skipped; no active tap")
-        return
-    }
-
-    CGEvent.tapEnable(tap: tap, enable: true)
-    log("event tap re-enabled")
-}
-
-let callback: CGEventTapCallBack = { _, type, event, _ in
-    if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-        log("event tap disabled type=\\(type.rawValue)")
-        reenableEventTap()
-        return Unmanaged.passUnretained(event)
-    }
-
-    guard type == .keyDown else {
-        return Unmanaged.passUnretained(event)
-    }
-
-    let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
-    let flags = event.flags
-    let hasOption = flags.contains(.maskAlternate)
-    let hasCommand = flags.contains(.maskCommand)
-    let hasControl = flags.contains(.maskControl)
-
-    if keyCode == spaceKeyCode && hasOption && !hasCommand && !hasControl {
-        log("Option+Space detected")
-        runWrapper()
-        return nil
-    }
-
-    return Unmanaged.passUnretained(event)
-}
-
-let mask = CGEventMask(1 << CGEventType.keyDown.rawValue)
-guard let eventTap = CGEvent.tapCreate(
-    tap: .cgSessionEventTap,
-    place: .headInsertEventTap,
-    options: .defaultTap,
-    eventsOfInterest: mask,
-    callback: callback,
-    userInfo: nil
-) else {
-    log("failed to create event tap; Accessibility/Input Monitoring is required")
-    hotkeyStatus.setStatus("error", "Accessibility required")
-    app.run()
-    exit(0)
-}
-
-activeEventTap = eventTap
-let runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
-CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
-CGEvent.tapEnable(tap: eventTap, enable: true)
-log("event tap listening for Option+Space")
-if trusted {
-    hotkeyStatus.setStatus("ready", "Ready")
-}
-app.run()
-"""
-    return (
-        source.replace("@@LOG_PATH@@", _swift_string(_macos_path_text(log_path)))
-        .replace("@@WRAPPER_PATH@@", _swift_string(_macos_path_text(wrapper_path)))
-        .replace("@@STATE_PATH@@", _swift_string(_macos_path_text(state_path)))
+    return _render_resource(
+        "macos_hotkey.swift",
+        {
+            "@@LOG_PATH@@": _swift_string(_macos_path_text(log_path)),
+            "@@WRAPPER_PATH@@": _swift_string(_macos_path_text(wrapper_path)),
+            "@@STATE_PATH@@": _swift_string(_macos_path_text(state_path)),
+        },
     )
 
 
@@ -692,6 +266,18 @@ def _macos_hotkey_executable_path(runtime: PlatformRuntime | None = None) -> Pat
 
 def _macos_hotkey_info_plist_path(runtime: PlatformRuntime | None = None) -> Path:
     return macos_hotkey_app_path(runtime) / "Contents" / "Info.plist"
+
+
+@cache
+def _resource_text(name: str) -> str:
+    return (files(__package__) / "resources" / name).read_text(encoding="utf-8")
+
+
+def _render_resource(name: str, replacements: dict[str, str]) -> str:
+    text = _resource_text(name)
+    for token, value in replacements.items():
+        text = text.replace(token, value)
+    return text
 
 
 def _swift_string(value: str) -> str:

--- a/transclip/desktop/hotkey/resources/macos_hotkey.swift
+++ b/transclip/desktop/hotkey/resources/macos_hotkey.swift
@@ -1,0 +1,328 @@
+import ApplicationServices
+import AppKit
+import Carbon
+import Foundation
+
+let logPath = "@@LOG_PATH@@"
+let wrapperPath = "@@WRAPPER_PATH@@"
+let statePath = "@@STATE_PATH@@"
+let spaceKeyCode: Int64 = 49
+
+func log(_ message: String) {
+    let formatter = ISO8601DateFormatter()
+    let line = "\(formatter.string(from: Date())) \(message)\n"
+    guard let data = line.data(using: .utf8) else { return }
+
+    if FileManager.default.fileExists(atPath: logPath),
+       let handle = try? FileHandle(forWritingTo: URL(fileURLWithPath: logPath)) {
+        defer { try? handle.close() }
+        _ = try? handle.seekToEnd()
+        _ = try? handle.write(contentsOf: data)
+    } else {
+        try? data.write(to: URL(fileURLWithPath: logPath))
+    }
+}
+
+func writeStateFile(_ state: String, _ detail: String) {
+    let formatter = ISO8601DateFormatter()
+    let line = "\(formatter.string(from: Date()))\t\(state)\t\(detail)\n"
+    try? line.write(to: URL(fileURLWithPath: statePath), atomically: true, encoding: .utf8)
+}
+
+func postCommandV() {
+    let source = CGEventSource(stateID: .hidSystemState)
+    let commandKeyCode: CGKeyCode = 55
+    let vKeyCode: CGKeyCode = 9
+
+    let commandDown = CGEvent(keyboardEventSource: source, virtualKey: commandKeyCode, keyDown: true)
+    commandDown?.flags = .maskCommand
+    commandDown?.post(tap: .cghidEventTap)
+    usleep(20_000)
+
+    let vDown = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true)
+    vDown?.flags = .maskCommand
+    vDown?.post(tap: .cghidEventTap)
+    usleep(20_000)
+
+    let vUp = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false)
+    vUp?.flags = .maskCommand
+    vUp?.post(tap: .cghidEventTap)
+    usleep(20_000)
+
+    let commandUp = CGEvent(keyboardEventSource: source, virtualKey: commandKeyCode, keyDown: false)
+    commandUp?.post(tap: .cghidEventTap)
+}
+
+class HotkeyStatus: NSObject {
+    let statusItem: NSStatusItem
+    let menu = NSMenu()
+    let statusMenuItem: NSMenuItem
+    var lastStateLine = ""
+    var readyResetTimer: Timer?
+
+    override init() {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        statusMenuItem = NSMenuItem(title: "TransClip: Ready", action: nil, keyEquivalent: "")
+        super.init()
+
+        statusMenuItem.isEnabled = false
+        menu.addItem(statusMenuItem)
+        menu.addItem(NSMenuItem.separator())
+
+        let openToggleLog = NSMenuItem(
+            title: "Open toggle log",
+            action: #selector(openToggleLog(_:)),
+            keyEquivalent: ""
+        )
+        openToggleLog.target = self
+        menu.addItem(openToggleLog)
+
+        let openHotkeyLog = NSMenuItem(
+            title: "Open hotkey log",
+            action: #selector(openHotkeyLog(_:)),
+            keyEquivalent: ""
+        )
+        openHotkeyLog.target = self
+        menu.addItem(openHotkeyLog)
+
+        menu.addItem(NSMenuItem.separator())
+        let quit = NSMenuItem(title: "Quit TransClip Hotkey", action: #selector(quit(_:)), keyEquivalent: "q")
+        quit.target = self
+        menu.addItem(quit)
+
+        statusItem.menu = menu
+        setStatus("ready", "Ready")
+    }
+
+    func setStatus(_ state: String, _ detail: String) {
+        if Thread.isMainThread {
+            applyStatus(state, detail)
+        } else {
+            DispatchQueue.main.async {
+                self.applyStatus(state, detail)
+            }
+        }
+    }
+
+    private func applyStatus(_ state: String, _ detail: String) {
+        readyResetTimer?.invalidate()
+        readyResetTimer = nil
+
+        let title: String
+        let fallback: String
+
+        switch state {
+        case "shortcut":
+            title = "TC..."
+            fallback = "Shortcut received"
+        case "busy":
+            title = "TC..."
+            fallback = "Already working"
+        case "recovering":
+            title = "TC..."
+            fallback = "Recovering"
+        case "listening":
+            title = "REC"
+            fallback = "Recording"
+        case "transcribing":
+            title = "TXT..."
+            fallback = "Transcribing"
+        case "pasting":
+            title = "PST..."
+            fallback = "Pasting transcript"
+        case "paste_requested":
+            title = "PST..."
+            fallback = "Paste transcript"
+        case "finished":
+            title = "OK"
+            fallback = "Finished"
+        case "ready":
+            title = "TC"
+            fallback = "Ready"
+        case "error":
+            title = "TC!"
+            fallback = "Error"
+        default:
+            title = "TC"
+            fallback = "Ready"
+        }
+
+        let message = detail.isEmpty ? fallback : detail
+        statusItem.button?.attributedTitle = NSAttributedString(
+            string: title,
+            attributes: [
+                .foregroundColor: color(for: state),
+                .font: NSFont.monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .semibold),
+            ]
+        )
+        statusItem.button?.toolTip = "TransClip: \(message)"
+        statusMenuItem.title = "TransClip: \(message)"
+
+        if state == "finished" {
+            readyResetTimer = Timer.scheduledTimer(withTimeInterval: 2.5, repeats: false) { [weak self] _ in
+                self?.setStatus("ready", "Ready")
+            }
+        }
+    }
+
+    private func color(for state: String) -> NSColor {
+        switch state {
+        case "shortcut", "busy", "recovering":
+            return .systemYellow
+        case "listening":
+            return .systemOrange
+        case "transcribing":
+            return .systemPurple
+        case "pasting", "paste_requested":
+            return .systemTeal
+        case "finished":
+            return .systemGreen
+        case "ready":
+            return .labelColor
+        case "error":
+            return .systemRed
+        default:
+            return .labelColor
+        }
+    }
+
+    @objc func pollState(_ timer: Timer) {
+        guard let line = try? String(contentsOfFile: statePath, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !line.isEmpty,
+              line != lastStateLine else {
+            return
+        }
+
+        lastStateLine = line
+        let parts = line.components(separatedBy: "\t")
+        let state = parts.count > 1 ? parts[1] : "ready"
+        let detail = parts.count > 2 ? parts[2] : state
+        if state == "paste_requested" {
+            performPasteRequest(detail)
+            return
+        }
+        setStatus(state, detail)
+    }
+
+    func performPasteRequest(_ detail: String) {
+        setStatus("pasting", detail.isEmpty ? "Pasting transcript" : detail)
+        log("paste requested by wrapper")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            postCommandV()
+            log("posted Command+V")
+            writeStateFile("finished", "Pasted")
+            self.setStatus("finished", "Pasted")
+        }
+    }
+
+    @objc func openToggleLog(_ sender: Any?) {
+        let toggleLogPath = logPath.replacingOccurrences(
+            of: "hotkey.log",
+            with: "toggle-record.log"
+        )
+        NSWorkspace.shared.open(URL(fileURLWithPath: toggleLogPath))
+    }
+
+    @objc func openHotkeyLog(_ sender: Any?) {
+        NSWorkspace.shared.open(URL(fileURLWithPath: logPath))
+    }
+
+    @objc func quit(_ sender: Any?) {
+        NSApplication.shared.terminate(nil)
+    }
+}
+
+let app = NSApplication.shared
+app.setActivationPolicy(.accessory)
+let hotkeyStatus = HotkeyStatus()
+Timer.scheduledTimer(
+    timeInterval: 0.25,
+    target: hotkeyStatus,
+    selector: #selector(HotkeyStatus.pollState(_:)),
+    userInfo: nil,
+    repeats: true
+)
+
+func runWrapper() {
+    hotkeyStatus.setStatus("shortcut", "Shortcut received")
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/sh")
+    process.arguments = ["-lc", wrapperPath]
+    do {
+        try process.run()
+        log("launched wrapper pid=\(process.processIdentifier)")
+    } catch {
+        log("failed to launch wrapper: \(error)")
+    }
+}
+
+let promptKey = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
+let trusted = AXIsProcessTrustedWithOptions([promptKey: true] as CFDictionary)
+log("event tap starting axTrusted=\(trusted)")
+if !trusted {
+    hotkeyStatus.setStatus("error", "Accessibility required")
+}
+
+var activeEventTap: CFMachPort?
+
+func reenableEventTap() {
+    guard let tap = activeEventTap else {
+        log("event tap re-enable skipped; no active tap")
+        return
+    }
+
+    CGEvent.tapEnable(tap: tap, enable: true)
+    log("event tap re-enabled")
+}
+
+let callback: CGEventTapCallBack = { _, type, event, _ in
+    if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+        log("event tap disabled type=\(type.rawValue)")
+        reenableEventTap()
+        return Unmanaged.passUnretained(event)
+    }
+
+    guard type == .keyDown else {
+        return Unmanaged.passUnretained(event)
+    }
+
+    let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+    let flags = event.flags
+    let hasOption = flags.contains(.maskAlternate)
+    let hasCommand = flags.contains(.maskCommand)
+    let hasControl = flags.contains(.maskControl)
+
+    if keyCode == spaceKeyCode && hasOption && !hasCommand && !hasControl {
+        log("Option+Space detected")
+        runWrapper()
+        return nil
+    }
+
+    return Unmanaged.passUnretained(event)
+}
+
+let mask = CGEventMask(1 << CGEventType.keyDown.rawValue)
+guard let eventTap = CGEvent.tapCreate(
+    tap: .cgSessionEventTap,
+    place: .headInsertEventTap,
+    options: .defaultTap,
+    eventsOfInterest: mask,
+    callback: callback,
+    userInfo: nil
+) else {
+    log("failed to create event tap; Accessibility/Input Monitoring is required")
+    hotkeyStatus.setStatus("error", "Accessibility required")
+    app.run()
+    exit(0)
+}
+
+activeEventTap = eventTap
+let runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
+CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
+CGEvent.tapEnable(tap: eventTap, enable: true)
+log("event tap listening for Option+Space")
+if trusted {
+    hotkeyStatus.setStatus("ready", "Ready")
+}
+app.run()

--- a/transclip/desktop/hotkey/resources/toggle_wrapper.sh
+++ b/transclip/desktop/hotkey/resources/toggle_wrapper.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+set -u
+
+LOG=@@LOG@@
+STATE=@@STATE@@
+BASE=@@BASE@@
+MAX_SECONDS=@@MAX_SECONDS@@
+STALE_LOCK_SECONDS=@@STALE_LOCK_SECONDS@@
+LOCK=/tmp/transclip-toggle.lock
+
+mkdir -p "$(dirname "$LOG")"
+mkdir -p "$(dirname "$STATE")"
+
+write_state() {
+  state=$1
+  detail=$2
+  printf '%s\t%s\t%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$state" "$detail" > "$STATE"
+  printf '%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') state=${state} ${detail}" >> "$LOG"
+}
+
+kill_process_tree() {
+  pid=$1
+  for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+    kill_process_tree "$child"
+  done
+  kill "$pid" 2>/dev/null || true
+}
+
+clear_stale_lock_owner() {
+  owner_pid=$(cat "$LOCK/pid" 2>/dev/null || true)
+  case "$owner_pid" in
+    ''|*[!0-9]*)
+      return
+      ;;
+  esac
+  owner_command=$(ps -p "$owner_pid" -o command= 2>/dev/null || true)
+  case "$owner_command" in
+    *transclip-toggle*)
+      write_state recovering "Clearing stale action"
+      printf '%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') killing stale TransClip action pid=${owner_pid}" >> "$LOG"
+      kill_process_tree "$owner_pid"
+      ;;
+  esac
+}
+
+printf '%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') wrapper invoked" >> "$LOG"
+write_state shortcut "Starting recording"
+
+if ! mkdir "$LOCK" 2>/dev/null; then
+  now=$(date +%s)
+  lock_mtime=$(stat -f %m "$LOCK" 2>/dev/null || printf '0')
+  lock_age=$((now - lock_mtime))
+  if [ "$lock_age" -lt "$STALE_LOCK_SECONDS" ]; then
+    write_state busy "Previous action still running"
+    printf '%s\n'       "$(date '+%Y-%m-%dT%H:%M:%S%z') ignored: previous TransClip action still running (${lock_age}s)"       >> "$LOG"
+    exit 0
+  fi
+  printf '%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') clearing stale TransClip action lock (${lock_age}s)" >> "$LOG"
+  clear_stale_lock_owner
+  rm -rf "$LOCK"
+  if ! mkdir "$LOCK" 2>/dev/null; then
+    printf '%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') ignored: could not acquire TransClip action lock" >> "$LOG"
+    exit 0
+  fi
+fi
+printf '%s\n' "$$" > "$LOCK/pid"
+trap 'rm -rf "$LOCK"' EXIT HUP INT TERM
+
+response=$(curl -sS --max-time 10 -X POST "$BASE/record/start"   -H 'content-type: application/json' --data '{}' 2>>"$LOG") || {
+  write_state error "Start failed"
+  printf '%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') start failed; restarting service" >> "$LOG"
+  @@RESTART_COMMAND@@
+  exit 0
+}
+printf '%s\n' "$response" >> "$LOG"
+case "$response" in
+  *'"already_recording": true'*|*'"already_recording":true'*)
+    already_recording=1
+    ;;
+  *)
+    already_recording=0
+    ;;
+esac
+printf '%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') start already_recording=${already_recording}" >> "$LOG"
+
+if [ "$already_recording" = "1" ]; then
+  write_state transcribing "Transcribing"
+  response=$(curl -sS --max-time "$MAX_SECONDS" -X POST "$BASE/record/stop"     -H 'content-type: application/json' --data '{}' 2>>"$LOG") || {
+    write_state error "Stop timed out; restarted"
+    printf '%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') stop failed; restarting service" >> "$LOG"
+    @@RESTART_COMMAND@@
+    exit 0
+  }
+  printf '%s\n' "$response" >> "$LOG"
+  text=$(printf '%s' "$response" | @@PYTHON@@ -c     'import json,sys; print(json.load(sys.stdin).get("text", ""), end="")' 2>>"$LOG")
+  if [ -n "$text" ]; then
+    write_state paste_requested "Paste transcript"
+    printf '%s' "$text" | pbcopy
+    printf '%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') copied transcript chars=${#text}" >> "$LOG"
+  else
+    write_state finished "No transcript"
+    printf '%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z') stop returned no text" >> "$LOG"
+  fi
+else
+  write_state listening "Recording"
+fi
+
+exit 0

--- a/transclip/service/types.py
+++ b/transclip/service/types.py
@@ -45,7 +45,7 @@ class RecordSessionResponse(TypedDict, total=False):
     voice_mode: str
     voice_trigger: str
     voice_literal: bool
-    shell: dict[str, Any]
+    shell: dict[str, Any] | None
     timings_ms: dict[str, float]
     debug_capture_dir: str
 
@@ -63,8 +63,14 @@ class CleanupTextResponse(TypedDict, total=False):
 JsonPayload = dict[str, object]
 
 
-class TranscribeResponse(RecordSessionResponse):
+# /transcribe responses carry every record-session field plus ASR-specific
+# detail. Keys are optional (total=False) because the serializer omits cleanup,
+# voice_trigger, and debug_capture_dir when the pipeline does not produce them.
+class TranscribeResponse(RecordSessionResponse, total=False):
     raw_asr: str
     cleanup: dict[str, Any]
     cleanup_enabled: bool
     submit: bool | None
+    asr_backend: str
+    asr_model: str
+    cleanup_backend: str


### PR DESCRIPTION
## What & why

A strict whole-repo maintainability audit (run as a 12-agent workflow with adversarial verification). Of 26 candidate findings, **21 were rejected** as thin/speculative or as fighting deliberate architectural boundaries — the 5 high-conviction, **behavior-preserving** fixes survived and are applied here.

Guardrails held throughout: **353/353 tests green**, `ruff check` clean, and `ty` diagnostics drop **42 → 37** with no new ones.

## Changes

### 1. Decompose `desktop/hotkey/macos.py` (702 → 288 lines)
The largest file in the repo was dominated by two monolithic string builders: a 130-line shell-script f-string and a 339-line embedded-Swift string. Both are extracted to **editable resource files** rendered via simple `@@TOKEN@@` substitution:
- `resources/toggle_wrapper.sh` — the toggle wrapper (now gets real shell syntax highlighting)
- `resources/macos_hotkey.swift` — the menu-bar helper (now real Swift)

Generated output is **byte-identical** for every case — default, custom timeouts, settings-path, Windows-path, and quote/backslash escaping — verified with a capture/diff oracle, and confirmed loadable from an **installed wheel** (not just the source tree).

### 2. Fix the `TranscribeResponse` TypedDict contract (`service/types.py`)
The subclass declared its added keys as *required*, so the conditionally-set `cleanup` key errored; it never declared `asr_backend`/`asr_model`/`cleanup_backend` though the serializer always writes them; and `shell` was typed non-optional though `shell_metadata()` returns `None`. Made the subclass `total=False`, declared the ASR keys, and widened `shell`. **Pure type-level change** (TypedDicts are static-only) — resolves 5 `ty` errors in `serialize.py` with zero runtime change.

### 3. Use the canonical `logs_dir()` helper (`daemon/windows.py`)
Windows re-implemented `user_log_dir(LOG_DIR_NAME, …)` inline in two places; now routes through the same `logs_dir()` wrapper Linux and macOS use.

### 4. Trim the public daemon API (`daemon/__init__.py`)
Stopped re-exporting test-only platform installers (`build_systemd_unit`, `install_linux_daemon`, `install_macos_daemon`); tests now import them from their platform submodules, matching the existing `install_windows_daemon` pattern.

## Explicitly *not* done
Several tempting refactors were rejected after verification as lateral moves or boundary violations: merging the two Granite dtype helpers behind a boolean flag (rearranges complexity rather than deleting it), collapsing the AR/NAR backends (reflects a real domain difference), unifying the HTTP-client vs in-process CLI paths (`CONTEXT.md` warns against it), and removing the paste/hotkey "thin wrappers" (they're real test seams). Pre-existing `ruff format` drift on master was left untouched to keep this diff focused.

## Verification
- `uv run -m unittest discover` → 353 passed
- `uv run ruff check .` → clean
- `uv run ty check` → 37 (was 42 on master; −5, no new)
- `uv run -m compileall transclip tests scripts` → ok
- macOS shell-execution tests pass; byte-identical render diff + installed-wheel resource load confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)