### PR TITLE
Enforce closed-set correctness with Literal types + add mypy comparison-overlap lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
         run: uv sync --extra dev --extra audio
       - name: Ruff
         run: uv run ruff check .
+      - name: Mypy (informational, non-blocking)
+        # ty is the primary type checker; this lane only surfaces typo-in-comparison
+        # (strict_equality) issues that ty cannot catch. It must never gate CI.
+        continue-on-error: true
+        run: uv run mypy
       - name: Compile
         run: uv run python -m compileall transclip scripts tests
       - name: Unit tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ macos-ui = ["pyobjc-framework-Cocoa>=10; sys_platform == 'darwin'"]
 windows-ui = ["pystray>=0.19", "pillow>=10", "keyboard>=0.13.5; sys_platform == 'win32'"]
 dev = [
     "coverage[toml]>=7.10",
+    "mypy>=1.11",
     "pytest>=8.4",
     "ruff>=0.12.11",
     "ty>=0.0.1a19",
@@ -51,10 +52,41 @@ line-ending = "lf"
 python-version = "3.12"
 
 [tool.ty.rules]
+# NOTE: unresolved-import is silenced globally because optional/platform-specific
+# deps (AppKit, Foundation, mlx, pystray, keyboard, ...) are not installed in every
+# environment. Scoping this per-import is a larger follow-up change; keep as-is for now.
 unresolved-import = "ignore"
 
 [tool.ty.src]
+# Recommended follow-up: widen this to also check "scripts" and "tests". Both are
+# excluded for now because each carries an un-cleared diagnostic backlog beyond the
+# scope of this PR (measured 2026-06: +"scripts" ~= +7 diagnostics, +"tests" ~= +259).
 include = ["transclip"]
+
+[tool.mypy]
+# Informational / non-blocking lane. ty is the primary type checker; mypy is run only
+# to cover the ONE gap ty does not flag: typo-in-comparison (Literal/str overlap), via
+# strict_equality. Intentionally NOT --strict / disallow_untyped_defs (would flood).
+python_version = "3.12"
+files = ["transclip"]
+ignore_missing_imports = true
+strict_equality = true
+warn_redundant_casts = true
+warn_unused_ignores = false
+# Silence the categories ty already reports (the pre-existing structural backlog) so
+# this lane is a clean GREEN tripwire whose sole job is to catch comparison-overlap.
+# Widening mypy (e.g. disallow_untyped_defs) is a separate follow-up; ty stays primary.
+disable_error_code = [
+    "arg-type",
+    "attr-defined",
+    "assignment",
+    "return-value",
+    "var-annotated",
+    "type-var",
+    "typeddict-item",
+    "func-returns-value",
+    "call-arg",
+]
 
 [tool.coverage.run]
 branch = true

--- a/transclip/asr.py
+++ b/transclip/asr.py
@@ -7,7 +7,7 @@ import tempfile
 import threading
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 from transclip.platform.runtime import PlatformRuntime
 
@@ -23,7 +23,20 @@ from .models import (
 from .settings import Settings
 from .timing import timed_ms
 
+if TYPE_CHECKING:
+    from .device import TorchDevice
+
 logger = logging.getLogger(__name__)
+
+# The backend identity string reported by an ASR backend (ASRBackend.name) and
+# carried on TranscriptionResult.backend / the /transcribe and /health wire
+# fields. Distinct from the catalog/normalized ASRBackendKind (e.g. "granite").
+ASRBackendName = Literal[
+    "granite-transformers",
+    "granite-nar-transformers",
+    "mlx-audio",
+    "test-file",
+]
 
 AR_TOKENS_PER_AUDIO_SECOND = 10
 AR_MIN_NEW_TOKENS = 200
@@ -33,12 +46,15 @@ AR_MIN_NEW_TOKENS = 200
 class TranscriptionResult:
     text: str
     timings_ms: dict[str, float]
+    # The backend identity reported on the wire. ASRBackend implementations pass
+    # their ASRBackendName; the incremental path passes its own free-form label,
+    # so this stays a plain str.
     backend: str
     model: str
 
 
 class ASRBackend(Protocol):
-    name: str
+    name: ASRBackendName
     model: str
 
     def transcribe(self, wav_path: Path, keywords: list[str] | None = None) -> TranscriptionResult: ...
@@ -118,7 +134,7 @@ DefaultASRAudioPreparer = TorchAudioPreparer
 
 
 class GraniteSpeechTransformersBackend:
-    name = "granite-transformers"
+    name: ASRBackendName = "granite-transformers"
 
     def __init__(
         self,
@@ -138,7 +154,7 @@ class GraniteSpeechTransformersBackend:
     def _device(self):
         return resolve_torch_device(self.device)
 
-    def _load(self, device: str):
+    def _load(self, device: TorchDevice):
         if self._loaded is not None:
             return self._loaded
         try:
@@ -218,7 +234,7 @@ GRANITE_NAR_BUCKET_SECONDS = 2.0
 
 
 class GraniteSpeechNarTransformersBackend:
-    name = "granite-nar-transformers"
+    name: ASRBackendName = "granite-nar-transformers"
 
     def __init__(
         self,
@@ -238,7 +254,7 @@ class GraniteSpeechNarTransformersBackend:
     def _device(self):
         return resolve_torch_device(self.device)
 
-    def _load(self, device: str):
+    def _load(self, device: TorchDevice):
         if self._loaded is not None:
             return self._loaded
         try:
@@ -299,7 +315,7 @@ class GraniteSpeechNarTransformersBackend:
 
 
 class MlxAudioASRBackend:
-    name = "mlx-audio"
+    name: ASRBackendName = "mlx-audio"
 
     def __init__(
         self,
@@ -375,7 +391,7 @@ class MlxAudioASRBackend:
 
 
 class FileTranscriptASRBackend:
-    name = "test-file"
+    name: ASRBackendName = "test-file"
 
     def __init__(self, transcript_path: Path):
         self.transcript_path = transcript_path
@@ -454,7 +470,7 @@ def granite_user_prompt(keywords: list[str] | None = None) -> str:
     return "transcribe the speech with proper punctuation and capitalization."
 
 
-def _granite_transformers_dtype(torch, device: str):
+def _granite_transformers_dtype(torch, device: TorchDevice):
     if device == "cuda":
         return torch.bfloat16
     if device == "mps" and _mps_bfloat16_supported():
@@ -471,7 +487,7 @@ def _mps_bfloat16_supported() -> bool:
     return major >= 14
 
 
-def _granite_nar_dtype(torch, device: str):
+def _granite_nar_dtype(torch, device: TorchDevice):
     if device != "cuda":
         return torch.float32
     if getattr(torch.version, "hip", None):
@@ -479,7 +495,7 @@ def _granite_nar_dtype(torch, device: str):
     return torch.bfloat16
 
 
-def _configure_rocm_nar_attention_env(os_module, torch, device: str) -> None:
+def _configure_rocm_nar_attention_env(os_module, torch, device: TorchDevice) -> None:
     if device == "cuda" and getattr(torch.version, "hip", None):
         os_module.environ.setdefault("FLASH_ATTENTION_TRITON_AMD_ENABLE", "TRUE")
         os_module.environ.setdefault("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL", "1")

--- a/transclip/cleanup.py
+++ b/transclip/cleanup.py
@@ -8,6 +8,9 @@ from .settings import Settings
 from .text_generation import TextGenerationBackend
 from .timing import timed_ms
 
+# How dictation transcripts are cleaned: rule-based normalization or a text model.
+DictationCleanup = Literal["rule", "model"]
+
 MODEL_CLEANUP_SYSTEM_PROMPT = (
     "Clean this ASR transcript faithfully. Preserve meaning. Correct punctuation, "
     "capitalization, and paragraphing. Remove filler only when it is clearly filler. "
@@ -68,7 +71,7 @@ MODEL_CLEANUP_POLICY = CleanupPromptPolicy(MODEL_CLEANUP_SYSTEM_PROMPT)
 
 @dataclass(frozen=True, slots=True)
 class CleanupPlan:
-    dictation_mode: Literal["rule", "model"]
+    dictation_mode: DictationCleanup
     requires_text_model: bool
 
     @classmethod

--- a/transclip/daemon/lifecycle.py
+++ b/transclip/daemon/lifecycle.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from transclip.platform.runtime import PlatformRuntime, get_runtime
 from transclip.settings import load_settings, write_default_settings
+
+if TYPE_CHECKING:
+    from transclip.platform.runtime import SystemPlatform
 
 from . import linux as linux_daemon
 from . import macos as macos_daemon
@@ -21,7 +25,7 @@ __all__ = [
     "uninstall_daemon",
 ]
 
-_PLATFORM_BACKENDS: dict[str, PlatformDaemon] = {
+_PLATFORM_BACKENDS: dict[SystemPlatform, PlatformDaemon] = {
     "Linux": linux_daemon.platform_daemon,
     "Darwin": macos_daemon.platform_daemon,
     "Windows": windows_daemon.platform_daemon,

--- a/transclip/desktop/tray/controller.py
+++ b/transclip/desktop/tray/controller.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from transclip.platform.runtime import open_path
 
 from .menu import MODEL_ITEMS_REF
+
+if TYPE_CHECKING:
+    from .menu import TrayAction
 from .menu_update import (
     HistoryMenuState,
     TrayMenuView,
@@ -116,8 +119,8 @@ def build_tray_action_callbacks(
     quit: Callable[[], Any],
     set_hotkey: Callable[[], Any] | None = None,
     copy_hotkey_setup: Callable[[], Any] | None = None,
-) -> dict[str, Callable[..., Any]]:
-    callbacks: dict[str, Callable[..., Any]] = {
+) -> dict[TrayAction, Callable[..., Any]]:
+    callbacks: dict[TrayAction, Callable[..., Any]] = {
         "toggle": lambda *_: controller.toggle_record(),
         "copy_partial": lambda *_: controller.copy_partial(),
         "copy_latest": lambda *_: controller.copy_latest(),

--- a/transclip/device.py
+++ b/transclip/device.py
@@ -6,6 +6,9 @@ from functools import lru_cache
 from typing import Literal
 
 TorchDevice = Literal["cpu", "cuda", "mps"]
+# Device strings accepted by resolve_torch_device (case-insensitively): the
+# resolved torch devices plus "auto" (probe) and "rocm" (alias for "cuda").
+ASRDeviceString = Literal["auto", "cpu", "cuda", "mps", "rocm"]
 
 
 def resolve_torch_device(requested: str = "auto") -> TorchDevice:

--- a/transclip/models/catalog.py
+++ b/transclip/models/catalog.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, cast
+
 from transclip.platform.profiles import detect_runtime_profile, is_apple_silicon, machine_architecture
 from transclip.platform.runtime import PlatformRuntime, get_runtime
 from transclip.settings import Settings, default_settings
 
 from .cache import cache_artifacts_present, model_cache_path
 from .types import GIB, ModelCatalogEntry, ModelRow
+
+if TYPE_CHECKING:
+    from .types import ASRBackendKind
 
 MODEL_CATALOG: tuple[ModelCatalogEntry, ...] = (
     ModelCatalogEntry(
@@ -140,11 +145,11 @@ def catalog_entry_for_backend(backend: str, model_id: str) -> ModelCatalogEntry:
     return entry
 
 
-def normalize_asr_backend(asr_backend: str) -> str:
+def normalize_asr_backend(asr_backend: str) -> ASRBackendKind:
     if asr_backend.startswith("file:"):
         return "file"
     try:
-        return ASR_BACKEND_ALIASES[asr_backend]
+        return cast("ASRBackendKind", ASR_BACKEND_ALIASES[asr_backend])
     except KeyError as exc:
         raise ValueError(f"Unsupported ASR backend: {asr_backend}") from exc
 
@@ -173,7 +178,7 @@ def validate_asr_model_backend(
     asr_backend: str,
     model_id: str,
     runtime: PlatformRuntime | None = None,
-) -> str:
+) -> ASRBackendKind:
     backend = normalize_asr_backend(asr_backend)
     if backend == "file":
         return backend

--- a/transclip/models/types.py
+++ b/transclip/models/types.py
@@ -7,11 +7,34 @@ GIB = 1024**3
 ModelRuntimeKind = Literal["torch", "mlx", "file"]
 PrefetchStrategy = Literal["transformers", "snapshot_download", "none"]
 
+# Normalized ASR backend kinds produced by normalize_asr_backend /
+# validate_asr_model_backend (catalog.py). "file" is the normalized kind for
+# any "file:..." backend; it is not stored on a catalog entry.
+ASRBackendKind = Literal[
+    "granite",
+    "granite_nar",
+    "granite_mlx",
+    "granite_nar_mlx",
+    "mlx_audio_whisper",
+    "file",
+]
+# The exact backend strings stored on a ModelCatalogEntry. ASR entries reuse the
+# ASR backend kinds (minus "file", which catalog entries never hold); text-model
+# entries use "text_generation".
+CatalogBackendKind = Literal[
+    "granite",
+    "granite_nar",
+    "granite_mlx",
+    "granite_nar_mlx",
+    "mlx_audio_whisper",
+    "text_generation",
+]
+
 
 @dataclass(frozen=True, slots=True)
 class ModelCatalogEntry:
     model_id: str
-    backend: str
+    backend: CatalogBackendKind
     display_name: str
     runtime_kind: ModelRuntimeKind
     estimated_bytes: int
@@ -24,7 +47,7 @@ class ModelCatalogEntry:
 @dataclass(frozen=True, slots=True)
 class ModelRow:
     model_id: str
-    backend: str
+    backend: CatalogBackendKind
     runtime: ModelRuntimeKind
     marker: str
     cached: bool

--- a/transclip/platform/capabilities.py
+++ b/transclip/platform/capabilities.py
@@ -2,20 +2,24 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from .runtime import PlatformRuntime, get_runtime
+
+if TYPE_CHECKING:
+    from .runtime import SystemPlatform
 
 
 @dataclass(frozen=True, slots=True)
 class SessionInfo:
-    system: str
+    system: SystemPlatform
     session: str
     desktop: str
 
 
 def session_info(
     environ: Mapping[str, str] | None = None,
-    system: str | None = None,
+    system: SystemPlatform | None = None,
     runtime: PlatformRuntime | None = None,
 ) -> SessionInfo:
     platform_runtime = get_runtime(runtime)

--- a/transclip/platform/profiles.py
+++ b/transclip/platform/profiles.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import platform
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from transclip.platform.runtime import PlatformRuntime, get_runtime
 from transclip.product import CONFIG_DIR_NAME, LOG_DIR_NAME
+
+if TYPE_CHECKING:
+    from transclip.platform.runtime import SystemPlatform
 
 ProfileRuntimeKind = Literal["torch_cuda", "torch_rocm", "torch_mps", "torch_cpu", "mlx", "file"]
 ProfileId = Literal[
@@ -22,7 +25,7 @@ ProfileId = Literal[
 @dataclass(frozen=True, slots=True)
 class RuntimeProfile:
     profile_id: ProfileId
-    system: str
+    system: SystemPlatform
     architecture: str
     default_asr_backend: str
     default_asr_model: str

--- a/transclip/platform/runtime.py
+++ b/transclip/platform/runtime.py
@@ -5,7 +5,10 @@ import platform
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, Protocol, cast
+from typing import Any, Literal, Protocol, cast
+
+# platform.system() returns one of these on every platform this app targets.
+SystemPlatform = Literal["Linux", "Darwin", "Windows"]
 
 SESSION_ENV_KEYS = (
     "XDG_SESSION_TYPE",
@@ -18,7 +21,7 @@ SESSION_ENV_KEYS = (
 
 
 class PlatformRuntime(Protocol):
-    def system(self) -> str: ...
+    def system(self) -> SystemPlatform: ...
 
     def home_dir(self) -> Path: ...
 
@@ -34,8 +37,8 @@ class PlatformRuntime(Protocol):
 
 
 class DefaultPlatformRuntime:
-    def system(self) -> str:
-        return platform.system()
+    def system(self) -> SystemPlatform:
+        return cast(SystemPlatform, platform.system())
 
     def home_dir(self) -> Path:
         return Path.home()
@@ -112,7 +115,7 @@ def open_path(path: Path, runtime: PlatformRuntime | None = None) -> None:
         )
         return
     if system == "Windows":
-        os.startfile(str(path))  # type: ignore[attr-defined]
+        os.startfile(str(path))  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         return
     subprocess.Popen(
         ["xdg-open", str(path)],

--- a/transclip/service/engine.py
+++ b/transclip/service/engine.py
@@ -4,7 +4,7 @@ import logging
 import tempfile
 from pathlib import Path
 from time import perf_counter
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from transclip.asr import (
     GRANITE_NAR_BUCKET_SECONDS,
@@ -40,6 +40,9 @@ from .types import (
     ServiceHealthResponse,
     TranscribeResponse,
 )
+
+if TYPE_CHECKING:
+    from .types import RecordSource
 
 
 class StopSignal(Protocol):
@@ -117,7 +120,7 @@ class InferenceEngine:
         self,
         cleanup: bool | None = None,
         discard: bool = False,
-        source: str = "/record/stop",
+        source: RecordSource = "/record/stop",
         record_history: bool = False,
     ) -> RecordSessionResponse:
         result = self.dictation_session.stop_recording(
@@ -284,7 +287,7 @@ class InferenceEngine:
         self,
         wav_path: Path,
         cleanup: bool | None,
-        source: str,
+        source: RecordSource,
     ) -> TranscribeResponse:
         return self.transcribe(
             wav_path,

--- a/transclip/service/health.py
+++ b/transclip/service/health.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from transclip.cleanup import CleanupPlan
 from transclip.platform.runtime import PlatformRuntime, get_runtime
 from transclip.settings import Settings, active_hotkey, paste_shortcut
 
 from .types import ServiceHealthResponse
+
+if TYPE_CHECKING:
+    from .types import DictationStatus
 
 _SETTINGS_HEALTH_FIELDS = (
     "cleanup_enabled",
@@ -37,7 +42,7 @@ def settings_health_payload(
 
 def build_health_status(
     *,
-    status: str,
+    status: DictationStatus,
     settings: Settings,
     asr_backend_name: str,
     asr_model: str,

--- a/transclip/service/session.py
+++ b/transclip/service/session.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock
 from time import perf_counter
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
 from transclip.asr_streaming import PartialTranscript
 from transclip.audio import AudioRecorder
@@ -14,6 +14,9 @@ from transclip.settings import Settings
 
 from .streaming import StreamingCapture, StreamingDictationAdapter
 from .types import RecordSessionResponse, TranscribeResponse
+
+if TYPE_CHECKING:
+    from .types import DictationStatus, DiscardReason, RecordSource
 
 
 class Recorder(Protocol):
@@ -27,7 +30,7 @@ class Recorder(Protocol):
 
 
 RecorderFactory = Callable[[Settings], Recorder]
-Transcriber = Callable[[Path, bool | None, str], TranscribeResponse]
+Transcriber = Callable[[Path, bool | None, "RecordSource"], TranscribeResponse]
 Clock = Callable[[], float]
 
 
@@ -38,7 +41,7 @@ class RecordingHandle(Protocol):
         self,
         *,
         cleanup: bool | None,
-        source: str,
+        source: RecordSource,
     ) -> TranscribeResponse: ...
 
     def discard(self) -> None: ...
@@ -56,7 +59,7 @@ class BatchRecording:
         self,
         *,
         cleanup: bool | None,
-        source: str,
+        source: RecordSource,
     ) -> TranscribeResponse:
         with tempfile.TemporaryDirectory() as tmp:
             wav_path = self.recorder.stop_to_wav(Path(tmp) / "recording.wav")
@@ -83,7 +86,7 @@ class StreamingRecording:
         self,
         *,
         cleanup: bool | None,
-        source: str,
+        source: RecordSource,
     ) -> TranscribeResponse:
         self.adapter.detach_session(self.capture.session)
         try:
@@ -133,7 +136,7 @@ class DictationSession:
         self._active: ActiveRecording | None = None
         self._last_toggle_accepted_at = 0.0
 
-    def status(self) -> str:
+    def status(self) -> DictationStatus:
         with self._lock:
             return "recording" if self._active else "ready"
 
@@ -155,7 +158,7 @@ class DictationSession:
         self,
         cleanup: bool | None = None,
         discard: bool = False,
-        source: str = "/record/stop",
+        source: RecordSource = "/record/stop",
     ) -> RecordSessionResponse:
         with self._lock:
             active = self._pop_active()
@@ -216,8 +219,8 @@ class DictationSession:
         *,
         cleanup: bool | None,
         discard: bool,
-        discard_reason: str | None = None,
-        source: str,
+        discard_reason: DiscardReason | None = None,
+        source: RecordSource,
     ) -> RecordSessionResponse:
         duration_ms = round((self._clock() - active.started_at) * 1000, 3)
         if discard:

--- a/transclip/service/types.py
+++ b/transclip/service/types.py
@@ -1,10 +1,29 @@
 from __future__ import annotations
 
-from typing import Any, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
+
+if TYPE_CHECKING:
+    from transclip.mode_routing import VoiceMode
+
+# Dictation lifecycle status reported by DictationSession.status() and echoed on
+# the /health and /record/* responses.
+DictationStatus = Literal["recording", "ready"]
+# The action a /record/toggle (or /record/stop) call resolved to.
+ToggleAction = Literal["started", "stopped", "discarded", "ignored"]
+# Why a recording was discarded / ignored.
+DiscardReason = Literal["toggle_cooldown", "max_recording_duration"]
+# The originating endpoint recorded for a record/transcribe session.
+RecordSource = Literal[
+    "/record/stop",
+    "/record/toggle",
+    "/transcribe",
+    "/cleanup/transcribe",
+    "/eval/incremental",
+]
 
 
 class ServiceHealthResponse(TypedDict, total=False):
-    status: str
+    status: DictationStatus
     asr_backend: str
     asr_model: str
     cleanup_backend: str
@@ -28,13 +47,13 @@ class ServiceHealthResponse(TypedDict, total=False):
 
 
 class RecordSessionResponse(TypedDict, total=False):
-    status: str
-    action: str
+    status: DictationStatus
+    action: ToggleAction
     text: str
     duration_ms: float
     discarded: bool
     already_recording: bool
-    reason: str
+    reason: DiscardReason
     cooldown_ms: int
     max_recording_ms: int
     history_error: str
@@ -42,7 +61,7 @@ class RecordSessionResponse(TypedDict, total=False):
     service_url: str
     paste: dict[str, Any]
     timestamp: str
-    voice_mode: str
+    voice_mode: VoiceMode
     voice_trigger: str
     voice_literal: bool
     shell: dict[str, Any]
@@ -54,7 +73,7 @@ class CleanupTextResponse(TypedDict, total=False):
     text: str
     backend: str
     timings_ms: dict[str, float]
-    voice_mode: str
+    voice_mode: VoiceMode
     voice_trigger: str
     voice_literal: bool
     cleanup_backend: str
@@ -63,8 +82,11 @@ class CleanupTextResponse(TypedDict, total=False):
 JsonPayload = dict[str, object]
 
 
-class TranscribeResponse(RecordSessionResponse):
+class TranscribeResponse(RecordSessionResponse, total=False):
     raw_asr: str
     cleanup: dict[str, Any]
     cleanup_enabled: bool
     submit: bool | None
+    asr_backend: str
+    asr_model: str
+    cleanup_backend: str

--- a/transclip/transcript_pipeline.py
+++ b/transclip/transcript_pipeline.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .cleanup import (
     CleanupBackend,
@@ -14,12 +14,15 @@ from .mode_routing import VoiceModeRoute
 from .settings import Settings
 from .shell_command import ShellCommandProcessor, ShellCommandResult
 
+if TYPE_CHECKING:
+    from .mode_routing import VoiceMode
+
 
 @dataclass(slots=True)
 class TranscriptOutcome:
     text: str
     raw_asr: str
-    voice_mode: str
+    voice_mode: VoiceMode
     voice_trigger: str | None
     voice_literal: bool
     cleanup: CleanupResult | None

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
 
 [[package]]
 name = "accelerate"
@@ -40,6 +44,46 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "ast-serialize"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/9d/09e27731bd5864a9ce04e3244074e674bb8936bf62b45e0357248717adac/ast_serialize-0.5.0.tar.gz", hash = "sha256:5880091bfe6f4f986f22866375c2e884843e7a0b6343ae41aeea659613d879b6", size = 61157, upload-time = "2026-05-17T17:48:29.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/9a/13dde51ba9e15f8b97957ab7cb0120d0e381524d651c6bd630b9c359227f/ast_serialize-0.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8f5c14f169eb0972c0c21bada5358b23d6047c76583b005234f865b11f1fa00a", size = 1183520, upload-time = "2026-05-17T17:47:30.831Z" },
+    { url = "https://files.pythonhosted.org/packages/37/de/5a7f0a9fe68944f536632a5af84676739c7d2582be42deb082634bf3a754/ast_serialize-0.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7d1a2de9de5be04652f0ed60738356ef94f66db37924a9499fffe98dc491aa0b", size = 1175779, upload-time = "2026-05-17T17:47:32.551Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/81/0bb853e76e4f6e9a1855d569003c59e19ffac45f7079d91505d1bb212f92/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be5173fb66f9b49026d9d5a2ff0fc7c7009077107c0eb285b2d60fdf1fe10bd1", size = 1233750, upload-time = "2026-05-17T17:47:34.731Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d3/4cf705beeccc08754d0bbda99aefff26110e209b9a07ac8a6b60eec48531/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8015cd071ac1339924ee2b8098c93e00e155f30a16f40ec9816fcf84f4753f6", size = 1235942, upload-time = "2026-05-17T17:47:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c8/ee097e437ea27dd2b8b227865c875492b585650a5802a22d82b304c8201b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5499e8797edff2a9186aa313ed382c6b422e798e9332d9953badcee6e69a88f2", size = 1442517, upload-time = "2026-05-17T17:47:38.17Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/bd/68063442838f1ba68ec72b5436430bc75b3bb17a1a3c3063f09b0c05ae2b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6848f2a093fb5548751a9a09bff8fcd229e2bbeb0e3331f391b6ae6d26cd9903", size = 1254081, upload-time = "2026-05-17T17:47:39.826Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e2/1e520793bc6a4e4524a6ab022391e827825eaa0c3811828bfdc6852eca26/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:832d4c998e0b091fd60a6d6bceee535483c4d490de9ba85003af835225719261", size = 1259910, upload-time = "2026-05-17T17:47:41.369Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e1/49b60f467979979cfe6913b43948ff25bca971ad0591d181812f163a988e/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:16db7c62ec0b8efe1d7afd283a388d8f74f2605d56032e5a37747d2de8dba027", size = 1250678, upload-time = "2026-05-17T17:47:43.702Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ba/66ab9555de6275677566f6574e5ef6c29cb185ea866f643bc06f8280a8ee/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:baf5eb061eb5bccade4128ad42da33787d72f6013809cd1b590376ece8b3c937", size = 1301603, upload-time = "2026-05-17T17:47:46.256Z" },
+    { url = "https://files.pythonhosted.org/packages/66/42/6aca9b9abc710014b2be9059689e5dd1679339e78f567ffb4d255a9e2050/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:104e4a35bd7c124173c41760ef9aaea17ddb3f86c65cb643671d59afbe3ee94c", size = 1410332, upload-time = "2026-05-17T17:47:47.899Z" },
+    { url = "https://files.pythonhosted.org/packages/47/68/2f76594432a22581ecf878b5e75a9b8601c24b2241cf0bbeb1e21fcf370c/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:36be371028fc1675acb38a331bde160dbab7ff907fdf00b67eb6911aa106951b", size = 1509979, upload-time = "2026-05-17T17:47:50.942Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ac/a93c9b58292653f6c595752f677a08e608f903b710594909e9231a389b3b/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:061ee58bdb52341c8201a6df41182a977736bae3b7ded87ca7176ca25a8a47ab", size = 1505002, upload-time = "2026-05-17T17:47:54.093Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2e/b278f68c497ee2f1d1576cbbef8db5281cd4a5f2db040537592ac9c8862e/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b15219e9cdc9f53f6f4cb51c009203507228226148c05c5e8fe451c28b435eb3", size = 1456231, upload-time = "2026-05-17T17:47:56.311Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/419be1c566a4c504cd8fd60ce2f84e790f295495c0f327cfaeadf3d51012/ast_serialize-0.5.0-cp314-cp314t-win32.whl", hash = "sha256:842d1c004bb466c7df036f95fabef789570541922b10976b12f5592a69cf0b38", size = 1058668, upload-time = "2026-05-17T17:47:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/03/6f/c9d4d549295ed05111aeb8853232d1afd9d0a179fddb01eeffbb3a4a6842/ast_serialize-0.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b0c06d760909b095cc466356dfccd05a1c7233a6ca191c020dca2c6a6f16c24c", size = 1101075, upload-time = "2026-05-17T17:48:00.35Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/8e/d00c5ab30c58222e07d62956fca86c59d91b9ad32997e633c38b526623a3/ast_serialize-0.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:787baedb0262cc49e8ce37cc15c00ae818e46a165a3b36f5e21ed174998104cb", size = 1075347, upload-time = "2026-05-17T17:48:01.753Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9e/dc2530acb3a60dc6e46d65abf27d1d9f86721694757906a148d90a6860de/ast_serialize-0.5.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0668aa9459cfa8c9c49ddd2163ebcf43088ba045ef7492af6fe22e0098303101", size = 1191380, upload-time = "2026-05-17T17:48:03.738Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0a/bd3d18a582f273d6c843d16bb9e22e9e16365ff7991e92f18f798e9f1224/ast_serialize-0.5.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bf683d6363edf2b39eed6b6d4fe22d34b6203867a67e27134d9e2a2680c4bc4a", size = 1183879, upload-time = "2026-05-17T17:48:05.463Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/1f919100f8620887af58fcc381c61a1f218cdf89c6e155f87b213e61010a/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cc22cf0c9be65e71cf88fda130af60d61eb4a79370ad4cfe7900d48a4aa2211", size = 1244529, upload-time = "2026-05-17T17:48:07.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ca/6376559dcce707cdbc1d0d9a13c8d3baaaa501e949ce0ebdc4230cd881aa/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f66173891548c9f2726bf27957b41cabce12fa679dc6da505ddbde4d4b3b31cf", size = 1240560, upload-time = "2026-05-17T17:48:08.46Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b2/a620e206b5aeb7efbf2710336df57d457cffbb3991076bbcc1147ef9abd4/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e42d729ef2be96a14efbad355093284739e3670ece3e534f82cc8832790911d9", size = 1451172, upload-time = "2026-05-17T17:48:09.922Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/e0/4ad5c04c24a40481b2935ce9a0ccdb6023dc8b667167d06ae530cc3512f2/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b725026bafa801dbd7310eb13a75f0a2e370e7e51b2cb225f9d21fcfadf919ee", size = 1265072, upload-time = "2026-05-17T17:48:11.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/71/4d1d479aa56d0101c40e17720c3d6ac2af7269ea0487a80b18e7bfd1a5b7/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b54f60c1d78767a53b67eaa663f0dfac3afe606aa07f1301572f588b73d64809", size = 1270488, upload-time = "2026-05-17T17:48:13.575Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4f/0de1bbe06f6edef9fde4ed12ca8e7b3ec7e6e2bd4e672c5af487f7957665/ast_serialize-0.5.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:27d51654fc240a1e87e742d353d98eb45b75f62f129086b3596ab53df2ac2a43", size = 1260702, upload-time = "2026-05-17T17:48:15.141Z" },
+    { url = "https://files.pythonhosted.org/packages/75/61/e00872439cfdddcc3c1b6cdaa6e5d904ba8e26a18807c67c4e14409d0ca8/ast_serialize-0.5.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c36237c46dd1674542f2109740ea5ea485a169bf1431939ada0434e17934", size = 1311182, upload-time = "2026-05-17T17:48:16.779Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8e/699a5b955f7926956c95e9e1d74132acad73c2fe7a426f94da89123c20aa/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1943db345233cc7194a470f13afa9c59772c0b123dea0c9414c4d4ca54369759", size = 1421410, upload-time = "2026-05-17T17:48:18.527Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ae/d5b7626874478997adc7a29ab28accf21e596fb590c944290401dfd0b29e/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:df1c00022cbbcb064bfaa505aa9c9295362443ce5dacb459d1331d3da353f887", size = 1516587, upload-time = "2026-05-17T17:48:20.133Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ce/b59e02a82d9c4244d64cde502e0b00e83e38816abe19155ceb5437402c7f/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cae65289fc456fde04af979a2be09302ef5d8ab92ef23e596d6746dc267ada27", size = 1515171, upload-time = "2026-05-17T17:48:21.921Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/38/d8d90042747d05aa08d4efcf1c99035a5f670a6bf4c214d31644392afbca/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:239a4c354e8d676e9d94631d1d4a64edc6b266f86ff3a5a80aedd344f342c01d", size = 1464668, upload-time = "2026-05-17T17:48:23.544Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/51/5b840c4df7334104cecffa28f23904fe81ca89ca223d2450e288de39fd3c/ast_serialize-0.5.0-cp39-abi3-win32.whl", hash = "sha256:143a4ef63285a075871908fda3672dc21864b83a8ec3ee12304aa3e4c5387b9a", size = 1068311, upload-time = "2026-05-17T17:48:25.027Z" },
+    { url = "https://files.pythonhosted.org/packages/41/11/ca5672c7d491825bc4cd6702dea106a6b60d928707712ec257c7833ae476/ast_serialize-0.5.0-cp39-abi3-win_amd64.whl", hash = "sha256:cf25572c526add400f26a4750dc6ce0c3bb93fc1f75e7ae0cad4ce4f2cd5c590", size = 1108931, upload-time = "2026-05-17T17:48:26.591Z" },
+    { url = "https://files.pythonhosted.org/packages/45/19/cc8bd127d28a43da249aa955cfd164cf8fd534e79e42cea96c4854d72fd0/ast_serialize-0.5.0-cp39-abi3-win_arm64.whl", hash = "sha256:92a31c9c20d25a076edaeec76b128a3535d74a24f340b9a8a7e96c9b86dc9642", size = 1081181, upload-time = "2026-05-17T17:48:28.122Z" },
 ]
 
 [[package]]
@@ -426,6 +470,66 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/08/9e7f6b5d2b5bed6ad055cdd5925f192bb403a51280f86b56554d9d0699a2/librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1", size = 200139, upload-time = "2026-05-10T18:17:25.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/d0/07c77e067f0838949b43bd89232c29d72efebb9d2801a9750184eb706b71/librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b87504f1690a23b9a2cca841191a04f83895d4fc2dd04df91d82b1a04ca2ad46", size = 144147, upload-time = "2026-05-10T18:15:53.227Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/24/8493538fa4f62f982686398a5b8f68008138a75086abdea19ade64bf4255/librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40071fc5fe0ce8daa6de616702314a01e1250711682b0523d6ab8d4525910cb3", size = 143614, upload-time = "2026-05-10T18:15:54.657Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1e/f8bad050810d9171f34a1648ed910e56814c2ba61639f2bd53c6377ae24b/librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:137e79445c896a0ea7b265f52d23954e05b64222ee1af69e2cb34219067cbb67", size = 485538, upload-time = "2026-05-10T18:15:56.117Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/fe/3594ebfbaf03084ba4b120c9ba5c3183fd938a48725e9bbe6ff0a5159ad8/librt-0.11.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:cca6644054e78746d8d4ef238681f9c34ff8b584fe6b988ecebb8db3b15e622a", size = 479623, upload-time = "2026-05-10T18:15:57.544Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/da/5d1876984b3746c85dbd219dbfcb73c85f54ee263fd32e5b2a632ec14571/librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5b0eea49f5562861ee8d757a32ef7d559c1d35be2aaaa1ec28941d74c9ffc8a", size = 513082, upload-time = "2026-05-10T18:15:58.805Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6e/55bdf5d5ca00c3e18430690bf2c953d8d3ffd3c337418173d33dec985dc9/librt-0.11.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0d1029d7e1ae1a7e647ed6fb5df8c4ce2dffefb7a9f5fd1376a4554d96dac09f", size = 508105, upload-time = "2026-05-10T18:16:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/f1f23a7c595ee90ece4d35c851e5d104b1311a887ed1b4ac4c35bbd13da8/librt-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bc3ce6b33c5828d9e80592011a5c584cb2ce86edbc4088405f70da47dc1d1b3b", size = 522268, upload-time = "2026-05-10T18:16:01.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/5720f5697a7f54b78b3aefbe20df3a48cedcff1276618c4aa481177942ed/librt-0.11.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:936c5995f3514a42111f20099397d8177c79b4d7e70961e396c6f5a0a3566766", size = 527348, upload-time = "2026-05-10T18:16:03.496Z" },
+    { url = "https://files.pythonhosted.org/packages/50/db/b4a47c6f91db4ff76348a0b3dd0cc65e090a078b765a810a62ff9434c3d3/librt-0.11.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9bc0ca6ad9381cbe8e4aa6e5726e4c80c78115a6e9723c599ed1d73e092bc49d", size = 516294, upload-time = "2026-05-10T18:16:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/58/9384b2f4eb1ed1d273d40948a7c5c4b2360213b402ef3be4641c06299f9c/librt-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:070aa8c26c0a74774317a72df8851facc7f0f012a5b406557ac56992d92e1ec8", size = 553608, upload-time = "2026-05-10T18:16:06.839Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7b/5aa8848a7c6a9278c79375146da1812e695754ceec5f005e6043461a7315/librt-0.11.0-cp312-cp312-win32.whl", hash = "sha256:6bf14feb84b05ae945277395451998c89c54d0def4070eb5c08de544930b245a", size = 101879, upload-time = "2026-05-10T18:16:08.103Z" },
+    { url = "https://files.pythonhosted.org/packages/37/33/8a745436944947575b584231750a41417de1a38cf6a2e9251d1065651c09/librt-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:75672f0bc524ede266287d532d7923dbce94c7514ad07627bac3d0c6d92cc4d9", size = 119831, upload-time = "2026-05-10T18:16:09.174Z" },
+    { url = "https://files.pythonhosted.org/packages/59/67/a6739ac96e28b7855808bdb0370e250606104a859750d209e5a0716fe7ab/librt-0.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:2f10cf143e4a9bb0f4f5af568a00df94a2d69ef41c2579584454bb0fe5cc642c", size = 103470, upload-time = "2026-05-10T18:16:10.369Z" },
+    { url = "https://files.pythonhosted.org/packages/82/61/e59168d4d0bf2bf90f4f0caf7a001bfc60254c3af4586013b04dc3ef517b/librt-0.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:78dc31f7fdfe9c9d0eb0e8f42d139db230e826415bbcabd9f0e9faaaee909894", size = 144119, upload-time = "2026-05-10T18:16:11.771Z" },
+    { url = "https://files.pythonhosted.org/packages/61/fd/caa1d60b12f7dd79ccea23054e06eeaebe266a5f52c40a6b651069200ce5/librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c", size = 143565, upload-time = "2026-05-10T18:16:13.334Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/dc744f5c2b4978d48db970be29f22716d3413d28b14ad99740817315cf2c/librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea", size = 485395, upload-time = "2026-05-10T18:16:14.729Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/21/7f8e97a1e4dae952a5a95948f6f8507a173bc1e669f54340bba6ca1ca31b/librt-0.11.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a9010e2ed5b3a9e158c5fd966b3ab7e834bb3d3aacc8f66c91dd4b57a3799230", size = 479383, upload-time = "2026-05-10T18:16:16.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2", size = 513010, upload-time = "2026-05-10T18:16:17.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/43/0b5708af2bd30a46400e72ba6bdaa8f066f15fb9a688527e34220e8d6c06/librt-0.11.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7aef3cf1d5af86e770ab04bfd993dfc4ae8b8c17f66fb77dd4a7d50de7bbb1a3", size = 508433, upload-time = "2026-05-10T18:16:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/50/356187247d09013490481033183b3532b58acf8028bcb34b2b56a375c9b2/librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:557183ddc36babe46b27dd60facbd5adb4492181a5be887587d57cda6e092f21", size = 522595, upload-time = "2026-05-10T18:16:20.642Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e7/c6ac4240899c7f3248079d5a9900debe0dadb3fdeaf856684c987105ba47/librt-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:83d3e1f72bd42f6c5c0b7daec530c3f829bd02db42c70b8ddf0c2d90a2459930", size = 527255, upload-time = "2026-05-10T18:16:22.352Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b5/a81322dbeedeeaf9c1ee6f001734d28a09d8383ac9e6779bc24bbd0743c6/librt-0.11.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4ce1f21fbe589bc1afd7872dece84fb0e1144f794a288e58a10d2c54a55c43be", size = 516847, upload-time = "2026-05-10T18:16:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/66/6e6323787d592b55204a42595ff1102da5115601b53a7e9ddebc889a6da5/librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b09f7044ea2b64c9da42fd3d335666518cfd1c6e8a182c95da73d0214b41e", size = 553920, upload-time = "2026-05-10T18:16:25.025Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/21/623f8ca230857102066d9ca8c6c1734995908c4d0d1bee7bb2ef0021cb33/librt-0.11.0-cp313-cp313-win32.whl", hash = "sha256:78fddc31cd4d3caa897ad5d31f856b1faadc9474021ad6cb182b9018793e254e", size = 101898, upload-time = "2026-05-10T18:16:26.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1d/b4ebd44dd723f768469007515cb92251e0ae286c94c140f374801140fa74/librt-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ca8aa88751a775870b764e93bad5135385f563cb8dcee399abf034ea4d3cb47", size = 119812, upload-time = "2026-05-10T18:16:27.859Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e4/b2f4ca7965ca373b491cdb4bc25cdb30c1649ca81a8782056a83850292a9/librt-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:96f044bb325fd9cf1a723015638c219e9143f0dfbc0ca54c565df2b7fc748b44", size = 103448, upload-time = "2026-05-10T18:16:29.066Z" },
+    { url = "https://files.pythonhosted.org/packages/29/eb/dbce197da4e227779e56b5735f2decc3eb36e55a1cdbf1bd65d6639d76c1/librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4a017a95e5837dc15a8c5661d60e05daa96b90908b1aa6b7acdf443cd25c8ebd", size = 143345, upload-time = "2026-05-10T18:16:30.674Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/254bebd0c11c8ba684018efb8006ff22e466abce445215cca6c778e7d9de/librt-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b1ecbd9819deccc39b7542bf4d2a740d8a620694d39989e58661d3763458f8d4", size = 143131, upload-time = "2026-05-10T18:16:32.037Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3f/f77d6122d21ac7bf6ae8a7dfced1bd2a7ac545d3273ebdcaf8042f6d619f/librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8", size = 477024, upload-time = "2026-05-10T18:16:33.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0a/2c996dadebaa7d9bbbd43ef2d4f3e66b6da545f838a41694ef6172cebec8/librt-0.11.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0dc56b1f8d06e60db362cc3fdae206681817f86ce4725d34511473487f12a34b", size = 474221, upload-time = "2026-05-10T18:16:34.864Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7e/f5d92af8486b8272c23b3e686b46ff72d89c8169585eb61eef01a2ac7147/librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175", size = 505174, upload-time = "2026-05-10T18:16:36.705Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/cb0734fe86398eb33193ab753b7326255c74cac5eb09e76b9b16536e7adb/librt-0.11.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae74872be221df4374d10fec61f93ed1513b9546ea84f2c0bf73ab3e9bd0b03", size = 497216, upload-time = "2026-05-10T18:16:38.418Z" },
+    { url = "https://files.pythonhosted.org/packages/18/06/094820f91558b66e29943c0ec41c9914f460f48dd51fc503c3101e10842d/librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32bcc918c0148eb7e3d57385125bac7e5f9e4359d05f07448b09f6f778c2f31c", size = 513921, upload-time = "2026-05-10T18:16:39.848Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c2/00de9018871a282f530cacb457d5ec0428f6ac7e6fedde9aff7468d9fb04/librt-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f9743fc99135d5f78d2454435615f6dec0473ca507c26ce9d92b10b562a280d3", size = 520850, upload-time = "2026-05-10T18:16:41.471Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9d/64631832348fd1834fb3a61b996434edddaaf25a31d03b0a76273159d2cf/librt-0.11.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5ba067f4aadae8fda802d91d2124c90c42195ff32d9161d3549e6d05cfe26f96", size = 504237, upload-time = "2026-05-10T18:16:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/ae5525eb16edc827a044e7bb8777a455ff95d4bca9379e7e6bddd7383647/librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:de3bf945454d032f9e390b85c4072e0a0570bf825421c8be0e71209fa65e1abe", size = 546261, upload-time = "2026-05-10T18:16:44.408Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/09/adce371f27ca039411da9659f7430fcc2ba6cd0c7b3e4467a0f091be7fa9/librt-0.11.0-cp314-cp314-win32.whl", hash = "sha256:d2277a05f6dcb9fd13db9566aac4fabd68c3ea1ea46ee5567d4eef8efa495a2f", size = 96965, upload-time = "2026-05-10T18:16:46.039Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ee/8ac720d98548f173c7ce2e632a7ca94673f74cacd5c8162a84af5b35958a/librt-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:ab73e8db5e3f564d812c1f5c3a175930a5f9bc96ccb5e3b22a34d7858b401cf7", size = 115151, upload-time = "2026-05-10T18:16:47.133Z" },
+    { url = "https://files.pythonhosted.org/packages/94/20/c900cf14efeb09b6bef2b2dff20779f73464b97fd58d1c6bccc379588ae3/librt-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aea3caa317752e3a466fa8af45d91ee0ea8c7fdd96e42b0a8dd9b76a7931eba1", size = 98850, upload-time = "2026-05-10T18:16:48.597Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/71/944bfe4b64e12abffcd3c15e1cce07f72f3d55655083786285f4dedeb532/librt-0.11.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d1b36540d7aaf9b9101b3a6f376c8d8e9f7a9aec93ed05918f2c69d493ffef72", size = 151138, upload-time = "2026-05-10T18:16:49.839Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/10/99e64a5c86989357fda078c8143c533389585f6473b7439172dd8f3b3b2d/librt-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:efbb343ab2ce3540f4ecbe6315d677ed70f37cd9a72b1e58066c918ca83acbaa", size = 151976, upload-time = "2026-05-10T18:16:51.062Z" },
+    { url = "https://files.pythonhosted.org/packages/21/31/5072ad880946d83e5ea4147d6d018c78eefce85b77819b19bdd0ee229435/librt-0.11.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0dd688aab3f7914d3e6e5e3554978e0383312fb8e771d84be008a35b9ee548", size = 557927, upload-time = "2026-05-10T18:16:52.632Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8d/70b5fb7cfbab60edbe7381614ab985da58e144fbf465c86d44c95f43cdca/librt-0.11.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f5fb36b8c6c63fdcbb1d526d94c0d1331610d43f4118cc1beb4efef4f3faacb2", size = 539698, upload-time = "2026-05-10T18:16:53.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a3/ba3495a0b3edbd24a4cae0d1d3c64f39a9fc45d06e812101289b50c1a619/librt-0.11.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a9a237d13addb93715b6fee74023d5ee3469b53fce527626c0e088aa585805f", size = 577162, upload-time = "2026-05-10T18:16:55.589Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/db/36e25fb81f99937ff1b96612a1dc9fd66f039cb9cc3aee12c01fac31aab9/librt-0.11.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5ddd17bd87b2c56ddd60e546a7984a2e64c4e8eab92fb4cf3830a48ad5469d51", size = 566494, upload-time = "2026-05-10T18:16:56.975Z" },
+    { url = "https://files.pythonhosted.org/packages/33/0d/3f622b47f0b013eeb9cf4cc07ae9bfe378d832a4eec998b2b209fe84244d/librt-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd43992b4473d42f12ff9e68326079f0696d9d4e6000e8f39a0238d482ba6ee2", size = 596858, upload-time = "2026-05-10T18:16:58.374Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/02/71b90bc93039c46a2000651f6ad60122b114c8f54c4ad306e0e96f5b75ad/librt-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:f8e3e8056dd674e279741485e2e512d6e9a751c7455809d0114e6ebf8d781085", size = 590318, upload-time = "2026-05-10T18:16:59.676Z" },
+    { url = "https://files.pythonhosted.org/packages/04/04/418cb3f75621e2b761fb1ab0f017f4d70a1a72a6e7c74ee4f7e8d198c2f3/librt-0.11.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c1f708d8ae9c56cf38a903c44297243d2ec83fd82b396b977e0144a3e76217e3", size = 575115, upload-time = "2026-05-10T18:17:01.007Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/2c/5a2183ac58dd911f26b5d7e7d7d8f1d87fcecdddd99d6c12169a258ff62c/librt-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0add982e0e7b9fc14cf4b33789d5f13f66581889b88c2f58099f6ce8f92617bd", size = 617918, upload-time = "2026-05-10T18:17:02.682Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1f/dc6771a52592a4451be6effa200cbfc9cec61e4393d3033d81a9d307961d/librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8", size = 103562, upload-time = "2026-05-10T18:17:03.99Z" },
+    { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -623,6 +727,59 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/15/cca9d88503549ed6fedeaa1d448cdddd542ee8a490232d732e278036fbf2/mypy-2.1.0.tar.gz", hash = "sha256:81e76ad12c2d804512e9b13240d1588316531bfba07558286078bfbce9613633", size = 3898359, upload-time = "2026-05-11T18:37:36.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/b1/55861beb5c339b44f9a2ba92df9e2cb1eeb4ae1eee674cdf7772c797778b/mypy-2.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:244358bf1c0da7722230bce60683d52e8e9fd030554926f15b747a84efb5b3af", size = 14874381, upload-time = "2026-05-11T18:37:31.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b3/b7f770114b7d0ac92d0f76e8d93c2780844a70488a90e91821927850da86/mypy-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4ec7c57657493c7a75534df2751c8ae2cda383c16ecc55d2106c54476b1b16f6", size = 13665501, upload-time = "2026-05-11T18:34:23.063Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f3/8ae2037967e2126689a0c11d99e2b707134a565191e92c60ca2572aec60a/mypy-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8161b6ff4392410023224f0969d17db93e1e154bc3e4ba62598e720723ae211", size = 14045750, upload-time = "2026-05-11T18:31:48.151Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/32/615eb5911859e43d054941b0d0a7d06cfa2870eba86529cf385b052b111c/mypy-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf03e12003084a67395184d3eb8cbd6a489dc3655b5664b28c210a9e2403ab0b", size = 15061630, upload-time = "2026-05-11T18:37:06.898Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/03/4eafbfff8bfab1b87082741eae6e6a624028c984e6708b73bce2a8570c9d/mypy-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:20509760fd791c51579d573153407d226385ec1f8bcce55d730b354f3336bc22", size = 15288831, upload-time = "2026-05-11T18:31:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/919661478e5891a3c96e549c036e467e64563ab85995b10c53c8358e16a3/mypy-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:6753d0c1fdd6b1a23b9e4f283ce80b2153b724adcb2653b20b85a8a28ac6436b", size = 11135228, upload-time = "2026-05-11T18:34:31.23Z" },
+    { url = "https://files.pythonhosted.org/packages/24/0a/6a12b9782ca0831a553192f351679f4548abc9d19a7cc93bb7feb02084c7/mypy-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:98ebb6589bb3b6d0c6f0c459d53ca55b8091fbc13d277c4041c885392e8195e8", size = 10040684, upload-time = "2026-05-11T18:36:48.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/dd/c7191469c777f07689c032a8f7326e393ea34c92d6d76eb7ce5ba57ea66d/mypy-2.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:35aac3bb114e03888f535d5eb51b8bafbb3266586b599da1940f9b1be3ec5bd5", size = 14852174, upload-time = "2026-05-11T18:31:38.929Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8c/aed55408879043d72bb9135f4d0d19a02b886dd569631e113e3d2706cb8d/mypy-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8de55a8c861f2a49331f807be98d90caeceeef520bde13d43a160207f8af613e", size = 13651542, upload-time = "2026-05-11T18:36:04.636Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8e/f371a824b1f1fa8ea6e3dbb8703d232977d572be2329554a3bc4d960302f/mypy-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5fdf2941a07434af755837d9880f7d7d25f1dacb1af9dcd4b9b66f2220a3024e", size = 14033929, upload-time = "2026-05-11T18:35:55.742Z" },
+    { url = "https://files.pythonhosted.org/packages/94/21/f54be870d6dd53a82c674407e0f8eed7174b05ec78d42e5abd7b42e84fd5/mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285", size = 15039200, upload-time = "2026-05-11T18:33:10.281Z" },
+    { url = "https://files.pythonhosted.org/packages/17/99/bf21748626a40ce59fd29a39386ab46afec88b7bd2f0fa6c3a97c995523f/mypy-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5431d42af987ebd92ba2f71d45c85ed41d8e6ca9f5fd209a69f68f707d2469e5", size = 15272690, upload-time = "2026-05-11T18:32:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d7/9e90d2cf47100bea550ed2bc7b0d4de3a62181d84d5e37da0003e8462637/mypy-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:767fe8c66dc3e01e19e1737d4c38ebefead16125e1b8e58ad421903b376f5c65", size = 11147435, upload-time = "2026-05-11T18:33:56.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/46/e5c449e858798e35ffc90946282a27c62a77be743fe17480e4977374eb91/mypy-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:ecfe70d43775ab99562ab128ce49854a362044c9f894961f68f898c23cb7429d", size = 10035052, upload-time = "2026-05-11T18:32:30.049Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ca/b279a672e874aedd5498ae25f722dacc8aa86bbffb939b3f97cbb1cf6686/mypy-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7354c5a7f69d9345c3d6e69921d57088eea3ddeeb6b20d34c1b3855b02c36ec2", size = 14848422, upload-time = "2026-05-11T18:35:45.984Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e6/3efe56c631d959b9b4454e208b0ac4b7f4f58b404c89f8bec7b49efdfc21/mypy-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:49890d4f76ac9e06ec117f9e09f3174da70a620a0c300953d8595c926e80947f", size = 13677374, upload-time = "2026-05-11T18:36:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7f/8107ea87a44fd1f1b59882442f033c9c3488c127201b1d1d15f1cbd6022e/mypy-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:761be68e023ef5d94678772396a8af1220030f80837a3afd8d0aef3b419666f4", size = 14055743, upload-time = "2026-05-11T18:35:18.361Z" },
+    { url = "https://files.pythonhosted.org/packages/51/4d/b6d34db183133b83761b9199a82d31557cdbb70a380d8c3b3438e11882a3/mypy-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c90345fc182dc363b891350457ec69c35140858538f38b4540845afcc32b1aef", size = 15020937, upload-time = "2026-05-11T18:34:59.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/d7/f08360c691d758acb02f45022c34d98b92892f4ea756644e1000d4b9f3d8/mypy-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b84802e7b5a6daf1f5e15bc9fcd7ddae77be13981ffab037f1c67bb84d67d135", size = 15253371, upload-time = "2026-05-11T18:36:41.081Z" },
+    { url = "https://files.pythonhosted.org/packages/67/1b/09460a13719530a19bce27bd3bc8449e83569dd2ba7faf51c9c3c30c0b61/mypy-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:022c771234936ceac541ebaf836fe9e2abeb3f5e09aff21588fe543ff006fe21", size = 11326429, upload-time = "2026-05-11T18:34:13.526Z" },
+    { url = "https://files.pythonhosted.org/packages/40/62/75dbf0f82f7b6680340efc614af29dd0b3c17b8a4f1cd09b8bd2fd6bc814/mypy-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:498207db725cec88829a6a5c2fc771205fd043719ef98bc49aba8fb9fc4e6d57", size = 10218799, upload-time = "2026-05-11T18:32:23.491Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/66/caca04ed7d972fb6eb6dd1ccd6df1de5c38fae8c5b3dc1c4e8e0d85ee6b9/mypy-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d5e5cad0efeba72b93cd17490cc0d69c5ac9ca132994fe3fb0314808aeeb83e", size = 15923458, upload-time = "2026-05-11T18:35:28.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/52/2d90cbe49d014b13ed7ff337930c30bad35893fe38a1e4641e756bb62191/mypy-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ff715050c127d724fd260a2e666e7747fdd83511c0c47d449d98238970aef780", size = 14757697, upload-time = "2026-05-11T18:36:14.208Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/37/d98f4a14e081b238992d0ed96b6d39c7cc0148c9699eb71eaa68629665ea/mypy-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82208da9e09414d520e912d3e462d454854bed0810b71540bb016dcbca7308fd", size = 15405638, upload-time = "2026-05-11T18:33:48.249Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c2/15c46613b24a84fad2aea1248bf9619b99c2767ae9071fe224c179a0b7d4/mypy-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e79ebc1b904b84f0310dff7469655a9c36c7a68bddb37bdd42b67a332df61d08", size = 16215852, upload-time = "2026-05-11T18:32:50.296Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/90/9c16a57f482c76d25f6379762b56bbf65c711d8158cf271fb2802cfb0640/mypy-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e583edc957cfb0deb142079162ae826f58449b116c1d442f2d91c69d9fced081", size = 16452695, upload-time = "2026-05-11T18:33:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/4c/215a4eeb63cacc5f17f516691ea7285d11e249802b942476bff15922a314/mypy-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b33b6cd332695bba180d55e717a79d3038e479a2c49cc5eb3d53603409b9a5d7", size = 12866622, upload-time = "2026-05-11T18:34:39.945Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/50/1043e1db5f455ffe4c9ab22747cd8ca2bc492b1e4f4e21b130a44ee2b217/mypy-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:4f910fe825376a7b66ef7ca8c98e5a149e8cd64c19ae71d84047a74ee060d4e6", size = 10610798, upload-time = "2026-05-11T18:36:31.444Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2a/13ca1f292f6db1b98ff495ef3467736b331621c5917cad984b7043e7348d/mypy-2.1.0-py3-none-any.whl", hash = "sha256:a663814603a5c563fb87a4f96fb473eeb30d1f5a4885afcf44f9db000a366289", size = 2693302, upload-time = "2026-05-11T18:31:29.246Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]
@@ -854,6 +1011,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -1632,6 +1798,7 @@ audio = [
 ]
 dev = [
     { name = "coverage" },
+    { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
@@ -1667,6 +1834,7 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'mlx'", specifier = ">=0.27" },
     { name = "keyboard", marker = "sys_platform == 'win32' and extra == 'windows-ui'", specifier = ">=0.13.5" },
     { name = "mlx-audio", extras = ["stt"], marker = "extra == 'mlx'", specifier = ">=0.4.3" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
     { name = "numpy", marker = "extra == 'audio'", specifier = ">=1.26" },
     { name = "pillow", marker = "extra == 'models'", specifier = ">=10" },
     { name = "pillow", marker = "extra == 'windows-ui'", specifier = ">=10" },


### PR DESCRIPTION
## What & why

Implements the type-system correctness audit. The audit **empirically probed `ty` (0.0.35)** and found the decisive fact: `ty` enforces `Literal` at param/assignment/return, but catches **no `== "typo"` comparison** for `Literal`, `StrEnum`, *or* `Enum`. So the right move is **`Literal` everywhere** (not StrEnum/Enum — zero runtime cost, JSON/TOML/shell output byte-identical), annotate the **producers** (not just wire fields), and add a **focused mypy lane** for the one gap `ty` can't cover.

This PR is **annotations + config only — zero observable runtime behavior change.**

## Type aliases (static-only, imported under `TYPE_CHECKING`)

| Alias | Home | Applied to |
|---|---|---|
| `DictationStatus`, `ToggleAction`, `DiscardReason`, `RecordSource` | `service/types.py` | wire TypedDicts + `DictationSession.status()`, `_finish_recording`, `build_health_status`, engine `source` params |
| `SystemPlatform` | `platform/runtime.py` | `PlatformRuntime.system()` (via `cast`), `RuntimeProfile.system`, `SessionInfo.system`; makes the daemon `_PLATFORM_BACKENDS` dict-key invariant enforceable |
| `ASRBackendKind` / `CatalogBackendKind` | `models/types.py` | catalog entries + `normalize_asr_backend`/`validate_asr_model_backend` return types |
| `ASRBackendName` | `asr.py` | the 4 backend `.name` attrs; internal dtype/`_load`/rocm params → `TorchDevice` |
| `DictationCleanup` | `cleanup.py` | `CleanupPlan.dictation_mode` |
| `VoiceMode` (existing) | — | `TranscriptOutcome.voice_mode` + wire `voice_mode` fields |

`desktop/tray/controller.py`: `build_tray_action_callbacks -> dict[TrayAction, Callable]` — **clears the live `ty` errors** at the three `materialize_tray_menu` call sites (dict key invariance).

## `ty` config + checker strategy
- Migrated the one dead `# type: ignore` that `ty` actually errors on (`os.startfile`) to also carry `# ty: ignore[unresolved-attribute]` (`ty` ignores mypy-syntax pragmas).
- Added a **non-blocking mypy lane** (`continue-on-error: true`) configured *only* as a comparison-overlap tripwire: `strict_equality` on, the structural codes `ty` already reports disabled — so it's **green today** and trips only on a real `== "typo"`. Verified: a planted `x == "recoding"` against `Literal["recording","ready"]` → `comparison-overlap` error.
- Documented two follow-ups with measured deltas: widening `[tool.ty.src]` to `scripts`/`tests` (+7 / +259 diagnostics) and per-import scoping of `unresolved-import`.

## Deliberately *not* done (behavior-safety / truthfulness)
- **No `assert_never` added** — every candidate `else`/`default` is a meaningful graceful fallback (e.g. `rule_cleanup`, lifecycle's "unsupported platform" return), and replacing those with a raise would change behavior.
- **No new runtime validation** (e.g. `coerce_setting_value` still accepts what it always did; also found `text_model_runtime`'s real set is `{"transformers","disabled"}`).
- **Wire `asr_backend` left `str`** — its real value is the `ASRBackend.name` set plus *open* producers (`"incremental"`, test `"fake"`), not the catalog `ASRBackendKind`. Typing it would be untruthful.
- Pre-existing `ruff format` drift in 5 touched files left untouched (identical on master, on lines this PR never edited, and not CI-gated).

## Verification
- `uv run -m unittest discover` → **353 passed**
- `uv run ruff check .` → clean
- `uv run ty check` → **41 → 33** (−8; zero net-new diagnostics — the "new" locations are line-shifts of identical pre-existing errors)
- `uv run -m compileall transclip tests scripts` → ok
- `uv run mypy` → **green** (0 comparison-overlap), and confirmed it trips on a planted typo

🤖 Generated with [Claude Code](https://claude.com/claude-code)