### PR TITLE
Fix macOS NAR dictation and hotkey repeat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,11 @@ jobs:
       - name: Unit tests
         run: uv run python -m tests
       - name: MLX import smoke
-        run: uv run python -c "import platform, mlx; from mlx_audio.stt.generate import generate_transcription; print(platform.machine(), generate_transcription)"
+        run: uv run python -c "import platform, mlx; import mlx_audio.stt.models.granite_speech_nar; from mlx_audio.stt.generate import generate_transcription; print(platform.machine(), generate_transcription)"
+      - name: macOS hotkey Swift typecheck
+        run: |
+          uv run python -c "from pathlib import Path; from transclip.desktop.hotkey.macos import build_macos_hotkey_source; Path('/tmp/TransClipHotkey.swift').write_text(build_macos_hotkey_source(Path('/tmp/transclip-toggle'), Path('/tmp/hotkey.log'), Path('/tmp/hotkey-state.tsv')), encoding='utf-8')"
+          xcrun swiftc -typecheck /tmp/TransClipHotkey.swift
 
   windows:
     runs-on: windows-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ build-backend = "hatchling.build"
 [project.optional-dependencies]
 audio = ["sounddevice>=0.5", "numpy>=1.26"]
 models = ["transformers>=4.52.1", "torch>=2.5", "torchaudio>=2.5", "torchcodec>=0.5", "torchvision>=0.20", "accelerate>=1.0", "soundfile>=0.12", "pillow>=10"]
-mlx = ["mlx-audio[stt]>=0.4.3", "huggingface_hub>=0.27", "soundfile>=0.12"]
+mlx = ["mlx-audio[stt]>=0.4.4", "huggingface_hub>=0.27", "soundfile>=0.12"]
 macos-ui = ["pyobjc-framework-Cocoa>=10; sys_platform == 'darwin'"]
 windows-ui = ["pystray>=0.19", "pillow>=10", "keyboard>=0.13.5; sys_platform == 'win32'"]
 dev = [

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -120,6 +120,27 @@ class ASRTests(unittest.TestCase):
         self.assertIn("audio_prepare", second.timings_ms)
         self.assertIn("generate_write", second.timings_ms)
 
+    def test_mlx_audio_preserves_empty_structured_transcript(self):
+        backend = MlxAudioASRBackend(
+            "mlx-community/example",
+            Settings(language="en"),
+            local_files_only=False,
+        )
+        backend.audio_preparer = SimpleNamespace(
+            prepare=lambda path: SimpleNamespace(wav_path=path, sample_rate=16000, temporary=False)
+        )
+
+        with (
+            patch("transclip.asr.load_mlx_model", return_value=object()),
+            patch(
+                "transclip.asr.generate_transcription",
+                return_value=SimpleNamespace(text=""),
+            ),
+        ):
+            result = backend.transcribe(Path("silent.wav"))
+
+        self.assertEqual(result.text, "")
+
     def test_non_granite_model_is_rejected(self):
         with self.assertRaises(ValueError):
             build_asr_backend(Settings(asr_model="openai/whisper-tiny"))

--- a/tests/test_macos_hotkey.py
+++ b/tests/test_macos_hotkey.py
@@ -195,6 +195,52 @@ esac
         self.assertIn("event tap re-enabled", source)
         self.assertIn("event tap listening for Option+Space", source)
 
+    def test_hotkey_source_consumes_shortcut_gesture_without_repeating(self):
+        source = build_macos_hotkey_source(
+            Path("/Users/test/bin/transclip-toggle"),
+            Path("/Users/test/Library/Logs/transclip/hotkey.log"),
+            Path("/Users/test/Library/Logs/transclip/hotkey-state.tsv"),
+        )
+
+        self.assertIn(
+            'process.executableURL = URL(fileURLWithPath: wrapperPath)',
+            source,
+        )
+        self.assertNotIn('process.executableURL = URL(fileURLWithPath: "/bin/sh")', source)
+        self.assertNotIn('process.arguments = ["-lc", wrapperPath]', source)
+        self.assertIn(
+            """CGEventMask(1 << CGEventType.keyDown.rawValue) |
+    CGEventMask(1 << CGEventType.keyUp.rawValue)""",
+            source,
+        )
+        self.assertIn(
+            """if type == .keyUp && keyCode == spaceKeyCode && shortcutIsActive {
+        shortcutIsActive = false
+        return nil
+    }""",
+            source,
+        )
+        self.assertIn(
+            """if keyCode == spaceKeyCode && shortcutIsActive {
+        return nil
+    }""",
+            source,
+        )
+        self.assertIn(
+            """shortcutIsActive = false
+    CGEvent.tapEnable(tap: tap, enable: true)""",
+            source,
+        )
+        self.assertIn(
+            """if isAutoRepeat {
+            return nil
+        }
+        shortcutIsActive = true
+        log("Option+Space detected")
+        runWrapper()""",
+            source,
+        )
+
     def test_installer_writes_helper_app_launch_agent_and_wrapper(self):
         calls = []
 

--- a/transclip/asr.py
+++ b/transclip/asr.py
@@ -367,7 +367,8 @@ class MlxAudioASRBackend:
                             output_stem,
                             language=self.settings.language if self.settings else None,
                         )
-                    text = getattr(result, "text", None) or str(result)
+                    result_text = getattr(result, "text", None)
+                    text = str(result) if result_text is None else str(result_text)
             finally:
                 if audio is not None and getattr(audio, "temporary", False):
                     audio.wav_path.unlink(missing_ok=True)

--- a/transclip/desktop/hotkey/macos.py
+++ b/transclip/desktop/hotkey/macos.py
@@ -455,8 +455,7 @@ Timer.scheduledTimer(
 func runWrapper() {
     hotkeyStatus.setStatus("shortcut", "Shortcut received")
     let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/bin/sh")
-    process.arguments = ["-lc", wrapperPath]
+    process.executableURL = URL(fileURLWithPath: wrapperPath)
     do {
         try process.run()
         log("launched wrapper pid=\\(process.processIdentifier)")
@@ -473,6 +472,7 @@ if !trusted {
 }
 
 var activeEventTap: CFMachPort?
+var shortcutIsActive = false
 
 func reenableEventTap() {
     guard let tap = activeEventTap else {
@@ -480,6 +480,7 @@ func reenableEventTap() {
         return
     }
 
+    shortcutIsActive = false
     CGEvent.tapEnable(tap: tap, enable: true)
     log("event tap re-enabled")
 }
@@ -491,17 +492,37 @@ let callback: CGEventTapCallBack = { _, type, event, _ in
         return Unmanaged.passUnretained(event)
     }
 
-    guard type == .keyDown else {
+    guard type == .keyDown || type == .keyUp else {
         return Unmanaged.passUnretained(event)
     }
 
     let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+
+    if type == .keyUp && keyCode == spaceKeyCode && shortcutIsActive {
+        shortcutIsActive = false
+        return nil
+    }
+
+    guard type == .keyDown else {
+        return Unmanaged.passUnretained(event)
+    }
+
+    let isAutoRepeat = event.getIntegerValueField(.keyboardEventAutorepeat) != 0
+
+    if keyCode == spaceKeyCode && shortcutIsActive {
+        return nil
+    }
+
     let flags = event.flags
     let hasOption = flags.contains(.maskAlternate)
     let hasCommand = flags.contains(.maskCommand)
     let hasControl = flags.contains(.maskControl)
 
     if keyCode == spaceKeyCode && hasOption && !hasCommand && !hasControl {
+        if isAutoRepeat {
+            return nil
+        }
+        shortcutIsActive = true
         log("Option+Space detected")
         runWrapper()
         return nil
@@ -510,7 +531,8 @@ let callback: CGEventTapCallBack = { _, type, event, _ in
     return Unmanaged.passUnretained(event)
 }
 
-let mask = CGEventMask(1 << CGEventType.keyDown.rawValue)
+let mask = CGEventMask(1 << CGEventType.keyDown.rawValue) |
+    CGEventMask(1 << CGEventType.keyUp.rawValue)
 guard let eventTap = CGEvent.tapCreate(
     tap: .cgSessionEventTap,
     place: .headInsertEventTap,

--- a/uv.lock
+++ b/uv.lock
@@ -565,7 +565,7 @@ wheels = [
 
 [[package]]
 name = "mlx-audio"
-version = "0.4.3"
+version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -578,9 +578,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/db/a9f95e3794eca373d681220c8b9f8f84451a0d14959f85cc341ca592394c/mlx_audio-0.4.3.tar.gz", hash = "sha256:8e87badf56a0f73bf91e3797b1195c01440a181cf0b64a2a08dc1bda4b037f54", size = 1144947, upload-time = "2026-04-28T20:18:12.09Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/1e/f712c9f7997e5051c4da3b658f38162203bb703c750741984c8358c8b897/mlx_audio-0.4.4.tar.gz", hash = "sha256:d751e5f477517e4e7f04de5567318e2fe91b4606af5d7e4b2973603c4777814a", size = 1386491, upload-time = "2026-06-06T15:32:03.504Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/25/0a89073ed7b7cdf34299042bd03d867c12c0c8b43f597be61bea7f146793/mlx_audio-0.4.3-py3-none-any.whl", hash = "sha256:6b87bf42d79d9ceb6b9310a77656b9b76429c2d6ddd89f634b2786c58a2e4721", size = 1373582, upload-time = "2026-04-28T20:18:10.512Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4d/93ac0e0526591c856a1ea2cd00a41f31530d9e021cc95bc9400550926d51/mlx_audio-0.4.4-py3-none-any.whl", hash = "sha256:39fe81b03e2b1354be70de82dc8bf01dd6e75efcb464150afef89f18f734d0d5", size = 1669932, upload-time = "2026-06-06T15:32:01.807Z" },
 ]
 
 [package.optional-dependencies]
@@ -1666,7 +1666,7 @@ requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=7.10" },
     { name = "huggingface-hub", marker = "extra == 'mlx'", specifier = ">=0.27" },
     { name = "keyboard", marker = "sys_platform == 'win32' and extra == 'windows-ui'", specifier = ">=0.13.5" },
-    { name = "mlx-audio", extras = ["stt"], marker = "extra == 'mlx'", specifier = ">=0.4.3" },
+    { name = "mlx-audio", extras = ["stt"], marker = "extra == 'mlx'", specifier = ">=0.4.4" },
     { name = "numpy", marker = "extra == 'audio'", specifier = ">=1.26" },
     { name = "pillow", marker = "extra == 'models'", specifier = ">=10" },
     { name = "pillow", marker = "extra == 'windows-ui'", specifier = ">=10" },


### PR DESCRIPTION
## Summary

- require `mlx-audio[stt]>=0.4.4`, refresh `uv.lock`, and smoke-import the Granite Speech NAR implementation in macOS CI
- preserve a valid empty `.text` value from structured MLX transcription results instead of pasting the `STTOutput(...)` representation
- make the native macOS shortcut consume one complete Option+Space gesture, suppress held-key repeats across modifier changes, recover cleanly after event-tap re-enablement, and execute the wrapper path directly
- typecheck the generated Swift helper in macOS CI

Fixes #40
Addresses #41

## Why

The lock previously selected `mlx-audio==0.4.3`, which cannot load the catalogued Granite NAR architecture. After upgrading, silent or empty NAR output exposed a second issue where a structured result was converted to its object representation. The native hotkey also launched multiple toggle processes during keyboard auto-repeat.

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run python -m compileall -q transclip scripts tests`
- [x] `uv run -m unittest tests.test_asr tests.test_macos_hotkey`
- [x] `uv run python -m tests` (355 tests in 40 modules)
- [x] Generate the macOS Swift helper and run `xcrun swiftc -typecheck`
- [x] Independent xhigh reviews covering MLX compatibility, macOS event-tap semantics, test quality, and maintainability; no remaining actionable findings

## Manual verification context

On Apple Silicon, `mlx-audio==0.4.4` loaded `mlx-community/granite-speech-4.1-2b-nar-mlx`, the service reached ready state, and a real silent-audio inference returned an empty transcript after the normalization fix. The final key-up/recovery state-machine hardening is compiler- and regression-tested but still requires the normal live Accessibility/event-tap smoke test in CI-unavailable user-session conditions.