### PR TITLE
Add Intel (OpenVINO) acceleration for integrated GPU / NPU on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,39 @@ Supported ASR on Windows:
 Granite Speech 4.1 NAR and ROCm are not supported on Windows. Eval thresholds
 for Windows Granite AR are in `eval/windows/manifest.json` (relaxed vs Linux NAR).
 
+### Intel acceleration (integrated GPU / NPU) via OpenVINO
+
+Windows laptops with an Intel CPU + integrated GPU (Iris Xe / Arc) and, on Core
+Ultra Series 1/2, an NPU can run accelerated ASR through OpenVINO instead of
+CUDA. IBM Granite Speech has no OpenVINO path, so the Intel build uses **Whisper**
+for ASR and an OpenVINO **Qwen** model for cleanup.
+
+```bash
+uv sync --extra audio --extra openvino --extra windows-ui
+uv run -m transclip.cli init-config
+uv run -m transclip.cli models prefetch --model OpenVINO/whisper-large-v3-int4-ov
+uv run -m transclip.cli models prefetch --model OpenVINO/Qwen2.5-1.5B-Instruct-int4-ov
+uv run -m transclip.cli doctor   # reports detected OpenVINO devices
+```
+
+Requires the Intel **GPU/NPU drivers** to be installed at the OS level (the pip
+wheels ship the runtime but not the device drivers); `doctor` surfaces missing
+devices. When no NVIDIA CUDA is present but an Intel iGPU/NPU is detected,
+`init-config` auto-selects the `windows_openvino` profile (`asr_backend =
+"openvino_whisper"`, `text_model_runtime = "openvino"`).
+
+Selectable OpenVINO ASR models:
+
+- `OpenVINO/whisper-large-v3-int4-ov` (default — fast, int4)
+- `OpenVINO/whisper-large-v3-int8-ov` (higher accuracy)
+- `OpenVINO/whisper-base-int8-ov` (lightweight / quick smoke test)
+- `FluidInference/whisper-large-v3-turbo-int4-ov-npu` (turbo, NPU-pre-exported)
+
+`asr_device` accepts `auto` (OpenVINO `AUTO` picks NPU/GPU/CPU) or an explicit
+`openvino:GPU`, `openvino:NPU`, or `openvino:CPU` (CPU works without Intel
+drivers and is the way to test on any machine). Whisper does not support keyword
+biasing, so keyword hints are ignored on this backend.
+
 ### Permissions (Windows)
 
 | Action | Permission | Notes |

--- a/plans/2026-06-13-intel-openvino-acceleration.md
+++ b/plans/2026-06-13-intel-openvino-acceleration.md
@@ -1,0 +1,196 @@
+# Intel HW Acceleration for TransClip via OpenVINO (Windows v1) — AS-BUILT
+
+> Status: **Shipped.** Committed on branch `intel-accel` and submitted as
+> [paulbrav/TransClip#43](https://github.com/paulbrav/TransClip/pull/43)
+> (fork `sumgup0:intel-accel` → `paulbrav:master`). 21 files changed, +948/−10.
+> Full suite: **377 passed, 2 skipped**; `compileall` clean.
+>
+> This document was updated to reflect what was actually written. A short
+> "Deltas vs original plan" section at the end records where the as-built code
+> diverged from the pre-implementation design.
+
+## Context
+
+TransClip's heavy models run only on NVIDIA CUDA (Windows/Linux), AMD ROCm
+(Linux), or Apple MLX (macOS). On a typical Windows laptop with an Intel CPU +
+integrated GPU (Iris Xe / Arc) and, on Core Ultra 1/2, an NPU, there was **no
+acceleration path** — those machines fell back to `windows_cpu` (slow CPU-torch)
+in [profiles.py](transclip/platform/profiles.py).
+
+The current default ASR model, IBM **Granite Speech 4.1**, is a custom
+speech-encoder + LLM architecture that **OpenVINO / `optimum-intel` do not
+support**. So the Intel story is **"swap Granite→Whisper for ASR + route Qwen
+through OpenVINO for cleanup"**, not "port Granite." Whisper is first-class on
+OpenVINO GenAI (`WhisperPipeline`) and TransClip already ships a Whisper backend
+on Apple Silicon; Qwen is a supported OpenVINO LLM (`LLMPipeline`). Pre-converted
+OpenVINO IR is downloaded from HF, so there is no on-device conversion.
+
+**Scope shipped:** Windows only; accelerate **both** ASR and text cleanup;
+default device **AUTO** (OpenVINO picks NPU/iGPU/CPU); multiple Whisper builds
+(int4 default, int8 accuracy, base lightweight, community turbo-NPU) and two OV
+Qwen builds. Linux OpenVINO was deliberately deferred (its profile branch assumes
+CUDA and would need a guard).
+
+**Outcome:** on an Intel Windows laptop with no NVIDIA GPU, a fresh install
+auto-selects an OpenVINO Whisper backend + OpenVINO Qwen cleanup, accelerated on
+the iGPU/NPU. CUDA/ROCm/MLX/CPU paths are untouched.
+
+## Design principle: keep OpenVINO device strings out of the torch path
+
+OpenVINO uses its own device namespace (`CPU`, `GPU`, `GPU.0`, `NPU`, `AUTO`) via
+`openvino.Core().available_devices`, separate from
+[`resolve_torch_device`](transclip/device.py:11) (cpu/cuda/mps/rocm). The OV
+backends route `asr_device` through `resolve_openvino_device` only; the torch
+resolver is never called for them. `asr_device` is overloaded with namespaced
+values (`auto`, `openvino:AUTO|GPU|NPU|CPU`) — no new ASR-device setting.
+
+## What was built (file-by-file, as shipped)
+
+### 1. `transclip/openvino_device.py` (new)
+Import-safe device layer (never raises, so profile detection can call it):
+- `openvino_available_devices() -> tuple[str, ...]` — `@lru_cache`; `import
+  openvino; tuple(openvino.Core().available_devices)`, `except Exception: ()`.
+  No subprocess smoke test (enumeration is cheap and allocates no device memory).
+- `has_intel_accelerator() -> bool` — any `NPU`/`GPU`/`GPU.*` device.
+- `resolve_openvino_device(requested="auto") -> str` — `auto`→`AUTO`; strips an
+  `openvino:` prefix; `CPU` always allowed; explicit `GPU`/`NPU` verified against
+  available devices (raises `RuntimeError` if absent); unknown → `ValueError`.
+
+### 2. ASR backend: `transclip/asr.py`
+- `OpenVINOWhisperBackend` (mirrors `MlxAudioASRBackend`: lazy, `RLock`-guarded
+  load from a local HF snapshot via `mlx_snapshot_path`). `_load()` imports
+  `openvino_genai`, sets `STATIC_PIPELINE=True` when device == `NPU`, builds
+  `WhisperPipeline(model_dir, device)`. `_read_audio` folds to mono + linear
+  resamples into a 1-D float32 numpy array fed straight to `generate()`.
+  `transcribe()` drops `keywords` (Whisper has no biasing) with a one-time DEBUG
+  log. Timing keys: `model_load` / `audio_prepare` / `generate`.
+- `build_asr_backend` dispatch branch for `openvino_whisper`, routing
+  `settings.asr_device` to the OV resolver (not `resolve_torch_device`).
+- Helpers `_whisper_language_token` (`en`→`<|en|>`) and `_openvino_result_text`.
+- MLX backend timing key renamed `generate_write`→`generate` to unify the
+  snapshot-backend timing schema (no code consumes the key; verified by grep).
+
+### 3. Text-gen backend: `transclip/text_generation.py`
+- `OpenVINOTextGenerationBackend` using `openvino_genai.LLMPipeline`; lazy,
+  lock-guarded; resolves the model dir via `mlx_snapshot_path`; device via
+  `resolve_openvino_device`.
+- `_render_chat_prompt` calls the OV tokenizer's `apply_chat_template` with
+  `enable_thinking=False` (suppresses Qwen `<think>` traces), guarded by
+  `try/except TypeError` for tokenizers/versions that reject the kwarg.
+- `build_text_generation_backend` dispatch for `text_model_runtime == "openvino"`.
+
+### 4. Catalog: `transclip/models/catalog.py` + `types.py`
+- `ModelRuntimeKind` widened with `"openvino"`.
+- **ASR Whisper entries** (`backend="openvino_whisper"`, `runtime_kind="openvino"`,
+  `prefetch_strategy="snapshot_download"`, `dependency_extra="openvino"`,
+  `supported_platforms={"Windows"}`):
+  - `OpenVINO/whisper-large-v3-int4-ov` — **default** (fast int4)
+  - `OpenVINO/whisper-large-v3-int8-ov` — higher accuracy
+  - `OpenVINO/whisper-base-int8-ov` — lightweight / smoke
+  - `FluidInference/whisper-large-v3-turbo-int4-ov-npu` — turbo, NPU-pre-exported
+- **Text Qwen entries** (`backend="text_generation"`, `runtime_kind="openvino"`,
+  `snapshot_download`, `supported_platforms={"Linux","Windows"}`):
+  - `OpenVINO/Qwen2.5-1.5B-Instruct-int4-ov` — default (lightweight)
+  - `OpenVINO/Qwen2.5-7B-Instruct-int4-ov` — higher quality
+- `ASR_BACKEND_ALIASES`: `openvino` / `openvino_whisper` / `ov` / `ov_whisper`
+  → `openvino_whisper`.
+- `validate_asr_model_backend`: guard requiring `"whisper"` in the model id
+  (defensive; matches the existing granite-name guards).
+
+### 5. Prefetch / cache — unchanged
+`prefetch_strategy="snapshot_download"` already routes to
+`huggingface_hub.snapshot_download`; `mlx_snapshot_path` is repo-agnostic and is
+reused directly. (The optional `openvino_snapshot_path` alias from the original
+plan was **not** added — the direct reuse was cleaner.) Only cosmetic change:
+generalized the "MLX" wording in the prefetch ImportError message.
+
+### 6. Platform profile + settings: `platform/profiles.py`, `settings.py`
+- `ProfileRuntimeKind` += `"openvino"`; `ProfileId` += `"windows_openvino"`.
+- `RuntimeProfile` gained `default_text_model_runtime="transformers"` and
+  `default_text_model="Qwen/Qwen3.5-4B"` (defaults match `Settings`, so all other
+  profiles are behavior-preserving).
+- Windows branch: between the CUDA check and the CPU fallback, `if
+  has_intel_accelerator(): return windows_openvino` with
+  `default_asr_backend="openvino_whisper"`,
+  `default_asr_model="OpenVINO/whisper-large-v3-int4-ov"`,
+  `default_asr_device="auto"`, `default_text_model_runtime="openvino"`,
+  `default_text_model="OpenVINO/Qwen2.5-1.5B-Instruct-int4-ov"`. Selection order:
+  **CUDA → Intel-OpenVINO → CPU-torch**.
+- `default_settings` wires `text_model_runtime` and `text_model` from the profile.
+
+### 7. Cleanup gating: `transclip/cleanup.py` (review fix — not in original plan)
+`CleanupPlan.from_settings` previously hard-coded `text_model_runtime ==
+"transformers"`, which on the `windows_openvino` profile silently disabled model
+cleanup **and** hid the OV text model from doctor's cache check (while the engine
+still built/called it → runtime failure on the first shell command). Fixed to
+treat `text_model_runtime in {"transformers", "openvino"}` as model-capable.
+
+### 8. Doctor: `transclip/doctor/asr.py`
+`build_backend_checks` branch for `runtime_kind == "openvino"` →
+`check_openvino_runtime`: imports `openvino` + `openvino_genai`, lists
+`available_devices`, validates the requested device — the user-facing surface for
+the **OS-driver prerequisite**. Exported from `transclip/doctor/__init__.py`.
+
+### 9. Packaging / docs
+- `pyproject.toml`: `openvino = ["openvino-genai>=2025.0", "openvino>=2025.0",
+  "huggingface_hub>=0.27", "soundfile>=0.12", "numpy>=1.26"]`. `uv.lock` updated
+  with openvino / openvino-genai / openvino-tokenizers / openvino-telemetry.
+- `README.md`: "Intel acceleration (integrated GPU / NPU) via OpenVINO" section
+  (install, prefetch, `asr_device` values, model list, caveats).
+
+## Risks / sharp edges (as shipped)
+- **Granite→Whisper is a product change:** different accuracy/latency, and
+  keyword biasing is lost on Intel (documented; keywords silently dropped).
+- **GPU/NPU OS drivers are out-of-band** (pip ships runtime, not drivers); doctor
+  detects and explains.
+- **NPU** needs static shapes (`STATIC_PIPELINE=True`, handled); best on Core
+  Ultra Series 2; cold compile latency (mitigated by lazy load; OpenVINO
+  `CACHE_DIR` warm-up is a future lever, not implemented).
+- **Not validated on real Intel hardware** — no Intel HW on the dev host; the
+  OpenVINO **CPU plugin** path is the proxy that was exercised.
+
+## Verification (as run)
+On this Windows host `ruff`/`ty` cannot execute (Defender blocks the native-binary
+wheels), so the gate was `compileall` + `pytest` rather than `make check`:
+- `.venv/Scripts/python.exe -m compileall -q transclip tests` — clean.
+- `.venv/Scripts/python.exe -m pytest tests/ -q` — **377 passed, 2 skipped**.
+- New tests: `tests/test_openvino_device.py` (resolver, has-accelerator),
+  `test_asr.py` (selection, keyword-drop, NPU `STATIC_PIPELINE` + CPU negative,
+  missing-artifacts error), `test_models.py` (catalog/alias/validation,
+  Windows-only listing), `test_platform_runtime.py` (windows_openvino +
+  regression), `test_text_generation.py` (LLMPipeline path, `enable_thinking`
+  fallback, runtime dispatch), `test_cleanup.py` (openvino runtime gating),
+  `test_doctor.py` (openvino runtime check).
+- End-to-end on Windows: `transclip models list` shows the OV Whisper + Qwen
+  entries with correct backend routing.
+- ruff lint pre-audited against the configured rule set (`B,C4,E,F,I,RUF,SIM,UP`,
+  line-length 120); fixed SIM117/RUF012 in new tests; kept the `elif`+nested-`if`
+  catalog guard (matches existing granite branches on green `master`).
+
+## Critical files
+- [transclip/openvino_device.py](transclip/openvino_device.py) — device resolver (new)
+- [transclip/asr.py](transclip/asr.py) — `OpenVINOWhisperBackend` + dispatch
+- [transclip/text_generation.py](transclip/text_generation.py) — OV `LLMPipeline` backend
+- [transclip/models/catalog.py](transclip/models/catalog.py) + [types.py](transclip/models/types.py)
+- [transclip/platform/profiles.py](transclip/platform/profiles.py) + [settings.py](transclip/settings.py)
+- [transclip/cleanup.py](transclip/cleanup.py) — model-capable runtime gate
+- [transclip/doctor/asr.py](transclip/doctor/asr.py) — OpenVINO runtime check
+- [pyproject.toml](pyproject.toml) — `openvino` extra (+ `uv.lock`)
+
+## Deltas vs original plan
+1. **Default ASR model**: planned `whisper-large-v3-turbo int4`; shipped
+   `OpenVINO/whisper-large-v3-int4-ov` (no *official* turbo exists — turbo is a
+   community catalog option instead).
+2. **OV Qwen entries**: planned one; shipped two (1.5B default + 7B).
+3. **`cleanup.py`**: not in the plan; added as a critical review fix so cleanup +
+   doctor recognize the OpenVINO text runtime.
+4. **`openvino_snapshot_path` alias**: planned (optional); not added — reused
+   `mlx_snapshot_path` directly.
+5. **Settings schema**: plan said "no schema change"; in practice `RuntimeProfile`
+   gained two text-model default fields and `default_settings` was wired to them
+   (the `Settings` dataclass itself is unchanged).
+6. **Timing keys**: unified MLX `generate_write`→`generate` (review follow-up;
+   not in plan).
+7. **`enable_thinking=False`** guard in OV text-gen (review follow-up; not in plan).
+8. **Verification**: plan referenced `make check`; actual gate was
+   `compileall` + `pytest` due to the host Defender quirk.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ build-backend = "hatchling.build"
 audio = ["sounddevice>=0.5", "numpy>=1.26"]
 models = ["transformers>=4.52.1", "torch>=2.5", "torchaudio>=2.5", "torchcodec>=0.5", "torchvision>=0.20", "accelerate>=1.0", "soundfile>=0.12", "pillow>=10"]
 mlx = ["mlx-audio[stt]>=0.4.4", "huggingface_hub>=0.27", "soundfile>=0.12"]
+openvino = ["openvino-genai>=2025.0", "openvino>=2025.0", "huggingface_hub>=0.27", "soundfile>=0.12", "numpy>=1.26"]
 macos-ui = ["pyobjc-framework-Cocoa>=10; sys_platform == 'darwin'"]
 windows-ui = ["pystray>=0.19", "pillow>=10", "keyboard>=0.13.5; sys_platform == 'win32'"]
 dev = [

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -11,9 +11,11 @@ from transclip.asr import (
     GraniteSpeechNarTransformersBackend,
     GraniteSpeechTransformersBackend,
     MlxAudioASRBackend,
+    OpenVINOWhisperBackend,
     _configure_rocm_nar_attention_env,
     _granite_nar_dtype,
     _pad_nar_waveform_to_bucket,
+    _whisper_language_token,
     build_asr_backend,
     granite_user_prompt,
 )
@@ -80,6 +82,134 @@ class ASRTests(unittest.TestCase):
         )
         self.assertIsInstance(backend, MlxAudioASRBackend)
 
+    @staticmethod
+    def _windows_runtime() -> FakeRuntime:
+        return FakeRuntime(system="Windows", home=Path("C:/Users/test"))
+
+    def test_windows_openvino_backend_selection(self):
+        runtime = self._windows_runtime()
+        with patch("transclip.device.torch_cuda_usable", return_value=True):
+            backend = build_asr_backend(
+                Settings(
+                    asr_backend="openvino_whisper",
+                    asr_model="OpenVINO/whisper-large-v3-int4-ov",
+                    asr_device="auto",
+                    models_local_files_only=False,
+                ),
+                runtime=runtime,
+            )
+        self.assertIsInstance(backend, OpenVINOWhisperBackend)
+        self.assertEqual(backend.device, "auto")
+
+    def test_openvino_requires_whisper_model(self):
+        runtime = self._windows_runtime()
+        with (
+            patch("transclip.device.torch_cuda_usable", return_value=True),
+            self.assertRaises(ValueError),
+        ):
+            build_asr_backend(
+                Settings(
+                    asr_backend="openvino_whisper",
+                    asr_model="ibm-granite/granite-speech-4.1-2b",
+                ),
+                runtime=runtime,
+            )
+
+    def test_openvino_transcribe_ignores_keywords_and_uses_pipeline(self):
+        captured = {}
+
+        class FakePipeline:
+            def generate(self, samples, **kwargs):
+                captured["samples_len"] = len(samples)
+                captured["kwargs"] = kwargs
+                return SimpleNamespace(texts=["  hello world  "])
+
+        backend = OpenVINOWhisperBackend(
+            "OpenVINO/whisper-large-v3-int4-ov",
+            Settings(language="en"),
+            device="openvino:CPU",
+            local_files_only=False,
+        )
+        backend._pipeline = FakePipeline()
+        backend._read_audio = lambda _path: np.zeros(16000, dtype=np.float32)
+
+        result = backend.transcribe(Path("a.wav"), keywords=["PyTorch"])
+
+        self.assertEqual(result.text, "hello world")
+        self.assertEqual(captured["samples_len"], 16000)
+        self.assertEqual(captured["kwargs"].get("language"), "<|en|>")
+        self.assertEqual(captured["kwargs"].get("task"), "transcribe")
+        self.assertIn("model_load", result.timings_ms)
+        self.assertIn("generate", result.timings_ms)
+
+    def test_openvino_load_sets_static_pipeline_on_npu(self):
+        captured = {}
+
+        class FakeWhisperPipeline:
+            def __init__(self, model_path, device, **kwargs):
+                captured["model_path"] = model_path
+                captured["device"] = device
+                captured["kwargs"] = kwargs
+
+        fake_genai = SimpleNamespace(WhisperPipeline=FakeWhisperPipeline)
+        backend = OpenVINOWhisperBackend(
+            "OpenVINO/whisper-large-v3-int4-ov",
+            Settings(),
+            device="openvino:NPU",
+            local_files_only=False,
+        )
+        backend._model_path = lambda: "/models/whisper"
+
+        with (
+            patch.dict("sys.modules", {"openvino_genai": fake_genai}),
+            patch(
+                "transclip.openvino_device.openvino_available_devices",
+                return_value=("CPU", "NPU"),
+            ),
+        ):
+            backend._load()
+
+        self.assertEqual(captured["device"], "NPU")
+        self.assertTrue(captured["kwargs"].get("STATIC_PIPELINE"))
+
+    def test_openvino_load_skips_static_pipeline_on_cpu(self):
+        captured = {}
+
+        class FakeWhisperPipeline:
+            def __init__(self, model_path, device, **kwargs):
+                captured["device"] = device
+                captured["kwargs"] = kwargs
+
+        fake_genai = SimpleNamespace(WhisperPipeline=FakeWhisperPipeline)
+        backend = OpenVINOWhisperBackend(
+            "OpenVINO/whisper-large-v3-int4-ov",
+            Settings(),
+            device="openvino:CPU",
+            local_files_only=False,
+        )
+        backend._model_path = lambda: "/models/whisper"
+
+        with patch.dict("sys.modules", {"openvino_genai": fake_genai}):
+            backend._load()
+
+        self.assertEqual(captured["device"], "CPU")
+        self.assertNotIn("STATIC_PIPELINE", captured["kwargs"])
+
+    def test_openvino_missing_local_artifacts_raises(self):
+        backend = OpenVINOWhisperBackend(
+            "OpenVINO/whisper-large-v3-int4-ov",
+            Settings(model_cache_dir="/transclip-nonexistent-cache"),
+            local_files_only=True,
+        )
+        with self.assertRaisesRegex(RuntimeError, "prefetch"):
+            backend._model_path()
+
+    def test_whisper_language_token_formatting(self):
+        self.assertEqual(_whisper_language_token("en"), "<|en|>")
+        self.assertEqual(_whisper_language_token("<|fr|>"), "<|fr|>")
+        self.assertEqual(_whisper_language_token(""), "")
+        self.assertEqual(_whisper_language_token(None), "")
+
     def test_mlx_audio_reuses_loaded_model_object_across_transcriptions(self):
         loaded_model = object()
         load_calls = []
@@ -118,7 +248,7 @@ class ASRTests(unittest.TestCase):
         self.assertEqual(second.text, "transcript 2")
         self.assertIn("model_load", second.timings_ms)
         self.assertIn("audio_prepare", second.timings_ms)
-        self.assertIn("generate_write", second.timings_ms)
+        self.assertIn("generate", second.timings_ms)
 
     def test_mlx_audio_preserves_empty_structured_transcript(self):
         backend = MlxAudioASRBackend(

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -60,6 +60,17 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(plan.dictation_mode, "rule")
         self.assertFalse(plan.requires_text_model)
 
+    def test_cleanup_plan_supports_openvino_text_runtime(self):
+        routed = CleanupPlan.from_settings(Settings(text_model_runtime="openvino"))
+        self.assertEqual(routed.dictation_mode, "rule")
+        self.assertTrue(routed.requires_text_model)
+
+        always_on = CleanupPlan.from_settings(
+            Settings(text_model_runtime="openvino", voice_model_cleanup_always_on=True)
+        )
+        self.assertEqual(always_on.dictation_mode, "model")
+        self.assertTrue(always_on.requires_text_model)
+
     def test_model_cleanup_prompt_contract_and_output_parsing(self):
         messages = MODEL_CLEANUP_POLICY.messages("um hello --flag /tmp/file")
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -52,6 +52,26 @@ class DoctorTests(unittest.TestCase):
             (Path(tmp) / "models--Qwen--Qwen3.5-4B").mkdir()
             self.assertTrue(check_model_cache(settings).ok)
 
+    def test_openvino_backend_emits_openvino_runtime_check(self):
+        from transclip.doctor import build_backend_checks
+
+        runtime = FakeRuntime(system="Windows", home=Path("C:/Users/test"))
+        with tempfile.TemporaryDirectory() as tmp:
+            settings = Settings(
+                asr_backend="openvino_whisper",
+                asr_model="OpenVINO/whisper-large-v3-int4-ov",
+                asr_device="openvino:CPU",
+                cleanup_enabled=False,
+                voice_mode_routing_enabled=False,
+                model_cache_dir=tmp,
+            )
+            with patch("transclip.device.torch_cuda_usable", return_value=True):
+                checks = build_backend_checks(settings, runtime)
+
+        openvino_checks = [check for check in checks if check.name == "openvino_runtime"]
+        self.assertEqual(len(openvino_checks), 1)
+        self.assertTrue(openvino_checks[0].detail)
+
     def test_nar_asr_runtime_checks_flash_attn(self):
         torch = SimpleNamespace(
             version=SimpleNamespace(hip=None),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -63,6 +63,39 @@ class ModelsTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "requires asr_backend='granite_nar'"):
             validate_asr_model_backend("granite", "ibm-granite/granite-speech-4.1-2b-nar", runtime)
 
+    def test_openvino_catalog_aliases_and_validation(self):
+        runtime = FakeRuntime(system="Windows", home=Path("C:/Users/test"))
+        asr_rows = {(model.backend, model.model_id) for model in SUPPORTED_MODELS}
+        self.assertIn(("openvino_whisper", "OpenVINO/whisper-large-v3-int4-ov"), asr_rows)
+        self.assertIn(("openvino_whisper", "OpenVINO/whisper-large-v3-int8-ov"), asr_rows)
+        text_rows = {(model.backend, model.model_id) for model in SUPPORTED_TEXT_MODELS}
+        self.assertIn(("text_generation", "OpenVINO/Qwen2.5-1.5B-Instruct-int4-ov"), text_rows)
+
+        self.assertEqual(normalize_asr_backend("openvino"), "openvino_whisper")
+        self.assertEqual(normalize_asr_backend("ov"), "openvino_whisper")
+        with patch("transclip.device.torch_cuda_usable", return_value=True):
+            self.assertEqual(
+                validate_asr_model_backend("openvino", "OpenVINO/whisper-large-v3-int4-ov", runtime),
+                "openvino_whisper",
+            )
+            with self.assertRaises(ValueError):
+                validate_asr_model_backend("openvino", "ibm-granite/granite-speech-4.1-2b", runtime)
+
+    def test_openvino_whisper_entry_uses_snapshot_runtime(self):
+        entry = next(m for m in SUPPORTED_MODELS if m.model_id == "OpenVINO/whisper-large-v3-int4-ov")
+        self.assertEqual(entry.runtime_kind, "openvino")
+        self.assertEqual(entry.prefetch_strategy, "snapshot_download")
+        self.assertEqual(entry.dependency_extra, "openvino")
+
+    def test_openvino_asr_models_listed_only_on_windows(self):
+        runtime = FakeRuntime(system="Windows", home=Path("C:/Users/test"))
+        with patch("transclip.device.torch_cuda_usable", return_value=True):
+            win_ids = {entry.model_id for entry in supported_catalog_entries(runtime)}
+        self.assertIn("OpenVINO/whisper-large-v3-int4-ov", win_ids)
+        with patch_linux_gpu_runtime():
+            lin_ids = {entry.model_id for entry in supported_catalog_entries(linux_gpu_runtime())}
+        self.assertNotIn("OpenVINO/whisper-large-v3-int4-ov", lin_ids)
+
     def test_cache_detection_and_rows_do_not_download(self):
         with tempfile.TemporaryDirectory() as tmp, patch_linux_gpu_runtime():
             runtime = linux_gpu_runtime()

--- a/tests/test_openvino_device.py
+++ b/tests/test_openvino_device.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from transclip.openvino_device import has_intel_accelerator, resolve_openvino_device
+
+
+class OpenVINODeviceTests(unittest.TestCase):
+    @staticmethod
+    def _devices(devices):
+        return patch(
+            "transclip.openvino_device.openvino_available_devices",
+            return_value=tuple(devices),
+        )
+
+    def test_auto_resolves_to_auto_plugin(self):
+        with self._devices(["CPU", "GPU.0", "NPU"]):
+            self.assertEqual(resolve_openvino_device("auto"), "AUTO")
+            self.assertEqual(resolve_openvino_device("openvino:AUTO"), "AUTO")
+            self.assertEqual(resolve_openvino_device(""), "AUTO")
+
+    def test_explicit_gpu_when_present(self):
+        with self._devices(["CPU", "GPU.0"]):
+            self.assertEqual(resolve_openvino_device("openvino:GPU"), "GPU")
+            self.assertEqual(resolve_openvino_device("openvino:GPU.0"), "GPU.0")
+
+    def test_npu_requested_but_absent_raises(self):
+        with self._devices(["CPU", "GPU.0"]), self.assertRaisesRegex(RuntimeError, "NPU"):
+            resolve_openvino_device("openvino:NPU")
+
+    def test_cpu_always_allowed_even_without_devices(self):
+        with self._devices([]):
+            self.assertEqual(resolve_openvino_device("openvino:CPU"), "CPU")
+
+    def test_has_intel_accelerator_detects_gpu_or_npu(self):
+        with self._devices(["CPU", "GPU.0", "NPU"]):
+            self.assertTrue(has_intel_accelerator())
+        with self._devices(["CPU", "NPU"]):
+            self.assertTrue(has_intel_accelerator())
+        with self._devices(["CPU"]):
+            self.assertFalse(has_intel_accelerator())
+        with self._devices([]):
+            self.assertFalse(has_intel_accelerator())
+
+    def test_unknown_device_raises_value_error(self):
+        with self._devices(["CPU"]), self.assertRaises(ValueError):
+            resolve_openvino_device("openvino:TPU")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_platform_runtime.py
+++ b/tests/test_platform_runtime.py
@@ -186,6 +186,36 @@ class PlatformRuntimeTests(unittest.TestCase):
         self.assertIn("ibm-granite/granite-speech-4.1-2b", model_ids)
         self.assertNotIn("ibm-granite/granite-speech-4.1-2b-nar", model_ids)
 
+    def test_windows_openvino_profile_selected_when_intel_accelerator_present(self):
+        runtime = FakeRuntime(system="Windows", home=Path("C:/Users/tester"))
+        with (
+            patch("transclip.device.torch_cuda_usable", return_value=False),
+            patch("transclip.openvino_device.has_intel_accelerator", return_value=True),
+        ):
+            profile = detect_runtime_profile(runtime)
+            settings = default_settings(runtime)
+
+        self.assertEqual(profile.profile_id, "windows_openvino")
+        self.assertEqual(profile.service_manager, "task_scheduler")
+        self.assertEqual(settings.asr_backend, "openvino_whisper")
+        self.assertEqual(settings.asr_model, "OpenVINO/whisper-large-v3-int4-ov")
+        self.assertEqual(settings.asr_device, "auto")
+        self.assertEqual(settings.text_model_runtime, "openvino")
+        self.assertEqual(settings.text_model, "OpenVINO/Qwen2.5-1.5B-Instruct-int4-ov")
+
+    def test_windows_cpu_profile_when_no_cuda_or_intel_accelerator(self):
+        runtime = FakeRuntime(system="Windows", home=Path("C:/Users/tester"))
+        with (
+            patch("transclip.device.torch_cuda_usable", return_value=False),
+            patch("transclip.openvino_device.has_intel_accelerator", return_value=False),
+        ):
+            profile = detect_runtime_profile(runtime)
+            settings = default_settings(runtime)
+
+        self.assertEqual(profile.profile_id, "windows_cpu")
+        self.assertEqual(settings.asr_backend, "granite")
+        self.assertEqual(settings.text_model_runtime, "transformers")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_text_generation.py
+++ b/tests/test_text_generation.py
@@ -2,9 +2,15 @@ import sys
 import threading
 import time
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
-from transclip.text_generation import TransformersTextGenerationBackend
+from transclip.settings import Settings
+from transclip.text_generation import (
+    OpenVINOTextGenerationBackend,
+    TransformersTextGenerationBackend,
+    build_text_generation_backend,
+)
 
 
 class TextGenerationTests(unittest.TestCase):
@@ -52,6 +58,84 @@ class TextGenerationTests(unittest.TestCase):
             backend.generate([{"role": "user", "content": "shell task"}], max_new_tokens=8)
 
         self.assertEqual(state.tokenizer.template_kwargs["enable_thinking"], False)
+
+    def test_openvino_backend_uses_llm_pipeline(self):
+        captured = {}
+
+        class FakeTokenizer:
+            def apply_chat_template(self, messages, **kwargs):
+                captured["messages"] = messages
+                captured["template_kwargs"] = kwargs
+                return "PROMPT"
+
+        class FakePipeline:
+            def get_tokenizer(self):
+                return FakeTokenizer()
+
+            def generate(self, prompt, **kwargs):
+                captured["prompt"] = prompt
+                captured["gen_kwargs"] = kwargs
+                return SimpleNamespace(texts=["  cleaned text  "])
+
+        backend = OpenVINOTextGenerationBackend(
+            "OpenVINO/Qwen2.5-1.5B-Instruct-int4-ov",
+            Settings(),
+            local_files_only=False,
+        )
+        backend._pipeline = FakePipeline()
+
+        result = backend.generate([{"role": "user", "content": "clean this"}], max_new_tokens=16)
+
+        self.assertEqual(result.text, "cleaned text")
+        self.assertEqual(result.backend, "openvino")
+        self.assertEqual(captured["prompt"], "PROMPT")
+        self.assertEqual(captured["gen_kwargs"]["max_new_tokens"], 16)
+        self.assertIs(captured["gen_kwargs"]["do_sample"], False)
+        self.assertTrue(captured["template_kwargs"]["add_generation_prompt"])
+        self.assertIs(captured["template_kwargs"]["enable_thinking"], False)
+
+    def test_openvino_render_prompt_falls_back_when_enable_thinking_unsupported(self):
+        captured = {}
+
+        class StrictTokenizer:
+            def apply_chat_template(self, messages, add_generation_prompt):
+                captured["messages"] = messages
+                captured["add_generation_prompt"] = add_generation_prompt
+                return "PROMPT"
+
+        class FakePipeline:
+            def get_tokenizer(self):
+                return StrictTokenizer()
+
+            def generate(self, prompt, **kwargs):
+                captured["prompt"] = prompt
+                return SimpleNamespace(texts=["ok"])
+
+        backend = OpenVINOTextGenerationBackend(
+            "OpenVINO/Qwen2.5-1.5B-Instruct-int4-ov",
+            Settings(),
+            local_files_only=False,
+        )
+        backend._pipeline = FakePipeline()
+
+        result = backend.generate([{"role": "user", "content": "hi"}], max_new_tokens=4)
+
+        self.assertEqual(result.text, "ok")
+        self.assertEqual(captured["prompt"], "PROMPT")
+        self.assertTrue(captured["add_generation_prompt"])
+
+    def test_build_text_generation_backend_selects_openvino(self):
+        backend = build_text_generation_backend(
+            Settings(
+                text_model_runtime="openvino",
+                text_model="OpenVINO/Qwen2.5-1.5B-Instruct-int4-ov",
+            )
+        )
+        self.assertIsInstance(backend, OpenVINOTextGenerationBackend)
+
+    def test_build_text_generation_backend_rejects_unknown_runtime(self):
+        with self.assertRaises(ValueError):
+            build_text_generation_backend(Settings(text_model_runtime="bogus"))
 
 
 class FakeTransformersState:

--- a/transclip/asr.py
+++ b/transclip/asr.py
@@ -20,6 +20,7 @@ from .models import (
     resolve_catalog_entry,
     validate_asr_model_backend,
 )
+from .openvino_device import resolve_openvino_device
 from .settings import Settings
 from .timing import timed_ms
 
@@ -360,7 +361,7 @@ class MlxAudioASRBackend:
             try:
                 with tempfile.TemporaryDirectory(prefix="transclip-mlx-") as tmp:
                     output_stem = str(Path(tmp) / "transcript")
-                    with timed_ms(timings, "generate_write"):
+                    with timed_ms(timings, "generate"):
                         result = generate_transcription(
                             model,
                             audio.wav_path,
@@ -373,6 +374,124 @@ class MlxAudioASRBackend:
                 if audio is not None and getattr(audio, "temporary", False):
                     audio.wav_path.unlink(missing_ok=True)
         return TranscriptionResult(text.strip(), timings, self.name, self.model)
+
+
+class OpenVINOWhisperBackend:
+    """Whisper ASR accelerated on Intel CPU/iGPU/NPU via OpenVINO GenAI.
+
+    Mirrors MlxAudioASRBackend: lazy, lock-guarded pipeline load from a local HF
+    snapshot. OpenVINO uses its own device namespace (CPU/GPU/NPU/AUTO) resolved
+    by resolve_openvino_device, kept separate from the torch device path.
+    """
+
+    name = "openvino-whisper"
+
+    def __init__(
+        self,
+        model: str,
+        settings: Settings | None = None,
+        *,
+        device: str = "auto",
+        local_files_only: bool = True,
+        cache_dir: str = "",
+        validate_cache: bool = False,
+    ):
+        self.model = model
+        self.settings = settings
+        self.device = device
+        self.local_files_only = local_files_only
+        self.cache_dir = cache_dir
+        self._resolved_path: str | None = None
+        self._resolved_device: str | None = None
+        self._pipeline: Any | None = None
+        self._model_lock = threading.RLock()
+        self.audio_preparer = PathAudioPreparer()
+        self._keywords_warned = False
+        if validate_cache:
+            self._model_path()
+
+    def _model_path(self) -> str:
+        if self._resolved_path:
+            return self._resolved_path
+        settings = self.settings
+        if settings is not None:
+            snapshot = mlx_snapshot_path(self.model, settings)
+            if snapshot is not None:
+                self._resolved_path = str(snapshot)
+                return self._resolved_path
+        if self.local_files_only:
+            raise RuntimeError(
+                f"Local OpenVINO model artifacts missing for {self.model}. "
+                f"Run: transclip models prefetch --model {self.model}"
+            )
+        self._resolved_path = self._download_snapshot()
+        return self._resolved_path
+
+    def _download_snapshot(self) -> str:
+        try:
+            from huggingface_hub import snapshot_download
+        except ImportError as exc:
+            raise RuntimeError(
+                "huggingface_hub is required to fetch OpenVINO models. Install transclip[openvino]."
+            ) from exc
+        return snapshot_download(repo_id=self.model, cache_dir=self.cache_dir or None)
+
+    def _ov_device(self) -> str:
+        if self._resolved_device is None:
+            self._resolved_device = resolve_openvino_device(self.device)
+        return self._resolved_device
+
+    def _load(self) -> Any:
+        with self._model_lock:
+            if self._pipeline is not None:
+                return self._pipeline
+            try:
+                import openvino_genai as ov_genai
+            except ImportError as exc:
+                raise RuntimeError(
+                    "openvino-genai is required for the OpenVINO ASR backend. Install transclip[openvino]."
+                ) from exc
+            device = self._ov_device()
+            config: dict[str, Any] = {}
+            if device == "NPU":
+                # The NPU plugin requires static shapes for the Whisper pipeline.
+                config["STATIC_PIPELINE"] = True
+            self._pipeline = ov_genai.WhisperPipeline(self._model_path(), device, **config)
+            return self._pipeline
+
+    def _read_audio(self, wav_path: Path) -> Any:
+        import numpy as np
+
+        loader = self.audio_preparer.loader
+        samples, sample_rate = loader.load_samples(wav_path)
+        mono = loader.fold_mono(samples)
+        if sample_rate != loader.target_sample_rate:
+            mono = _linear_resample(mono, sample_rate, loader.target_sample_rate)
+        return np.ascontiguousarray(mono, dtype=np.float32)
+
+    def _generate(self, pipeline: Any, samples: Any) -> Any:
+        kwargs: dict[str, Any] = {}
+        language = self.settings.language if self.settings else None
+        token = _whisper_language_token(language) if language else ""
+        if token:
+            kwargs["language"] = token
+            kwargs["task"] = "transcribe"
+        return pipeline.generate(samples, **kwargs)
+
+    def transcribe(self, wav_path: Path, keywords: list[str] | None = None) -> TranscriptionResult:
+        if keywords and not self._keywords_warned:
+            logger.debug("OpenVINO Whisper does not support keyword biasing; keywords are ignored")
+            self._keywords_warned = True
+        del keywords
+        timings: dict[str, float] = {}
+        with timed_ms(timings, "asr"):
+            with timed_ms(timings, "model_load"):
+                pipeline = self._load()
+            with timed_ms(timings, "audio_prepare"):
+                samples = self._read_audio(wav_path)
+            with timed_ms(timings, "generate"):
+                result = self._generate(pipeline, samples)
+        return TranscriptionResult(_openvino_result_text(result).strip(), timings, self.name, self.model)
 
 
 class FileTranscriptASRBackend:
@@ -415,6 +534,14 @@ def build_asr_backend(
             **cache_options,
             validate_cache=settings.models_local_files_only,
         )
+    elif backend_kind == "openvino_whisper":
+        backend = OpenVINOWhisperBackend(
+            settings.asr_model,
+            settings,
+            device=settings.asr_device,
+            **cache_options,
+            validate_cache=settings.models_local_files_only,
+        )
     else:
         backend = GraniteSpeechTransformersBackend(settings.asr_model, torch_device, **cache_options)
     return backend
@@ -445,6 +572,20 @@ def _pad_nar_waveform_to_bucket(
     padded = np.zeros(target, dtype=getattr(waveform, "dtype", np.float32))
     padded[:length] = waveform
     return padded
+
+
+def _whisper_language_token(language: str | None) -> str:
+    lang = (language or "").strip()
+    if not lang or lang.startswith("<|"):
+        return lang
+    return f"<|{lang}|>"
+
+
+def _openvino_result_text(result: Any) -> str:
+    texts = getattr(result, "texts", None)
+    if texts:
+        return str(texts[0])
+    return str(result)
 
 
 def granite_user_prompt(keywords: list[str] | None = None) -> str:

--- a/transclip/cleanup.py
+++ b/transclip/cleanup.py
@@ -73,8 +73,9 @@ class CleanupPlan:
 
     @classmethod
     def from_settings(cls, settings: Settings) -> CleanupPlan:
-        uses_model = settings.text_model_runtime == "transformers" and settings.voice_model_cleanup_always_on
-        requires_text_model = settings.text_model_runtime == "transformers" and (
+        model_capable_runtime = settings.text_model_runtime in {"transformers", "openvino"}
+        uses_model = model_capable_runtime and settings.voice_model_cleanup_always_on
+        requires_text_model = model_capable_runtime and (
             settings.voice_mode_routing_enabled or uses_model
         )
         return cls(

--- a/transclip/doctor/__init__.py
+++ b/transclip/doctor/__init__.py
@@ -22,6 +22,7 @@ from .asr import (
     check_asr_runtime,
     check_incremental_transcription,
     check_model_cache,
+    check_openvino_runtime,
     check_torch_runtime,
 )
 from .platform import (
@@ -42,6 +43,7 @@ __all__ = [
     "check_incremental_transcription",
     "check_microphone_devices",
     "check_model_cache",
+    "check_openvino_runtime",
     "check_paste_tools",
     "check_torch_runtime",
     "checks_as_json",

--- a/transclip/doctor/asr.py
+++ b/transclip/doctor/asr.py
@@ -53,11 +53,43 @@ def build_backend_checks(settings: Settings, runtime: PlatformRuntime | None = N
                 check_incremental_transcription(settings, runtime),
             ]
         )
+    elif entry is not None and entry.runtime_kind == "openvino":
+        checks.append(check_openvino_runtime(settings))
     elif entry is not None and entry.runtime_kind == "torch":
         checks.append(check_torch_runtime(settings, runtime))
     else:
         checks.append(Check("asr_runtime", True, f"{settings.asr_backend} has no extra runtime checks"))
     return checks
+
+
+def check_openvino_runtime(settings: Settings) -> Check:
+    try:
+        import openvino
+    except ImportError as exc:
+        return Check("openvino_runtime", False, f"openvino import failed: {exc}; install transclip[openvino]")
+    try:
+        import openvino_genai  # noqa: F401
+    except ImportError as exc:
+        return Check("openvino_runtime", False, f"openvino-genai import failed: {exc}; install transclip[openvino]")
+    from transclip.openvino_device import openvino_available_devices, resolve_openvino_device
+
+    devices = openvino_available_devices()
+    if not devices:
+        return Check(
+            "openvino_runtime",
+            False,
+            "OpenVINO found no devices; install Intel GPU/NPU drivers (or use asr_device='openvino:CPU')",
+        )
+    version = getattr(openvino, "__version__", "unknown")
+    try:
+        selected = resolve_openvino_device(settings.asr_device)
+    except (RuntimeError, ValueError) as exc:
+        return Check("openvino_runtime", False, f"openvino {version}; devices: {', '.join(devices)}; {exc}")
+    return Check(
+        "openvino_runtime",
+        True,
+        f"openvino {version}; devices: {', '.join(devices)}; using {selected}",
+    )
 
 
 def build_mlx_checks(settings: Settings, runtime: PlatformRuntime | None = None) -> list[Check]:

--- a/transclip/models/catalog.py
+++ b/transclip/models/catalog.py
@@ -74,6 +74,50 @@ MODEL_CATALOG: tuple[ModelCatalogEntry, ...] = (
         dependency_extra="mlx",
         prefetch_strategy="snapshot_download",
     ),
+    ModelCatalogEntry(
+        model_id="OpenVINO/whisper-large-v3-int4-ov",
+        backend="openvino_whisper",
+        display_name="Intel OpenVINO Whisper large-v3 (int4)",
+        runtime_kind="openvino",
+        estimated_bytes=int(1.2 * GIB),
+        supported_platforms=frozenset({"Windows"}),
+        supported_architectures=None,
+        dependency_extra="openvino",
+        prefetch_strategy="snapshot_download",
+    ),
+    ModelCatalogEntry(
+        model_id="OpenVINO/whisper-large-v3-int8-ov",
+        backend="openvino_whisper",
+        display_name="Intel OpenVINO Whisper large-v3 (int8, higher accuracy)",
+        runtime_kind="openvino",
+        estimated_bytes=int(1.8 * GIB),
+        supported_platforms=frozenset({"Windows"}),
+        supported_architectures=None,
+        dependency_extra="openvino",
+        prefetch_strategy="snapshot_download",
+    ),
+    ModelCatalogEntry(
+        model_id="OpenVINO/whisper-base-int8-ov",
+        backend="openvino_whisper",
+        display_name="Intel OpenVINO Whisper base (int8, lightweight)",
+        runtime_kind="openvino",
+        estimated_bytes=int(0.2 * GIB),
+        supported_platforms=frozenset({"Windows"}),
+        supported_architectures=None,
+        dependency_extra="openvino",
+        prefetch_strategy="snapshot_download",
+    ),
+    ModelCatalogEntry(
+        model_id="FluidInference/whisper-large-v3-turbo-int4-ov-npu",
+        backend="openvino_whisper",
+        display_name="Intel OpenVINO Whisper Turbo (int4, NPU-ready)",
+        runtime_kind="openvino",
+        estimated_bytes=int(1.0 * GIB),
+        supported_platforms=frozenset({"Windows"}),
+        supported_architectures=None,
+        dependency_extra="openvino",
+        prefetch_strategy="snapshot_download",
+    ),
 )
 
 SUPPORTED_MODELS = list(MODEL_CATALOG)
@@ -91,6 +135,28 @@ SUPPORTED_TEXT_MODELS = [
         dependency_extra="models",
         prefetch_strategy="transformers",
     ),
+    ModelCatalogEntry(
+        model_id="OpenVINO/Qwen2.5-1.5B-Instruct-int4-ov",
+        backend="text_generation",
+        display_name="OpenVINO Qwen2.5 1.5B Instruct (int4, lightweight)",
+        runtime_kind="openvino",
+        estimated_bytes=int(1.2 * GIB),
+        supported_platforms=frozenset({"Linux", "Windows"}),
+        supported_architectures=None,
+        dependency_extra="openvino",
+        prefetch_strategy="snapshot_download",
+    ),
+    ModelCatalogEntry(
+        model_id="OpenVINO/Qwen2.5-7B-Instruct-int4-ov",
+        backend="text_generation",
+        display_name="OpenVINO Qwen2.5 7B Instruct (int4, higher quality)",
+        runtime_kind="openvino",
+        estimated_bytes=int(5.0 * GIB),
+        supported_platforms=frozenset({"Linux", "Windows"}),
+        supported_architectures=None,
+        dependency_extra="openvino",
+        prefetch_strategy="snapshot_download",
+    ),
 ]
 
 ASR_BACKEND_ALIASES = {
@@ -106,6 +172,10 @@ ASR_BACKEND_ALIASES = {
     "granite_mlx": "granite_mlx",
     "granite_nar_mlx": "granite_nar_mlx",
     "granite-nar-mlx": "granite_nar_mlx",
+    "openvino": "openvino_whisper",
+    "openvino_whisper": "openvino_whisper",
+    "ov": "openvino_whisper",
+    "ov_whisper": "openvino_whisper",
 }
 
 
@@ -190,6 +260,9 @@ def validate_asr_model_backend(
             raise ValueError('Use asr_backend = "granite_nar" with Granite NAR models')
         if "granite-speech" not in model_id:
             raise ValueError("Granite ASR requires an ibm-granite granite-speech model")
+    elif backend == "openvino_whisper":
+        if "whisper" not in model_id.lower():
+            raise ValueError("OpenVINO ASR requires an OpenVINO Whisper model (whisper-*-ov)")
     profile = detect_runtime_profile(runtime)
     if backend == "granite_nar" and profile.granite_nar_unsupported_reason:
         raise ValueError(profile.granite_nar_unsupported_reason)

--- a/transclip/models/prefetch.py
+++ b/transclip/models/prefetch.py
@@ -41,7 +41,10 @@ def _prefetch_snapshot(entry: ModelCatalogEntry, cache_dir: str) -> None:
     try:
         from huggingface_hub import snapshot_download
     except ImportError as exc:
-        raise RuntimeError("huggingface_hub is required for MLX model prefetch.") from exc
+        raise RuntimeError(
+            "huggingface_hub is required to download model snapshots. "
+            "Install transclip[openvino] or transclip[mlx]."
+        ) from exc
     snapshot_download(
         repo_id=entry.model_id,
         cache_dir=cache_dir,

--- a/transclip/models/types.py
+++ b/transclip/models/types.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 GIB = 1024**3
-ModelRuntimeKind = Literal["torch", "mlx", "file"]
+ModelRuntimeKind = Literal["torch", "mlx", "file", "openvino"]
 PrefetchStrategy = Literal["transformers", "snapshot_download", "none"]
 
 

--- a/transclip/openvino_device.py
+++ b/transclip/openvino_device.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+OpenVINODevice = str
+
+_OPENVINO_PREFIX = "openvino:"
+
+
+@lru_cache(maxsize=1)
+def openvino_available_devices() -> tuple[str, ...]:
+    """Return the OpenVINO devices on this host (e.g. CPU, GPU.0, NPU).
+
+    Import-safe: returns an empty tuple when OpenVINO is not installed or device
+    enumeration fails, so callers (profile detection, doctor) never raise.
+    Enumeration is cheap and does not allocate device memory, so unlike the CUDA
+    smoke test there is no subprocess guard.
+    """
+    try:
+        import openvino
+
+        return tuple(openvino.Core().available_devices)
+    except Exception:
+        return ()
+
+
+def has_intel_accelerator() -> bool:
+    """True when an Intel iGPU or NPU is available via OpenVINO.
+
+    Standard OpenVINO only exposes Intel CPU/GPU/NPU plugins, so any GPU/NPU
+    entry implies Intel acceleration. NVIDIA GPUs are not enumerated here.
+    """
+    return any(_is_accelerator(device) for device in openvino_available_devices())
+
+
+def resolve_openvino_device(requested: str = "auto") -> OpenVINODevice:
+    """Translate a settings device value into an OpenVINO device string.
+
+    Accepts ``auto`` and the namespaced forms ``openvino:AUTO|GPU|NPU|CPU``
+    (and indexed GPUs like ``openvino:GPU.1``). ``auto`` maps to OpenVINO's
+    ``AUTO`` plugin, which picks NPU/GPU/CPU itself. Explicit ``GPU``/``NPU``
+    are verified against the available devices; ``CPU`` is always allowed (the
+    universal plugin used for testing without Intel hardware).
+    """
+    value = (requested or "auto").strip()
+    if value.lower().startswith(_OPENVINO_PREFIX):
+        value = value[len(_OPENVINO_PREFIX) :].strip()
+    normalized = value.upper()
+    if normalized in {"", "AUTO"}:
+        return "AUTO"
+    if normalized == "CPU":
+        return "CPU"
+    if normalized in {"NPU", "GPU"} or normalized.startswith("GPU."):
+        available = openvino_available_devices()
+        if not _device_present(normalized, available):
+            listed = ", ".join(available) if available else "none"
+            raise RuntimeError(
+                f"OpenVINO device {normalized!r} was requested, but available devices are: {listed}"
+            )
+        return normalized
+    raise ValueError(
+        f"Unsupported OpenVINO device: {requested!r}. "
+        "Use auto, openvino:AUTO, openvino:GPU, openvino:NPU, or openvino:CPU."
+    )
+
+
+def _is_accelerator(device: str) -> bool:
+    return device in {"NPU", "GPU"} or device.startswith("GPU.")
+
+
+def _device_present(device: str, available: tuple[str, ...]) -> bool:
+    if device in available:
+        return True
+    if device == "GPU":
+        return any(entry == "GPU" or entry.startswith("GPU.") for entry in available)
+    return False

--- a/transclip/platform/profiles.py
+++ b/transclip/platform/profiles.py
@@ -7,13 +7,14 @@ from typing import Literal
 from transclip.platform.runtime import PlatformRuntime, get_runtime
 from transclip.product import CONFIG_DIR_NAME, LOG_DIR_NAME
 
-ProfileRuntimeKind = Literal["torch_cuda", "torch_rocm", "torch_mps", "torch_cpu", "mlx", "file"]
+ProfileRuntimeKind = Literal["torch_cuda", "torch_rocm", "torch_mps", "torch_cpu", "mlx", "openvino", "file"]
 ProfileId = Literal[
     "linux_gpu",
     "linux_cpu",
     "darwin_arm_mlx",
     "darwin_other",
     "windows_cuda",
+    "windows_openvino",
     "windows_cpu",
     "unsupported",
 ]
@@ -32,6 +33,8 @@ class RuntimeProfile:
     granite_nar_unsupported_reason: str | None = None
     incremental_transcription_supported: bool = False
     incremental_transcription_unsupported_reason: str | None = None
+    default_text_model_runtime: str = "transformers"
+    default_text_model: str = "Qwen/Qwen3.5-4B"
     config_dir_name: str = CONFIG_DIR_NAME
     log_dir_name: str = LOG_DIR_NAME
 
@@ -151,6 +154,23 @@ def detect_runtime_profile(runtime: PlatformRuntime | None = None) -> RuntimePro
                 service_manager="task_scheduler",
                 granite_nar_unsupported_reason=GRANITE_NAR_UNSUPPORTED_WINDOWS,
                 incremental_transcription_unsupported_reason=INCREMENTAL_UNSUPPORTED_WINDOWS,
+            )
+        from transclip.openvino_device import has_intel_accelerator
+
+        if has_intel_accelerator():
+            return RuntimeProfile(
+                profile_id="windows_openvino",
+                system=system,
+                architecture=arch,
+                default_asr_backend="openvino_whisper",
+                default_asr_model="OpenVINO/whisper-large-v3-int4-ov",
+                default_asr_device="auto",
+                supported_runtime_kinds=("openvino", "torch_cpu", "file"),
+                service_manager="task_scheduler",
+                granite_nar_unsupported_reason=GRANITE_NAR_UNSUPPORTED_WINDOWS,
+                incremental_transcription_unsupported_reason=INCREMENTAL_UNSUPPORTED_WINDOWS,
+                default_text_model_runtime="openvino",
+                default_text_model="OpenVINO/Qwen2.5-1.5B-Instruct-int4-ov",
             )
         return RuntimeProfile(
             profile_id="windows_cpu",

--- a/transclip/settings.py
+++ b/transclip/settings.py
@@ -77,6 +77,8 @@ def default_settings(runtime: PlatformRuntime | None = None) -> Settings:
         asr_backend=profile.default_asr_backend,
         asr_model=profile.default_asr_model,
         asr_device=profile.default_asr_device,
+        text_model_runtime=profile.default_text_model_runtime,
+        text_model=profile.default_text_model,
     )
 
 

--- a/transclip/text_generation.py
+++ b/transclip/text_generation.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import threading
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Any, Protocol
 
 from .device import resolve_torch_device
+from .models import mlx_snapshot_path
+from .openvino_device import resolve_openvino_device
 from .settings import Settings
 from .timing import timed_ms
 
@@ -106,11 +108,115 @@ def _processor_messages(messages: list[dict[str, str]]) -> list[dict[str, object
     ]
 
 
+class OpenVINOTextGenerationBackend:
+    """Text cleanup / shell generation on Intel CPU/iGPU/NPU via OpenVINO GenAI.
+
+    Mirrors the transformers backend's lazy, lock-guarded load but uses
+    ``openvino_genai.LLMPipeline`` over a local HF snapshot. Defaults to the
+    OpenVINO ``AUTO`` device; large LLMs generally run best on the iGPU.
+    """
+
+    name = "openvino"
+
+    def __init__(
+        self,
+        model_name: str,
+        settings: Settings | None = None,
+        *,
+        device: str = "auto",
+        local_files_only: bool = True,
+        cache_dir: str = "",
+    ):
+        self.model_name = model_name
+        self.settings = settings
+        self.device = device
+        self.local_files_only = local_files_only
+        self.cache_dir = cache_dir
+        self._pipeline: Any | None = None
+        self._resolved_path: str | None = None
+        self._lock = threading.RLock()
+
+    def _model_path(self) -> str:
+        if self._resolved_path:
+            return self._resolved_path
+        settings = self.settings
+        if settings is not None:
+            snapshot = mlx_snapshot_path(self.model_name, settings)
+            if snapshot is not None:
+                self._resolved_path = str(snapshot)
+                return self._resolved_path
+        if self.local_files_only:
+            raise RuntimeError(
+                f"Local OpenVINO model artifacts missing for {self.model_name}. "
+                f"Run: transclip models prefetch --model {self.model_name}"
+            )
+        self._resolved_path = self._download_snapshot()
+        return self._resolved_path
+
+    def _download_snapshot(self) -> str:
+        try:
+            from huggingface_hub import snapshot_download
+        except ImportError as exc:
+            raise RuntimeError(
+                "huggingface_hub is required to fetch OpenVINO models. Install transclip[openvino]."
+            ) from exc
+        return snapshot_download(repo_id=self.model_name, cache_dir=self.cache_dir or None)
+
+    def _load(self):
+        with self._lock:
+            if self._pipeline is not None:
+                return self._pipeline
+            try:
+                import openvino_genai as ov_genai
+            except ImportError as exc:
+                raise RuntimeError(
+                    "openvino-genai is required for the OpenVINO text backend. Install transclip[openvino]."
+                ) from exc
+            device = resolve_openvino_device(self.device)
+            self._pipeline = ov_genai.LLMPipeline(self._model_path(), device)
+            return self._pipeline
+
+    def generate(self, messages: list[dict[str, str]], *, max_new_tokens: int) -> TextGenerationResult:
+        timings: dict[str, float] = {}
+        with self._lock:
+            pipeline = self._load()
+            with timed_ms(timings, "text_generation"):
+                prompt = _render_chat_prompt(pipeline, messages)
+                output = pipeline.generate(prompt, max_new_tokens=max_new_tokens, do_sample=False)
+                text = _openvino_text(output)
+        return TextGenerationResult(text.strip(), timings, self.name, self.model_name)
+
+
+def _render_chat_prompt(pipeline: Any, messages: list[dict[str, str]]) -> str:
+    history = [{"role": message["role"], "content": message["content"]} for message in messages]
+    tokenizer = pipeline.get_tokenizer()
+    # Suppress Qwen "thinking" traces (matches the transformers backend). Not all
+    # OpenVINO tokenizers accept enable_thinking, so fall back when it is rejected.
+    try:
+        return tokenizer.apply_chat_template(history, add_generation_prompt=True, enable_thinking=False)
+    except TypeError:
+        return tokenizer.apply_chat_template(history, add_generation_prompt=True)
+
+
+def _openvino_text(output: Any) -> str:
+    texts = getattr(output, "texts", None)
+    if texts:
+        return str(texts[0])
+    return str(output)
+
+
 def build_text_generation_backend(settings: Settings) -> TextGenerationBackend:
     runtime = settings.text_model_runtime.lower()
     if runtime == "transformers":
         return TransformersTextGenerationBackend(
             settings.text_model,
+            local_files_only=settings.models_local_files_only,
+            cache_dir=settings.model_cache_dir,
+        )
+    if runtime == "openvino":
+        return OpenVINOTextGenerationBackend(
+            settings.text_model,
+            settings,
             local_files_only=settings.models_local_files_only,
             cache_dir=settings.model_cache_dir,
         )

--- a/uv.lock
+++ b/uv.lock
@@ -848,6 +848,82 @@ wheels = [
 ]
 
 [[package]]
+name = "openvino"
+version = "2026.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "openvino-telemetry" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/e5/4b8945f9cdef4273a608b013cf822edcc263e8560918c9776f9476f5f1b2/openvino-2026.2.0-21903-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8ecf8a16cf893f51c5d13e8e6e9cf9bda52f29e1bbc0c24c8656696e1eae124a", size = 31171963, upload-time = "2026-05-28T09:03:40.584Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/79/bd9fbb2e2b8a9ab629e00767aa2b7764f0d5bb8e2c57be620932cb31cd60/openvino-2026.2.0-21903-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c0b35490c2b7041d4a3855563bfec1843c508d235a9a287d8e0526330878fcba", size = 58363572, upload-time = "2026-05-28T09:03:45.379Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/35/bf0f472ded1fd2463c78e6f21c9f70a36e709750aec89a578f9c7d66d5ee/openvino-2026.2.0-21903-cp312-cp312-manylinux_2_35_aarch64.whl", hash = "sha256:57de704e6164902fb749f83674de7a441b45addeff22e9333f7252d782130569", size = 28362975, upload-time = "2026-05-28T09:03:48.669Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4f/80400a0b506acf913ceeb1dccd7b7fd4424828feeea7d958f2d1577b88da/openvino-2026.2.0-21903-cp312-cp312-win_amd64.whl", hash = "sha256:fd9ba2eae04f76ea7266a461aa35b4e8bfd5408d732de96e88060ba9700792e0", size = 76169024, upload-time = "2026-05-28T09:03:53.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/30/2b046a34e5d909077996251d0b645e4886f1b5f4d751c88820529a1a6921/openvino-2026.2.0-21903-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:96acb618bf371312d23f2faf17794d316700fcb463011e574e2fedb434d003c3", size = 31172272, upload-time = "2026-05-28T09:03:56.828Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a6/98ee692cfb10c27a7c624852ba9e2a02035427416ff266bcbe08f24c5f6e/openvino-2026.2.0-21903-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:0de579de9fa467a3fbe02cf40bef46cb6aa1c6065256b29707c355b7c51385e8", size = 58363356, upload-time = "2026-05-28T09:04:01.327Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/95/4c652551ca08ac9f9534709b5b8dec5842ff8636e1f1f001389d65bca760/openvino-2026.2.0-21903-cp313-cp313-manylinux_2_35_aarch64.whl", hash = "sha256:c5eed7a4c886a161e36fb8f08c1e9500abd5fa7c6e6fce61dcd1c3548fffd460", size = 28369847, upload-time = "2026-05-28T09:04:04.633Z" },
+    { url = "https://files.pythonhosted.org/packages/34/01/2f63c58f2655845bbbb3d8fd7eff37f43bbe1837621f01d44572b20ab9f9/openvino-2026.2.0-21903-cp313-cp313-win_amd64.whl", hash = "sha256:1524d9f1b781acf87912169958d6691c2cc4fa37510d176ef34926da05c529bd", size = 76169114, upload-time = "2026-05-28T09:04:09.516Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a4/5bb947c3669a5e01d015dd91437f12a61e56c387960d6fc3846434150613/openvino-2026.2.0-21903-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3d92721402e1ee00e232930e630fe96d2b5ca7af300ad8b5e6b8963b61b27c19", size = 31153192, upload-time = "2026-05-28T09:04:13.183Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/52/271f128e817e666920ffc759549f5042b8b2ac9fec48248ed18e3d434c27/openvino-2026.2.0-21903-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e822fded364c4935b3d852fb07c01c75c01a3e1adfa4c173cc9abee8c3c13695", size = 58365696, upload-time = "2026-05-28T09:04:17.624Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/98/3a0985259739f72b755f73380fe07c704560d6064ada08bc0393a2842169/openvino-2026.2.0-21903-cp314-cp314-manylinux_2_35_aarch64.whl", hash = "sha256:930f500c19c7bd866b6ace9d2ae2a171fdabb8eb5c1219252a15c97dd98ecf92", size = 28376439, upload-time = "2026-05-28T09:04:20.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/15/b83574fe3a12f64f0917bc6ed1e66571a450cda3c01ed6f14f46243a6490/openvino-2026.2.0-21903-cp314-cp314-win_amd64.whl", hash = "sha256:5319d06b9e98dc00d5c164a68dd832e9f72a1091a715175d3d335d951a9e5aa6", size = 76171282, upload-time = "2026-05-28T09:04:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/18/df/6fcd4f4fd651a821452445fc46e61ce49aecfb2f1845d336e4391951f9c8/openvino-2026.2.0-21903-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2994af8dca6ef425a1a3f7ce1a168494c9a30b228b6f46f100b6d95d7335c514", size = 31381302, upload-time = "2026-05-28T09:04:29.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/e9/8cc292936ee85a100a2d0743e4a0a969a775bddbbb296dbdefc99928ac18/openvino-2026.2.0-21903-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:3ffdf1b1b18b10c84967acbe768a0b390cc59c695bbafb9a1b437f60efa0d9f7", size = 58409527, upload-time = "2026-05-28T09:04:33.345Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1b/8389bae5d4d1c24c53321126b2454c001c74c0751bc5546042675e05eb98/openvino-2026.2.0-21903-cp314-cp314t-manylinux_2_35_aarch64.whl", hash = "sha256:b8f0b876e73d3cd1fa09d70834039227514073dd604f9796e439da001046fb75", size = 25519281, upload-time = "2026-05-28T09:04:36.382Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/71/31dbf2238e2c249b662047159aba43a4f86792101c03b3c65865625cd903/openvino-2026.2.0-21903-cp314-cp314t-win_amd64.whl", hash = "sha256:d55fb289b41df099ad708e836c23e4bebda8248623fadf26e02d085ddd16865e", size = 76336598, upload-time = "2026-05-28T09:04:41.479Z" },
+]
+
+[[package]]
+name = "openvino-genai"
+version = "2026.2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openvino-tokenizers" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/67/515e0e50565aabb8eab515b6f21a099d9e09f5d2e23267c31b1cbff48c69/openvino_genai-2026.2.0.0-2350-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7a4c83af31e81944cead792b3056e549052b031f9b238548f83c515378445f92", size = 3654254, upload-time = "2026-05-28T09:13:30.367Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f9/f3a8649a2771d4ddedfca49e8a443e8e5a1ef316f5a4994dbf6d18c01521/openvino_genai-2026.2.0.0-2350-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:89a81227e93cb9b56f27208b1afd91ea766c381ebe5272198287ab9172443470", size = 5278963, upload-time = "2026-05-28T09:13:32.039Z" },
+    { url = "https://files.pythonhosted.org/packages/41/bb/e5b744a57dda602d2197dba8e1bfa60dfafb7c5732cc2ee05b31cc05ff2b/openvino_genai-2026.2.0.0-2350-cp312-cp312-manylinux_2_31_aarch64.whl", hash = "sha256:2ac9980198abfa394542275dd6e022c3e372ff4eec9d41ff5c302cf36c29e378", size = 4643434, upload-time = "2026-05-28T09:13:33.611Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/e9/6bc960052c01408f1df3f23af6fbe68fd1687addaa1283a6310caa8bbaa8/openvino_genai-2026.2.0.0-2350-cp312-cp312-win_amd64.whl", hash = "sha256:f483b5f4b5442561dde0ff56a9f61fb07ac2b35c5e36b8cd5cee74db5ebf8e76", size = 3146098, upload-time = "2026-05-28T09:13:35.062Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/da/9c9ff6db65ca37315049ebd04b39106d705c43123665f276058e7e982846/openvino_genai-2026.2.0.0-2350-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c6025c956e9156d9603b6633fc48de8ecca84cd11a67e4b6df596a089c1ede6d", size = 3654357, upload-time = "2026-05-28T09:13:36.627Z" },
+    { url = "https://files.pythonhosted.org/packages/03/16/4b7a229dd059cbc4b13cb82953072a171a3b617e666facc56d5a026603f4/openvino_genai-2026.2.0.0-2350-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3caf4379ea8b2f510aee1d0ae55dce7197518249ddda66a04643063f79e368f4", size = 5278997, upload-time = "2026-05-28T09:13:38.214Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/62/6447002299d16152830f6a846843afaa942e6c403f6dcd61c04891377e6d/openvino_genai-2026.2.0.0-2350-cp313-cp313-manylinux_2_31_aarch64.whl", hash = "sha256:08a45fa12325e8b1611495f0f8f74fd7e7ab691c5fd6d1d3fc4e96cbd8b49667", size = 4643432, upload-time = "2026-05-28T09:13:39.635Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/4d/e79b1b8900abf848e42dea939537f346f681f746c7d2ee0149971de6ffa3/openvino_genai-2026.2.0.0-2350-cp313-cp313-win_amd64.whl", hash = "sha256:473099902df97317cd42fd362856ee6ed07f07545697af51ae4d790e2bb3d4b9", size = 3146140, upload-time = "2026-05-28T09:13:41.102Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ee/de8bb0019428684773842f04421ed46ad201b371c3d9ce2152e33f6a1b2d/openvino_genai-2026.2.0.0-2350-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:56f6635e8d8b6257034c2d1bd7e06ce42cfa8f96e44f3263fc9b259bca072b2a", size = 3657240, upload-time = "2026-05-28T09:13:42.967Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/4c/504fe7208cb8451e7be99715d3e1b74145e49d8caaf4863f6d6545828409/openvino_genai-2026.2.0.0-2350-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:3831b40f4d02e179afd614d037f017b81bf31ee0412928ca062778e29a09915e", size = 5279762, upload-time = "2026-05-28T09:13:44.516Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/51/ff28251895ed3ffe0c7e1f3c7fa5fd64b7e081cb0f6dcda1e80278db45be/openvino_genai-2026.2.0.0-2350-cp314-cp314-manylinux_2_31_aarch64.whl", hash = "sha256:a6665c37e624164942b54d67c4b477ae9d652a48fa99b12a96d21c64a13df312", size = 4647162, upload-time = "2026-05-28T09:13:45.96Z" },
+    { url = "https://files.pythonhosted.org/packages/97/d8/5cb6fa37fef063fe966e2a94d461f148e8f69d0e9a8e197a6ae978e2da15/openvino_genai-2026.2.0.0-2350-cp314-cp314-win_amd64.whl", hash = "sha256:8de6746a969b359417dc30e08fb22b9b0d9f491d4afed19965e061fe8610d241", size = 3146358, upload-time = "2026-05-28T09:13:47.562Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/c9/fe13caafb668c73e993829bfef0811b49af7c7fbd3d962148d1c465d1060/openvino_genai-2026.2.0.0-2350-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c5528933f3bd3d158a59353c2387648413b421c2c8b99b0d88e188bf31d8dd53", size = 3739459, upload-time = "2026-05-28T09:13:49.017Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e7/736e740252c3a9cd175575e7620e3d322fa1d1b683860ca684d849cbb8a9/openvino_genai-2026.2.0.0-2350-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:820523aff1e1e9e12b48a4c1e078c3d2cbfb85932d95734975bbdc1703752c5c", size = 5290422, upload-time = "2026-05-28T09:13:50.522Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/13/25f0fec8d3ca73d11b4998b75e15314ccef187a253ddc122bc4bff6d98ad/openvino_genai-2026.2.0.0-2350-cp314-cp314t-manylinux_2_31_aarch64.whl", hash = "sha256:e7e061e30a12aa0ad25aa0f0f37787408fcba48ece0a36fa454dcfdf4200460e", size = 4657954, upload-time = "2026-05-28T09:13:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c0/818ca79af4d5dac47fd84921cc9c7d392ffe123e88795e79a9c05beb25e8/openvino_genai-2026.2.0.0-2350-cp314-cp314t-win_amd64.whl", hash = "sha256:e86230496627fb1074188d619d4aa0433ecee0eb44f6701c5d03b829a155c671", size = 3146604, upload-time = "2026-05-28T09:13:53.229Z" },
+]
+
+[[package]]
+name = "openvino-telemetry"
+version = "2025.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/8a/89d82f1a9d913fb266c2e6dc2f6030935db24b7152963a8db6c4f039787f/openvino_telemetry-2025.2.0.tar.gz", hash = "sha256:8bf8127218e51e99547bf38b8fb85a8b31c9bf96e6f3a82eb0b3b6a34155977c", size = 18894, upload-time = "2025-07-07T10:29:51.159Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ac/5ab0ca0aa269ad3c73f7bfc3801b10e5f56f75a31bf68c1ae8bd51cf70a4/openvino_telemetry-2025.2.0-py3-none-any.whl", hash = "sha256:bcb667e83a44f202ecf4cfa49281715c6d7e21499daec04ff853b7f964833599", size = 25227, upload-time = "2025-07-07T10:29:50.189Z" },
+]
+
+[[package]]
+name = "openvino-tokenizers"
+version = "2026.2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openvino" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/6d/1cef7db9de6e1e58e0fd43a282fea8eb2f8cba025e7828b4cc9e76a8a38d/openvino_tokenizers-2026.2.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1e84f3a5a593921d8e39b8c7b89d1ecf8a12c35ca249e35b1af9b5cf348fbb60", size = 1726994, upload-time = "2026-05-28T09:10:35.991Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/07/0fc1fac5bf773c4d5cf54390f5e4e0197836822eadb6a9e0ab396d58495d/openvino_tokenizers-2026.2.0.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:0264203986b19b377cdf19e2ee0237a8f1ec2a9040522585e7c499e51bcf56a9", size = 1802611, upload-time = "2026-05-28T09:10:37.748Z" },
+    { url = "https://files.pythonhosted.org/packages/af/f5/a00cbd683b94d7d6276de9c3e39a2d78adb1b96e0967fa0595ee14ce04df/openvino_tokenizers-2026.2.0.0-py3-none-manylinux_2_31_aarch64.whl", hash = "sha256:3b4b10010d5b23ee4069b0b30cc6671b6054958892bc8ef8bb235804fdcf0e4e", size = 1719332, upload-time = "2026-05-28T09:10:39.023Z" },
+    { url = "https://files.pythonhosted.org/packages/21/ee/4c9b168c91b1ffc88ab659b4e078f473b3f989a8bc1b32fe3be3d9294965/openvino_tokenizers-2026.2.0.0-py3-none-win_amd64.whl", hash = "sha256:18f6395d839be442797e6e3435917f4ba5bdbf32bcacfd53a042e7ee219417e8", size = 1524411, upload-time = "2026-05-28T09:10:40.343Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1654,6 +1730,13 @@ models = [
     { name = "torchvision" },
     { name = "transformers" },
 ]
+openvino = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "openvino" },
+    { name = "openvino-genai" },
+    { name = "soundfile" },
+]
 windows-ui = [
     { name = "keyboard", marker = "sys_platform == 'win32'" },
     { name = "pillow" },
@@ -1665,9 +1748,13 @@ requires-dist = [
     { name = "accelerate", marker = "extra == 'models'", specifier = ">=1.0" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=7.10" },
     { name = "huggingface-hub", marker = "extra == 'mlx'", specifier = ">=0.27" },
+    { name = "huggingface-hub", marker = "extra == 'openvino'", specifier = ">=0.27" },
     { name = "keyboard", marker = "sys_platform == 'win32' and extra == 'windows-ui'", specifier = ">=0.13.5" },
     { name = "mlx-audio", extras = ["stt"], marker = "extra == 'mlx'", specifier = ">=0.4.4" },
     { name = "numpy", marker = "extra == 'audio'", specifier = ">=1.26" },
+    { name = "numpy", marker = "extra == 'openvino'", specifier = ">=1.26" },
+    { name = "openvino", marker = "extra == 'openvino'", specifier = ">=2025.0" },
+    { name = "openvino-genai", marker = "extra == 'openvino'", specifier = ">=2025.0" },
     { name = "pillow", marker = "extra == 'models'", specifier = ">=10" },
     { name = "pillow", marker = "extra == 'windows-ui'", specifier = ">=10" },
     { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin' and extra == 'macos-ui'", specifier = ">=10" },
@@ -1677,6 +1764,7 @@ requires-dist = [
     { name = "sounddevice", marker = "extra == 'audio'", specifier = ">=0.5" },
     { name = "soundfile", marker = "extra == 'mlx'", specifier = ">=0.12" },
     { name = "soundfile", marker = "extra == 'models'", specifier = ">=0.12" },
+    { name = "soundfile", marker = "extra == 'openvino'", specifier = ">=0.12" },
     { name = "torch", marker = "extra == 'models'", specifier = ">=2.5" },
     { name = "torchaudio", marker = "extra == 'models'", specifier = ">=2.5" },
     { name = "torchcodec", marker = "extra == 'models'", specifier = ">=0.5" },
@@ -1684,7 +1772,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'models'", specifier = ">=4.52.1" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a19" },
 ]
-provides-extras = ["audio", "models", "mlx", "macos-ui", "windows-ui", "dev"]
+provides-extras = ["audio", "models", "mlx", "openvino", "macos-ui", "windows-ui", "dev"]
 
 [[package]]
 name = "transformers"


### PR DESCRIPTION
## Summary
Adds an **additive OpenVINO backend (Windows v1)** so machines with an Intel integrated GPU (Iris Xe / Arc) or NPU (Core Ultra Series 1/2) can run accelerated ASR + text cleanup without NVIDIA CUDA. The CUDA / ROCm / MLX / CPU paths are unchanged.

IBM Granite Speech 4.1 (the current default ASR) is a custom speech-encoder + LLM architecture that OpenVINO / optimum-intel do not support, so on Intel the ASR model is swapped to **Whisper** (`openvino_genai.WhisperPipeline`) — the same family TransClip already runs on Apple Silicon via MLX — and the Qwen cleanup model runs via `openvino_genai.LLMPipeline`. Pre-converted OpenVINO IR is downloaded from Hugging Face (no on-device conversion).

A new `windows_openvino` runtime profile is auto-selected when no CUDA is present but an Intel iGPU/NPU is detected (`openvino.Core().available_devices`). `asr_device` defaults to OpenVINO `AUTO` (picks NPU/GPU/CPU) and also accepts `openvino:GPU|NPU|CPU`.

## Models (catalog)
- **ASR (Whisper):** default `OpenVINO/whisper-large-v3-int4-ov` (fast int4); also `OpenVINO/whisper-large-v3-int8-ov` (higher accuracy), `OpenVINO/whisper-base-int8-ov` (lightweight / smoke), `FluidInference/whisper-large-v3-turbo-int4-ov-npu` (turbo, NPU-pre-exported).
- **Cleanup (Qwen):** default `OpenVINO/Qwen2.5-1.5B-Instruct-int4-ov` (lightweight); also `OpenVINO/Qwen2.5-7B-Instruct-int4-ov` (higher quality).

## Changes
- `transclip/openvino_device.py` (new): AUTO/GPU/NPU/CPU resolver + import-safe device enumeration.
- `OpenVINOWhisperBackend` (`asr.py`) and `OpenVINOTextGenerationBackend` (`text_generation.py`) + dispatch in `build_asr_backend` / `build_text_generation_backend`.
- Catalog/types entries, `ASR_BACKEND_ALIASES`, validation guard, new `openvino` runtime kind.
- `windows_openvino` profile + settings defaults; `cleanup.py` treats `openvino` as a model-capable text runtime so cleanup and doctor cover the OV text model.
- `doctor` `check_openvino_runtime` surfaces the Intel GPU/NPU driver prerequisite.
- `openvino` extra in `pyproject.toml` (+ `uv.lock`); README "Intel acceleration" section.

## Caveats
- Whisper has no keyword biasing, so keyword hints are ignored on this backend.
- Requires the Intel GPU/NPU **OS drivers** (the pip wheels ship the runtime, not the drivers); `doctor` reports missing devices.
- NPU uses static-shape pipelines (`STATIC_PIPELINE=True`, handled) and is best on Core Ultra Series 2.

## Test plan
- [x] Full suite on Windows: **377 passed, 2 skipped**; `python -m compileall` clean.
- [x] New tests: device resolution, backend dispatch/selection, NPU `STATIC_PIPELINE` (+ CPU negative), profile detection + regression, cleanup gating, doctor check, OV text-gen (incl. `enable_thinking` fallback), missing-artifacts error.
- [ ] On real Intel hardware: `doctor` lists GPU/NPU and a live dictation runs on the accelerator — not yet validated (no Intel HW on the dev host; the OpenVINO CPU-plugin path is exercised instead).
- ruff/ty were not run on the dev host (a local Defender rule blocks the native-binary wheels); code was written to the project's configured ruff rule set.
