### PR TITLE
Harden Windows 11 support: paste/tray/notification fixes + admin-free Run-key autostart

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,8 +41,9 @@ registers `hotkey_windows` (default `ctrl+shift+space`).
 service manager, and supported runtime kinds. Linux x86_64 defaults to Granite
 NAR with systemd; Linux CPU defaults to Granite AR. macOS Apple Silicon defaults
 to MLX Whisper via `mlx-audio` with launchd. Windows defaults to Granite AR
-(`ibm-granite/granite-speech-4.1-2b`) with CUDA when available and Task
-Scheduler for the background service. Granite NAR is not supported on Windows.
+(`ibm-granite/granite-speech-4.1-2b`) with CUDA when available and a per-user
+logon autostart entry (HKCU Run key) for the background service. Granite NAR is
+not supported on Windows.
 
 **ASR runtime**: The local speech-to-text execution path for a WAV file. It
 includes audio preparation, backend selection, local model loading, transcript

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ uv sync --extra audio --extra mlx --extra macos-ui
 transclip tray
 ```
 
-On Windows, `install` registers a Task Scheduler logon task. Global hotkey
+On Windows, `install` registers a per-user logon autostart entry (an HKCU Run-key
+value, no admin required). Global hotkey
 `ctrl+shift+space` is registered when `transclip tray` is running (Windows tray
 in `transclip.desktop.tray.win32`). Sync optional UI dependencies for the
 system tray and in-process hotkey:
@@ -239,7 +240,9 @@ Requirements: Windows 10+, Python 3.12+, NVIDIA CUDA PyTorch for GPU inference.
 
 ```bash
 uv sync --extra audio --extra models --extra windows-ui
-uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
+# Match the CUDA build to your GPU: Blackwell (RTX 50-series) needs cu128+;
+# older NVIDIA GPUs can use cu124/cu126.
+uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
 uv run -m transclip.cli init-config
 uv run -m transclip.cli models prefetch --model ibm-granite/granite-speech-4.1-2b
 uv run -m transclip.cli install

--- a/README.md
+++ b/README.md
@@ -296,6 +296,13 @@ biasing, so keyword hints are ignored on this backend.
 | Recording | Microphone | Settings > Privacy & security > Microphone |
 | Paste | Focused app | SendInput Ctrl+V; elevated apps may block injection (UIPI) |
 
+**Elevated (administrator) apps:** Windows UIPI blocks a normal-integrity
+process from injecting input into a window owned by a process running as
+administrator. If the transcript is copied to the clipboard but paste does
+nothing in an elevated app (some terminals, installers, or apps "Run as
+administrator"), either run that app without elevation or run TransClip at the
+same elevation. `transclip doctor` reports this under `windows_elevated_paste`.
+
 ## Linux CUDA / ROCm Quick Start
 
 For the portable CPU/CUDA path, install the model extras first:

--- a/README.md
+++ b/README.md
@@ -289,6 +289,9 @@ Selectable OpenVINO ASR models:
 drivers and is the way to test on any machine). Whisper does not support keyword
 biasing, so keyword hints are ignored on this backend.
 
+A future zero-download, on-device Windows speech backend is tracked in
+[docs/windows-roadmap.md](docs/windows-roadmap.md).
+
 ### Permissions (Windows)
 
 | Action | Permission | Notes |

--- a/docs/windows-roadmap.md
+++ b/docs/windows-roadmap.md
@@ -1,0 +1,56 @@
+# Windows roadmap
+
+Deferred Windows enhancements that are larger than the incremental hardening
+already landed. Each entry states why it is not done yet and what adopting it
+would take.
+
+## W5 — On-device Windows Speech Recognition as an ASR backend
+
+**Status:** roadmap (not started). **Target:** Windows 11; **primary value:** a
+zero-download ASR path on Windows.
+
+### What it is
+
+At Build 2026 Microsoft announced a **Speech Recognition API** (public preview)
+as part of the Windows AI APIs / Windows AI Foundry: real-time or batch,
+**on-device** speech-to-text from live audio, shipping in-box on capable
+Windows 11 devices. See the
+[Build 2026 Windows developer recap](https://blogs.windows.com/windowsdeveloper/2026/06/02/build-2026-furthering-windows-as-the-trusted-platform-for-development/)
+and the [Windows notifications/AI overview on Microsoft Learn](https://learn.microsoft.com/en-us/windows/apps/develop/).
+
+### Why it is on-strategy for TransClip
+
+TransClip's default Windows backend is Granite AR, which needs a CUDA PyTorch
+wheel and a multi-GB model download (`transclip models prefetch …`). An in-box
+Windows speech API would give:
+
+- **No model download and no GPU requirement** — works on any capable Win11 box.
+- A natural **lightweight/fallback `asr_backend`** alongside `granite`,
+  `granite_nar`, `mlx`, and the `file:` test backend.
+
+### Why it is deferred (not "cheap/easy")
+
+- It is a **new ASR backend**, not a one-call hygiene fix: it must implement the
+  same engine contract the existing backends use (see `transclip/asr.py` and how
+  `asr_backend` is dispatched) and pass the eval harness.
+- The API is **public preview** and **Windows 11 only**, so it cannot be the
+  default; it would be opt-in via `asr_backend = "windows_speech"`.
+- The exact projection surface must be confirmed at implementation time. Two
+  candidates, both reachable from Python via [pywinrt](https://github.com/pywinrt/pywinrt)
+  `winrt-*` packages (the same mechanism W4 uses for toasts):
+  - the **new** Build 2026 Windows AI speech API (preview), or
+  - the existing **`Windows.Media.SpeechRecognition`** namespace as an interim
+    on-device option.
+
+### What adopting it would take
+
+1. Add a `windows_speech` backend implementing the engine contract; keep it
+   behind a capability check that reports unavailable off Windows 11 / when the
+   projection is missing (mirror `notifications.windows_toast`'s best-effort
+   degradation).
+2. Add the required `winrt-*` namespace packages to the `windows-ui` (or a new
+   `windows-speech`) extra with a `sys_platform == 'win32'` marker.
+3. Wire it into `doctor` (a readiness check) and document it in the README
+   Windows section.
+4. Run the Windows eval (`eval/windows/manifest.json`) to set/verify accuracy
+   and latency gates against Granite AR.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ line-ending = "lf"
 
 [tool.ty.environment]
 python-version = "3.12"
+# Tri-platform codebase: don't assume a single OS, so platform-gated APIs
+# (ctypes.WinDLL, winreg on Windows; mlx/AppKit on macOS) resolve instead of
+# producing false "unresolved" diagnostics on the Linux CI runner.
+python-platform = "all"
 
 [tool.ty.rules]
 # NOTE: unresolved-import is silenced globally because optional/platform-specific

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,15 @@ models = ["transformers>=4.52.1", "torch>=2.5", "torchaudio>=2.5", "torchcodec>=
 mlx = ["mlx-audio[stt]>=0.4.4", "huggingface_hub>=0.27", "soundfile>=0.12"]
 openvino = ["openvino-genai>=2025.0", "openvino>=2025.0", "huggingface_hub>=0.27", "soundfile>=0.12", "numpy>=1.26"]
 macos-ui = ["pyobjc-framework-Cocoa>=10; sys_platform == 'darwin'"]
-windows-ui = ["pystray>=0.19", "pillow>=10", "keyboard>=0.13.5; sys_platform == 'win32'"]
+windows-ui = [
+    "pystray>=0.19",
+    "pillow>=10",
+    "keyboard>=0.13.5; sys_platform == 'win32'",
+    "winrt-runtime>=3.2; sys_platform == 'win32'",
+    "winrt-Windows.UI.Notifications>=3.2; sys_platform == 'win32'",
+    "winrt-Windows.Data.Xml.Dom>=3.2; sys_platform == 'win32'",
+    "winrt-Windows.Foundation>=3.2; sys_platform == 'win32'",
+]
 dev = [
     "coverage[toml]>=7.10",
     "mypy>=1.11",

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -277,18 +277,38 @@ class DaemonTests(unittest.TestCase):
             self.assertTrue(any("ctrl+shift+space" in result.detail for result in results))
             self.assertTrue(any("prefetch" in result.detail for result in results))
 
-    def test_windows_service_state_reports_running_task(self):
+    def test_windows_service_state_detects_running_task_in_any_locale(self):
         runtime = FakeRuntime(
             system="Windows",
             home=Path("C:/Users/test"),
             env={"LOCALAPPDATA": "C:/Users/test/AppData/Local"},
         )
 
-        def running(_command, **_kwargs):
-            return type("Completed", (), {"returncode": 0, "stdout": "Status: Running"})()
+        def runner(command, **_kwargs):
+            if command and "powershell" in command[0].lower():
+                # MSFT_ScheduledTask.State enum is numeric: Running == 4.
+                return type("Completed", (), {"returncode": 0, "stdout": "4"})()
+            # schtasks prints a localized status on non-English Windows; relying
+            # on it would report the task inactive even while it is running.
+            return type("Completed", (), {"returncode": 0, "stdout": "Status: Wird ausgeführt"})()
 
-        state = service_state(runner=running, runtime=runtime)
-        self.assertTrue(state.active)
+        self.assertTrue(service_state(runner=runner, runtime=runtime).active)
+
+    def test_windows_service_state_reports_ready_task_as_inactive(self):
+        runtime = FakeRuntime(
+            system="Windows",
+            home=Path("C:/Users/test"),
+            env={"LOCALAPPDATA": "C:/Users/test/AppData/Local"},
+        )
+
+        def runner(command, **_kwargs):
+            if command and "powershell" in command[0].lower():
+                return type("Completed", (), {"returncode": 0, "stdout": "3"})()  # Ready, not Running
+            return type("Completed", (), {"returncode": 0, "stdout": "TaskName: \\TransClip"})()
+
+        state = service_state(runner=runner, runtime=runtime)
+        self.assertTrue(state.installed)
+        self.assertFalse(state.active)
 
     def test_windows_service_action_runs_schtasks(self):
         calls = []
@@ -330,11 +350,17 @@ class DaemonTests(unittest.TestCase):
             [normalize_path_text(str(part)) for part in command],
         )
 
-    def test_windows_service_state_ignores_running_substring_without_status_line(self):
-        from transclip.daemon.windows import _windows_task_reports_running
+    def test_windows_task_state_parses_numeric_enum(self):
+        from transclip.daemon.windows import _windows_task_state
 
-        self.assertFalse(_windows_task_reports_running("Last Result: Running tasks only"))
-        self.assertTrue(_windows_task_reports_running("Status: Running"))
+        def running(_command, **_kwargs):
+            return type("Completed", (), {"returncode": 0, "stdout": "4\n"})()
+
+        def missing(_command, **_kwargs):
+            return type("Completed", (), {"returncode": 1, "stdout": ""})()
+
+        self.assertEqual(_windows_task_state(running), 4)
+        self.assertIsNone(_windows_task_state(missing))
 
     def test_install_daemon_passes_settings_to_platform_backend(self):
         from transclip.daemon.common import CommandResult

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -16,10 +16,9 @@ from transclip.daemon import (
 )
 from transclip.daemon.linux import build_systemd_unit, install_linux_daemon
 from transclip.daemon.macos import install_macos_daemon, launch_agent_path
-from transclip.daemon.windows import build_task_scheduler_xml, install_windows_daemon
+from transclip.daemon.windows import install_windows_daemon
 from transclip.desktop.hotkey import build_toggle_invocation, windows_hotkey_setup_message
 from transclip.paths import service_settings_path
-from transclip.product import TASK_SCHEDULER_NAME
 from transclip.settings import Settings, write_settings
 
 from tests.service_helpers import FakeRuntime, normalize_path_text
@@ -155,8 +154,7 @@ class DaemonTests(unittest.TestCase):
             self.assertTrue(any("Keyboard Shortcut" in result.detail for result in results))
             self.assertTrue(
                 any(
-                    "Library/Logs/transclip/toggle-record.log"
-                    in normalize_path_text(result.detail)
+                    "Library/Logs/transclip/toggle-record.log" in normalize_path_text(result.detail)
                     for result in results
                 )
             )
@@ -248,69 +246,91 @@ class DaemonTests(unittest.TestCase):
         self.assertFalse(status["paste"]["ok"])
         self.assertIn("wtype unusable", status["paste"]["detail"])
 
-    def test_windows_install_uses_schtasks_and_skips_gnome_shortcut(self):
-        calls = []
-
-        def runner(command, **_kwargs):
-            calls.append(command)
-            return type("Completed", (), {"returncode": 0, "stdout": ""})()
-
-        with tempfile.TemporaryDirectory() as tmp:
-            home = Path(tmp)
-            runtime = FakeRuntime(
-                system="Windows",
-                home=home,
-                env={"LOCALAPPDATA": str(home / "AppData/Local")},
+    def test_windows_install_registers_run_key_autostart_and_skips_gnome_shortcut(self):
+        # The Run key is a per-user registry value (no admin needed); install
+        # also starts the service immediately so status is "active" right away
+        # rather than only after the next sign-in.
+        runtime = FakeRuntime(
+            system="Windows",
+            home=Path("C:/Users/test"),
+            env={"LOCALAPPDATA": "C:/Users/test/AppData/Local"},
+        )
+        with (
+            patch("transclip.daemon.windows._set_autostart") as set_autostart,
+            patch("transclip.daemon.windows._spawn_service") as spawn,
+            patch("transclip.daemon.linux.install_shortcut") as install_shortcut,
+        ):
+            results = install_windows_daemon(
+                runtime=runtime,
+                hotkey_setup_message=windows_hotkey_setup_message,
             )
-            with patch("transclip.daemon.linux.install_shortcut") as install_shortcut:
-                results = install_windows_daemon(
-                    runner=runner,
-                    runtime=runtime,
-                    hotkey_setup_message=windows_hotkey_setup_message,
-                )
 
-            xml_path = home / "AppData/Local/transclip/logs/TransClip.xml"
-            self.assertTrue(xml_path.exists())
-            self.assertIn(["schtasks", "/Create", "/TN", TASK_SCHEDULER_NAME, "/XML", str(xml_path), "/F"], calls)
-            self.assertIn(["schtasks", "/Run", "/TN", TASK_SCHEDULER_NAME], calls)
-            install_shortcut.assert_not_called()
-            self.assertTrue(any("ctrl+shift+space" in result.detail for result in results))
-            self.assertTrue(any("prefetch" in result.detail for result in results))
+        set_autostart.assert_called_once()
+        registered_command = set_autostart.call_args.args[0]
+        self.assertIn("transclip.cli", registered_command)
+        self.assertTrue(registered_command.rstrip().endswith("serve"))
+        spawn.assert_called_once()
+        install_shortcut.assert_not_called()
+        self.assertTrue(any("ctrl+shift+space" in result.detail for result in results))
+        self.assertTrue(any("prefetch" in result.detail for result in results))
 
-    def test_windows_service_state_detects_running_task_in_any_locale(self):
-        runtime = FakeRuntime(
-            system="Windows",
-            home=Path("C:/Users/test"),
-            env={"LOCALAPPDATA": "C:/Users/test/AppData/Local"},
-        )
+    def test_windows_service_state_reports_active_when_service_process_running(self):
+        runtime = FakeRuntime(system="Windows", home=Path("C:/Users/test"))
 
-        def runner(command, **_kwargs):
-            if command and "powershell" in command[0].lower():
-                # MSFT_ScheduledTask.State enum is numeric: Running == 4.
-                return type("Completed", (), {"returncode": 0, "stdout": "4"})()
-            # schtasks prints a localized status on non-English Windows; relying
-            # on it would report the task inactive even while it is running.
-            return type("Completed", (), {"returncode": 0, "stdout": "Status: Wird ausgeführt"})()
+        def runner(_command, **_kwargs):
+            return type("Completed", (), {"returncode": 0, "stdout": "1"})()
 
-        self.assertTrue(service_state(runner=runner, runtime=runtime).active)
+        with patch(
+            "transclip.daemon.windows._autostart_command",
+            return_value="pythonw -m transclip.cli serve",
+        ):
+            state = service_state(runner=runner, runtime=runtime)
 
-    def test_windows_service_state_reports_ready_task_as_inactive(self):
-        runtime = FakeRuntime(
-            system="Windows",
-            home=Path("C:/Users/test"),
-            env={"LOCALAPPDATA": "C:/Users/test/AppData/Local"},
-        )
-
-        def runner(command, **_kwargs):
-            if command and "powershell" in command[0].lower():
-                return type("Completed", (), {"returncode": 0, "stdout": "3"})()  # Ready, not Running
-            return type("Completed", (), {"returncode": 0, "stdout": "TaskName: \\TransClip"})()
-
-        state = service_state(runner=runner, runtime=runtime)
         self.assertTrue(state.installed)
+        self.assertTrue(state.active)
+
+    def test_windows_service_state_reports_inactive_when_no_service_process(self):
+        runtime = FakeRuntime(system="Windows", home=Path("C:/Users/test"))
+
+        def runner(_command, **_kwargs):
+            return type("Completed", (), {"returncode": 0, "stdout": "0"})()
+
+        with patch(
+            "transclip.daemon.windows._autostart_command",
+            return_value="pythonw -m transclip.cli serve",
+        ):
+            state = service_state(runner=runner, runtime=runtime)
+
+        self.assertTrue(state.installed)  # autostart registered
+        self.assertFalse(state.active)  # but no live service process
+
+    def test_windows_service_state_reports_uninstalled_without_autostart(self):
+        runtime = FakeRuntime(system="Windows", home=Path("C:/Users/test"))
+
+        def runner(_command, **_kwargs):
+            return type("Completed", (), {"returncode": 0, "stdout": "0"})()
+
+        with patch("transclip.daemon.windows._autostart_command", return_value=None):
+            state = service_state(runner=runner, runtime=runtime)
+
+        self.assertFalse(state.installed)
         self.assertFalse(state.active)
 
-    def test_windows_service_action_runs_schtasks(self):
+    def test_windows_service_action_start_spawns_registered_command(self):
+        runtime = FakeRuntime(system="Windows", home=Path("C:/Users/test"))
+        with (
+            patch(
+                "transclip.daemon.windows._autostart_command",
+                return_value="pythonw -m transclip.cli serve",
+            ),
+            patch("transclip.daemon.windows._spawn_service") as spawn,
+        ):
+            result = service_action("start", runner=MagicMock(), runtime=runtime)
+
+        self.assertTrue(result.ok)
+        spawn.assert_called_once_with("pythonw -m transclip.cli serve")
+
+    def test_windows_service_action_stop_kills_matching_processes(self):
         calls = []
 
         def runner(command, **_kwargs):
@@ -318,22 +338,23 @@ class DaemonTests(unittest.TestCase):
             return type("Completed", (), {"returncode": 0, "stdout": ""})()
 
         runtime = FakeRuntime(system="Windows", home=Path("C:/Users/test"))
-        result = service_action("start", runner=runner, runtime=runtime)
+        result = service_action("stop", runner=runner, runtime=runtime)
 
         self.assertTrue(result.ok)
-        self.assertIn(["schtasks", "/Run", "/TN", TASK_SCHEDULER_NAME], calls)
+        joined = " ".join(calls[0])
+        self.assertIn("Stop-Process", joined)
+        self.assertIn("serve", joined)  # only the service, not the tray/toggle
 
-    def test_task_scheduler_xml_quotes_settings_paths_with_spaces(self):
-        settings_path = Path("C:/Users/test user/AppData/Roaming/transclip/settings.toml")
-        xml = build_task_scheduler_xml(settings_path)
+    def test_windows_run_key_command_preserves_settings_path_with_spaces(self):
+        from transclip.daemon.windows import _service_command_line
 
-        self.assertIn('encoding="UTF-16"', xml)
-        self.assertIn("<Enabled>true</Enabled>", xml)
-        self.assertIn("<Hidden>true</Hidden>", xml)
-        self.assertIn("test user", xml)
-        self.assertIn("--settings", xml)
-        self.assertIn("-m transclip.cli", xml)
-        self.assertIn(" serve</Arguments>", xml)
+        path = Path("C:/Users/test user/AppData/Roaming/transclip/settings.toml")
+        command = _service_command_line(path)
+
+        self.assertIn("test user", command)
+        self.assertIn("--settings", command)
+        self.assertIn("transclip.cli", command)
+        self.assertTrue(command.rstrip().endswith("serve"))
 
     def test_service_settings_path_preserves_absolute_windows_paths(self):
         path = Path("C:/Users/test user/AppData/Roaming/transclip/settings.toml")
@@ -350,17 +371,17 @@ class DaemonTests(unittest.TestCase):
             [normalize_path_text(str(part)) for part in command],
         )
 
-    def test_windows_task_state_parses_numeric_enum(self):
-        from transclip.daemon.windows import _windows_task_state
+    def test_count_service_processes_parses_powershell_count(self):
+        from transclip.daemon.windows import _count_service_processes
 
         def running(_command, **_kwargs):
-            return type("Completed", (), {"returncode": 0, "stdout": "4\n"})()
+            return type("Completed", (), {"returncode": 0, "stdout": "2\n"})()
 
-        def missing(_command, **_kwargs):
+        def errored(_command, **_kwargs):
             return type("Completed", (), {"returncode": 1, "stdout": ""})()
 
-        self.assertEqual(_windows_task_state(running), 4)
-        self.assertIsNone(_windows_task_state(missing))
+        self.assertEqual(_count_service_processes(running), 2)
+        self.assertEqual(_count_service_processes(errored), 0)
 
     def test_install_daemon_passes_settings_to_platform_backend(self):
         from transclip.daemon.common import CommandResult
@@ -388,6 +409,29 @@ class DaemonTests(unittest.TestCase):
 
         self.assertFalse(results[0].ok)
         self.assertIn("unsupported platform", results[0].detail)
+
+
+@unittest.skipUnless(sys.platform == "win32", "Run-key autostart uses the real Windows registry")
+class WindowsRunKeyRegistryTests(unittest.TestCase):
+    """Exercise the real winreg round-trip the mocked tests stub out.
+
+    Uses a throwaway value name under HKCU\\...\\Run and always cleans it up, so
+    the user's actual ``TransClip`` autostart entry is never touched.
+    """
+
+    def test_autostart_set_read_clear_roundtrip(self) -> None:
+        from transclip.daemon import windows
+
+        with patch.object(windows, "RUN_KEY_VALUE_NAME", "TransClipPytestProbe"):
+            try:
+                self.assertIsNone(windows._autostart_command())  # absent to start
+                windows._set_autostart("pythonw -m transclip.cli serve")
+                self.assertEqual(windows._autostart_command(), "pythonw -m transclip.cli serve")
+                self.assertTrue(windows._clear_autostart())
+                self.assertIsNone(windows._autostart_command())  # gone after clear
+                self.assertFalse(windows._clear_autostart())  # idempotent: already gone
+            finally:
+                windows._clear_autostart()
 
 
 if __name__ == "__main__":

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,3 +1,4 @@
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -37,6 +38,25 @@ class DaemonTests(unittest.TestCase):
         self.assertIn(f"-m transclip.cli --settings {settings_path} serve", normalized_unit)
         self.assertIn("Restart=on-failure", unit)
         self.assertIn("FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE", unit)
+
+    @unittest.skipUnless(sys.platform == "win32", "pythonw swap is Windows-only")
+    def test_service_command_uses_pythonw_on_windows(self):
+        from transclip.daemon.common import service_command
+
+        # The logon Task Scheduler service must not flash a console window;
+        # python.exe is a console-subsystem binary, pythonw.exe is not.
+        self.assertEqual(Path(service_command()[0]).name.lower(), "pythonw.exe")
+
+    def test_service_command_keeps_executable_off_windows(self):
+        from transclip.daemon import common
+
+        # The pythonw swap is Windows-only: systemd/launchd want the real
+        # interpreter and have no console-window problem.
+        with (
+            patch.object(common.sys, "platform", "linux"),
+            patch.object(common.sys, "executable", "/usr/bin/python3"),
+        ):
+            self.assertEqual(common.service_command()[0], "/usr/bin/python3")
 
     def test_linux_install_writes_unit_runs_systemctl_and_installs_shortcut(self):
         calls = []

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -42,7 +42,7 @@ class DaemonTests(unittest.TestCase):
     def test_service_command_uses_pythonw_on_windows(self):
         from transclip.daemon.common import service_command
 
-        # The logon Task Scheduler service must not flash a console window;
+        # The logon autostart service must not flash a console window;
         # python.exe is a console-subsystem binary, pythonw.exe is not.
         self.assertEqual(Path(service_command()[0]).name.lower(), "pythonw.exe")
 
@@ -344,6 +344,12 @@ class DaemonTests(unittest.TestCase):
         joined = " ".join(calls[0])
         self.assertIn("Stop-Process", joined)
         self.assertIn("serve", joined)  # only the service, not the tray/toggle
+        # Constrain to the python interpreter image so the querying PowerShell
+        # process - whose command line also contains these literals - is not
+        # matched and killed by its own pipeline.
+        self.assertIn("$_.Name -like 'python*'", joined)
+        # A PID that exits between enumeration and Stop-Process must stay quiet.
+        self.assertIn("SilentlyContinue", joined)
 
     def test_windows_run_key_command_preserves_settings_path_with_spaces(self):
         from transclip.daemon.windows import _service_command_line

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -326,7 +326,7 @@ card 1: Generic_1 [HD-Audio Generic], device 0: ALC245 Analog [ALC245 Analog]
         self.assertIn("USB Mic", check.detail)
         self.assertIn("Microphone", check.detail)
 
-    def test_windows_service_manager_check_mentions_task_scheduler(self):
+    def test_windows_service_manager_check_mentions_autostart(self):
         from transclip.daemon.common import ServiceState
         from transclip.doctor import check_service_manager
 
@@ -337,7 +337,8 @@ card 1: Generic_1 [HD-Audio Generic], device 0: ALC245 Analog [ALC245 Analog]
         )
 
         self.assertFalse(check.ok)
-        self.assertIn("Task Scheduler", check.detail)
+        self.assertIn("autostart", check.detail)
+        self.assertIn("transclip install", check.detail)
 
     def test_windows_granite_asr_runtime_skips_flash_attn_gate(self):
         settings = Settings(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -293,6 +293,23 @@ card 1: Generic_1 [HD-Audio Generic], device 0: ALC245 Analog [ALC245 Analog]
         self.assertIn("tray", check.detail.lower())
         self.assertNotIn("XF86TouchpadOff", check.detail)
 
+    def test_windows_elevated_paste_note_warns_about_uipi(self):
+        from transclip.doctor.platform import check_windows_elevated_paste
+
+        runtime = FakeRuntime(system="Windows", home=Path("C:/Users/test"))
+        check = check_windows_elevated_paste(runtime)
+
+        self.assertEqual(check.name, "windows_elevated_paste")
+        self.assertIn("UIPI", check.detail)
+        self.assertIn("administrator", check.detail.lower())
+        self.assertFalse(check.required)  # informational, not a failure
+
+    def test_windows_elevated_paste_note_skipped_off_windows(self):
+        from transclip.doctor.platform import check_windows_elevated_paste
+
+        runtime = FakeRuntime(system="Linux", home=Path("/home/test"))
+        self.assertIn("not checked", check_windows_elevated_paste(runtime).detail)
+
     def test_windows_microphone_check_mentions_privacy_settings(self):
         runtime = FakeRuntime(system="Windows", home=Path("C:/Users/test"))
         fake_sd = type(

--- a/tests/test_hotkey_windows.py
+++ b/tests/test_hotkey_windows.py
@@ -51,6 +51,69 @@ class HotkeyWindowsTests(unittest.TestCase):
             self.assertFalse(is_valid_hotkey("definitely not a hotkey!!"))
             self.assertFalse(is_valid_hotkey(""))
 
+    def test_stop_is_idempotent(self):
+        runtime = FakeRuntime(system="Windows", home=Path("C:/Users/test"))
+        removes = []
+
+        def remove_hotkey(handle):
+            removes.append(handle)
+            if len(removes) > 1:
+                raise KeyError(handle)  # keyboard raises if the hotkey is already gone
+
+        keyboard = types.ModuleType("keyboard")
+        keyboard.add_hotkey = MagicMock(return_value="handle-1")
+        keyboard.remove_hotkey = remove_hotkey
+
+        with patch.dict(sys.modules, {"keyboard": keyboard}):
+            stop = start_windows_hotkey(lambda: None, Settings(), runtime)
+            stop()
+            stop()  # second stop must not raise
+
+        self.assertEqual(removes, ["handle-1", "handle-1"])
+
+    def test_pause_capture_resume_does_not_double_remove_hotkey(self):
+        # Reproduces the Set-hotkey "Record keys" crash: pause stops the live
+        # hotkey, then resume (restart) must not try to remove it again.
+        from transclip.desktop.tray.win32 import _capture_hotkey
+
+        runtime = FakeRuntime(system="Windows", home=Path("C:/Users/test"))
+        registered: list[object] = []
+
+        def add_hotkey(_binding, _cb, suppress=False):
+            handle = object()
+            registered.append(handle)
+            return handle
+
+        def remove_hotkey(handle):
+            if handle not in registered:  # keyboard raises if already gone
+                raise KeyError(handle)
+            registered.remove(handle)
+
+        keyboard = types.ModuleType("keyboard")
+        keyboard.add_hotkey = add_hotkey
+        keyboard.remove_hotkey = remove_hotkey
+
+        with patch.dict(sys.modules, {"keyboard": keyboard}):
+            holder: dict[str, object] = {"stop": None}
+
+            def restart():
+                stop = holder["stop"]
+                if stop is not None:
+                    stop()
+                holder["stop"] = start_windows_hotkey(lambda: None, Settings(), runtime)
+
+            def pause():
+                stop = holder["stop"]
+                if stop is not None:
+                    stop()
+                    holder["stop"] = None
+
+            restart()  # initial registration
+            result = _capture_hotkey(pause=pause, resume=restart, read_hotkey=lambda: "ctrl+alt+x")
+
+        self.assertEqual(result, "ctrl+alt+x")
+        self.assertEqual(len(registered), 1)  # exactly one hotkey live after capture
+
     def test_is_valid_hotkey_false_when_keyboard_missing(self):
         with patch.dict(sys.modules, {"keyboard": None}):
             from transclip.desktop.hotkey.windows import is_valid_hotkey

--- a/tests/test_hotkey_windows.py
+++ b/tests/test_hotkey_windows.py
@@ -35,6 +35,28 @@ class HotkeyWindowsTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "only available on Windows"):
             start_windows_hotkey(lambda: None, Settings(), runtime)
 
+    def test_is_valid_hotkey_accepts_parseable_and_rejects_garbage(self):
+        keyboard = types.ModuleType("keyboard")
+
+        def parse_hotkey(binding):
+            if not binding or "!" in binding:
+                raise ValueError(f"unparseable hotkey {binding!r}")
+            return [[(29, "ctrl")]]
+
+        keyboard.parse_hotkey = parse_hotkey
+        with patch.dict(sys.modules, {"keyboard": keyboard}):
+            from transclip.desktop.hotkey.windows import is_valid_hotkey
+
+            self.assertTrue(is_valid_hotkey("ctrl+shift+space"))
+            self.assertFalse(is_valid_hotkey("definitely not a hotkey!!"))
+            self.assertFalse(is_valid_hotkey(""))
+
+    def test_is_valid_hotkey_false_when_keyboard_missing(self):
+        with patch.dict(sys.modules, {"keyboard": None}):
+            from transclip.desktop.hotkey.windows import is_valid_hotkey
+
+            self.assertFalse(is_valid_hotkey("ctrl+shift+space"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -65,6 +65,35 @@ class WindowsToastTests(unittest.TestCase):
             self.assertFalse(notifications.windows_toast("t", "m"))
 
 
+class RecordingToastMessageTests(unittest.TestCase):
+    def _msg(self, **kw):
+        from transclip.desktop.notifications import recording_toast_message
+
+        defaults = {"ok": True, "action": "started", "paste_failed": False, "error": ""}
+        defaults.update(kw)
+        return recording_toast_message(
+            defaults["ok"], defaults["action"], paste_failed=defaults["paste_failed"], error=defaults["error"]
+        )
+
+    def test_started_announces_recording(self):
+        self.assertIn("Recording", self._msg(action="started"))
+
+    def test_stopped_confirms_paste(self):
+        self.assertIn("paste", self._msg(action="stopped").lower())
+
+    def test_stopped_with_blocked_paste_tells_user_to_paste_manually(self):
+        msg = self._msg(action="stopped", paste_failed=True)
+        self.assertIn("Ctrl+V", msg)
+
+    def test_failure_includes_reason(self):
+        msg = self._msg(ok=False, action=None, error="microphone busy")
+        self.assertIn("failed", msg.lower())
+        self.assertIn("microphone busy", msg)
+
+    def test_unknown_action_yields_no_toast(self):
+        self.assertIsNone(self._msg(action=None))
+
+
 @unittest.skipUnless(sys.platform == "win32", "writes to HKCU")
 class RegisterToastAppIdLiveTests(unittest.TestCase):
     def test_register_writes_display_name(self) -> None:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,87 @@
+import sys
+import unittest
+from unittest.mock import patch
+
+
+class ToastXmlTests(unittest.TestCase):
+    def test_toast_xml_escapes_and_includes_text(self) -> None:
+        from transclip.desktop.notifications import toast_xml
+
+        xml = toast_xml("Title & <b>", "Body line")
+        self.assertTrue(xml.startswith("<toast>"))
+        self.assertIn("Title &amp; &lt;b&gt;", xml)
+        self.assertIn("<text>Body line</text>", xml)
+
+
+class WindowsToastTests(unittest.TestCase):
+    def test_returns_false_when_winrt_unavailable(self) -> None:
+        from transclip.desktop import notifications
+
+        with patch.object(notifications, "_winrt_toast_api", side_effect=ImportError):
+            self.assertFalse(notifications.windows_toast("t", "m"))
+
+    def test_drives_winrt_with_app_id_and_text(self) -> None:
+        from transclip.desktop import notifications
+
+        calls: dict[str, object] = {}
+
+        class FakeDoc:
+            def load_xml(self, xml: str) -> None:
+                calls["xml"] = xml
+
+        class FakeToast:
+            def __init__(self, doc: object) -> None:
+                calls["doc"] = doc
+
+        class FakeManager:
+            @staticmethod
+            def create_toast_notifier_with_id(app_id: str):
+                calls["app_id"] = app_id
+
+                class _Notifier:
+                    def show(self, toast: object) -> None:
+                        calls["shown"] = toast
+
+                return _Notifier()
+
+        with patch.object(notifications, "_winrt_toast_api", return_value=(FakeDoc, FakeToast, FakeManager)):
+            ok = notifications.windows_toast("Hello", "World", app_id="com.test.App")
+
+        self.assertTrue(ok)
+        self.assertEqual(calls["app_id"], "com.test.App")
+        self.assertIn("Hello", calls["xml"])
+        self.assertIn("World", calls["xml"])
+        self.assertIsInstance(calls["shown"], FakeToast)
+
+    def test_returns_false_if_show_raises(self) -> None:
+        from transclip.desktop import notifications
+
+        class Boom:
+            @staticmethod
+            def create_toast_notifier_with_id(app_id: str):
+                raise RuntimeError("no shell")
+
+        with patch.object(notifications, "_winrt_toast_api", return_value=(object, object, Boom)):
+            self.assertFalse(notifications.windows_toast("t", "m"))
+
+
+@unittest.skipUnless(sys.platform == "win32", "writes to HKCU")
+class RegisterToastAppIdLiveTests(unittest.TestCase):
+    def test_register_writes_display_name(self) -> None:
+        import winreg
+
+        from transclip.desktop.notifications import register_toast_app_id
+
+        app_id = "com.paulbrav.TransClip.RegTest"
+        key_path = rf"Software\Classes\AppUserModelId\{app_id}"
+        self.assertTrue(register_toast_app_id(app_id, "TransClip Reg Test"))
+        try:
+            with winreg.OpenKey(winreg.HKEY_CURRENT_USER, key_path) as key:
+                value, _ = winreg.QueryValueEx(key, "DisplayName")
+            self.assertEqual(value, "TransClip Reg Test")
+        finally:
+            winreg.DeleteKey(winreg.HKEY_CURRENT_USER, key_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shell_command.py
+++ b/tests/test_shell_command.py
@@ -54,6 +54,23 @@ class ShellCommandTests(unittest.TestCase):
         self.assertFalse(result.ok)
         self.assertIn("syntax error", result.diagnostics[0])
 
+    def test_nonfunctional_bash_skips_validation_instead_of_failing(self):
+        # bash is on PATH but cannot run, e.g. the Windows WSL launcher
+        # (System32\bash.exe) relaying into a distro with no /bin/bash. That
+        # exits 1 (not the syntax-error code 2), so we cannot validate and must
+        # not report a possibly-valid command as invalid Bash.
+        runtime = FakeRuntime(
+            available={"bash": "/usr/bin/bash"},
+            run_func=lambda _command, **_kwargs: completed(
+                1, stderr="<3>WSL (10 - Relay) ERROR: CreateProcessCommon:800: execvpe(/bin/bash) failed"
+            ),
+        )
+
+        result = validate_shell_command("ls -la", Settings(), runtime=runtime)
+
+        self.assertTrue(result.ok)
+        self.assertTrue(result.metadata["bash_nonfunctional"])
+
     def test_shellcheck_syntax_errors_block_but_warnings_do_not(self):
         results = iter(
             [

--- a/tests/test_tray.py
+++ b/tests/test_tray.py
@@ -478,6 +478,12 @@ class TrayTests(unittest.TestCase):
         runtime = FakeRuntime(system="Windows", home=Path("C:/Users/test"))
         with (
             patch("transclip.desktop.tray.get_runtime", return_value=runtime),
+            # Mock the single-instance guard so the test deterministically reaches
+            # the pystray check. The guard runs first; if a real TransClip tray is
+            # running on this host it holds the mutex and run_tray exits 0
+            # ("already running") before ever checking pystray, failing this test.
+            patch("transclip.desktop.tray.win32.acquire_single_instance", return_value=object()),
+            patch("transclip.desktop.tray.win32.release_single_instance"),
             patch.dict(sys.modules, {"pystray": None}),
         ):
             code = run_tray(Settings())
@@ -534,9 +540,7 @@ class TrayTests(unittest.TestCase):
                 setup(self)
                 menu_holder["before_toggle"] = self.menu
                 toggle = next(
-                    item
-                    for item in self.menu.items
-                    if getattr(item, "action", None) and item.text == "Record"
+                    item for item in self.menu.items if getattr(item, "action", None) and item.text == "Record"
                 )
                 toggle.action(None, toggle)
 
@@ -585,9 +589,7 @@ class TrayTests(unittest.TestCase):
             code = run_windows_tray(Settings(), runtime=runtime)
 
         icon = icon_holder["icon"]
-        status = next(
-            item for item in icon.menu.items if getattr(item, "text", "").startswith("Service:")
-        )
+        status = next(item for item in icon.menu.items if getattr(item, "text", "").startswith("Service:"))
         toggle = next(item for item in icon.menu.items if getattr(item, "action", None))
 
         self.assertEqual(code, 0)

--- a/tests/test_tray.py
+++ b/tests/test_tray.py
@@ -497,11 +497,22 @@ class TrayTests(unittest.TestCase):
         menu_holder: dict[str, object] = {}
 
         class FakeMenuItem:
+            # Faithful to pystray: text/enabled are read-only and a callable is
+            # re-evaluated on each read (the previous mutable fake hid the
+            # immutable-MenuItem crash).
             def __init__(self, text, action=None, enabled=True):
-                self.text = text
+                self._text = text
                 self.action = action
-                self.enabled = enabled
+                self._enabled = enabled
                 self.submenu = None
+
+            @property
+            def text(self):
+                return self._text(self) if callable(self._text) else self._text
+
+            @property
+            def enabled(self):
+                return self._enabled(self) if callable(self._enabled) else self._enabled
 
         class FakeMenu:
             def __init__(self, *items):
@@ -515,6 +526,9 @@ class TrayTests(unittest.TestCase):
                 self.menu = menu
                 self.visible = False
                 icon_holder["icon"] = self
+
+            def update_menu(self):
+                menu_holder["update_count"] = menu_holder.get("update_count", 0) + 1
 
             def run(self, setup=None):
                 setup(self)
@@ -565,6 +579,8 @@ class TrayTests(unittest.TestCase):
             patch("transclip.history.read_history", return_value=[]),
             patch("transclip.recording_ops.toggle_recording", fake_toggle),
             patch("transclip.desktop.tray.win32.start_windows_hotkey", return_value=lambda: None),
+            patch("transclip.desktop.tray.win32.acquire_single_instance", return_value=object()),
+            patch("transclip.desktop.tray.win32.release_single_instance"),
         ):
             code = run_windows_tray(Settings(), runtime=runtime)
 
@@ -579,6 +595,8 @@ class TrayTests(unittest.TestCase):
         self.assertIs(menu_holder["before_toggle"], icon.menu)
         self.assertEqual(status.text, "Service: recording")
         self.assertEqual(toggle.text, "Stop + paste")
+        # pystray items are immutable, so the refresh repaints via update_menu.
+        self.assertGreater(menu_holder.get("update_count", 0), 0)
 
 
 def menu_item_by_label(indicator, label: str):

--- a/tests/test_tray_controller.py
+++ b/tests/test_tray_controller.py
@@ -1,3 +1,4 @@
+import contextlib
 import unittest
 from unittest.mock import MagicMock
 
@@ -15,6 +16,10 @@ from tests.service_helpers import FakeRuntime, patch_linux_gpu_runtime
 class RecordingView:
     def __init__(self) -> None:
         self.history: list[tuple[str, str]] = []
+
+    @contextlib.contextmanager
+    def batch(self):
+        yield
 
     def set_label(self, ref: str, text: str) -> None:
         del ref, text

--- a/tests/test_tray_menu_update.py
+++ b/tests/test_tray_menu_update.py
@@ -1,9 +1,11 @@
+import contextlib
 import unittest
 from typing import Any
 from unittest.mock import patch
 
 from transclip.desktop.tray.menu_update import (
     HistoryMenuState,
+    TrayMenuSnapshot,
     after_tray_action,
     apply_menu_snapshot,
     compute_tray_menu_snapshot,
@@ -24,6 +26,12 @@ class RecordingMenuView:
         self.model_labels: list[tuple[Any, str]] = []
         self.history: list[tuple[str, str]] = []
         self.icon: str = ""
+        self.batches = 0
+
+    @contextlib.contextmanager
+    def batch(self):
+        self.batches += 1
+        yield
 
     def set_label(self, ref: str, text: str) -> None:
         self.labels[ref] = text
@@ -39,6 +47,62 @@ class RecordingMenuView:
 
     def set_health_icon(self, icon: str) -> None:
         self.icon = icon
+
+
+class RefDrivenMenuViewBatchTests(unittest.TestCase):
+    def _view(self, repaints):
+        from types import SimpleNamespace
+
+        from transclip.desktop.tray.views import RefDrivenMenuView
+
+        refs = {"status_item": SimpleNamespace(text=""), "partial_item": SimpleNamespace(enabled=True)}
+        view = RefDrivenMenuView(
+            refs,
+            set_item_label=lambda h, t: setattr(h, "text", t),
+            set_item_enabled=lambda h, e: setattr(h, "enabled", e),
+            rebuild_history=lambda _e: None,
+            set_health_icon=lambda _i: None,
+            on_updated=lambda: repaints.append(1),
+        )
+        return view, refs
+
+    def test_batch_coalesces_updates_to_one_repaint(self):
+        repaints: list[int] = []
+        view, refs = self._view(repaints)
+
+        with view.batch():
+            view.set_label("status_item", "a")
+            view.set_label("status_item", "b")
+            view.set_enabled("partial_item", False)
+
+        self.assertEqual(refs["status_item"].text, "b")
+        self.assertFalse(refs["partial_item"].enabled)
+        self.assertEqual(repaints, [1])  # one repaint for the whole batch, not three
+
+    def test_updates_outside_batch_repaint_each_time(self):
+        repaints: list[int] = []
+        view, _ = self._view(repaints)
+
+        view.set_label("status_item", "a")
+        view.set_label("status_item", "b")
+
+        self.assertEqual(repaints, [1, 1])
+
+    def test_apply_menu_snapshot_applies_updates_in_one_batch(self):
+        view = RecordingMenuView()
+        snapshot = TrayMenuSnapshot(
+            status_label="Service: ready",
+            toggle_label="Record",
+            partial_enabled=False,
+            latest_enabled=False,
+            model_cleanup_label="Model cleanup: off",
+            health_icon="ready",
+        )
+
+        apply_menu_snapshot(snapshot, view, model_rows=[])
+
+        self.assertEqual(view.batches, 1)
+        self.assertEqual(view.labels["status_item"], "Service: ready")
 
 
 class TrayMenuUpdateTests(unittest.TestCase):

--- a/tests/test_tray_win32.py
+++ b/tests/test_tray_win32.py
@@ -1,0 +1,70 @@
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+@unittest.skipUnless(sys.platform == "win32", "tray win32 adapter requires pystray/Pillow")
+class TrayWin32HotkeyTests(unittest.TestCase):
+    def test_invalid_binding_is_rejected_without_persisting_or_restarting(self) -> None:
+        from transclip.desktop.tray import win32
+
+        session = MagicMock()
+        session.settings.hotkey_windows = "ctrl+shift+space"
+        restart = MagicMock()
+        with (
+            patch.object(win32, "is_valid_hotkey", return_value=False),
+            patch.object(win32, "patch_settings") as patch_settings_mock,
+        ):
+            win32._apply_hotkey_selection(session, "definitely not!!", restart)
+
+        patch_settings_mock.assert_not_called()
+        restart.assert_not_called()
+
+    def test_blank_binding_leaves_hotkey_unchanged(self) -> None:
+        from transclip.desktop.tray import win32
+
+        session = MagicMock()
+        restart = MagicMock()
+        with patch.object(win32, "patch_settings") as patch_settings_mock:
+            win32._apply_hotkey_selection(session, "   ", restart)
+
+        patch_settings_mock.assert_not_called()
+        restart.assert_not_called()
+
+    def test_valid_binding_is_persisted_and_registered(self) -> None:
+        from transclip.desktop.tray import win32
+
+        session = MagicMock()
+        session.explicit_settings_path = None
+        restart = MagicMock()
+        with (
+            patch.object(win32, "is_valid_hotkey", return_value=True),
+            patch.object(win32, "patch_settings") as patch_settings_mock,
+            patch.object(win32, "settings_path", return_value="cfg"),
+        ):
+            win32._apply_hotkey_selection(session, "ctrl+alt+t", restart)
+
+        patch_settings_mock.assert_called_once()
+        self.assertEqual(patch_settings_mock.call_args.kwargs["hotkey_windows"], "ctrl+alt+t")
+        restart.assert_called_once()
+
+
+@unittest.skipUnless(sys.platform == "win32", "tray win32 adapter requires pystray/Pillow")
+class TrayWin32IconTests(unittest.TestCase):
+    def test_health_icon_color_maps_known_states(self) -> None:
+        from transclip.desktop.tray.win32 import health_icon_color
+
+        self.assertEqual(health_icon_color("recording"), "red")
+        self.assertEqual(health_icon_color("ready"), "green")
+        self.assertEqual(health_icon_color("offline"), "orange")
+
+    def test_health_icon_color_falls_back_for_unknown_state(self) -> None:
+        from transclip.desktop.tray.win32 import health_icon_color
+
+        # A new health state must not raise KeyError: build_image runs inside
+        # the pystray event loop, so an unmapped name would crash the tray.
+        self.assertEqual(health_icon_color("busy"), "gray")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tray_win32.py
+++ b/tests/test_tray_win32.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
@@ -68,6 +69,48 @@ class TrayWin32IconTests(unittest.TestCase):
         # A new health state must not raise KeyError: build_image runs inside
         # the pystray event loop, so an unmapped name would crash the tray.
         self.assertEqual(health_icon_color("busy"), "gray")
+
+
+@unittest.skipUnless(sys.platform == "win32", "real pystray validates menu actions")
+class PystrayMenuSinkActionTests(unittest.TestCase):
+    """The real pystray rejects menu actions taking >2 positional args.
+
+    The other tray tests inject a fake pystray that does not enforce this, so a
+    closure with a default-arg binding (which inflates co_argcount) passes them
+    but crashes the live tray. These build the menus with the real pystray.
+    """
+
+    def _sink(self):
+        import pystray
+        from transclip.desktop.tray.sinks.win32 import PystrayMenuSink
+
+        items: list = []
+        refs: dict = {}
+        sink = PystrayMenuSink(
+            items,
+            refs,
+            pystray=pystray,
+            after_action=lambda fn: fn(),
+            set_model=lambda model_id, backend: None,
+            on_copy_history=lambda value: None,
+        )
+        return sink, items, refs
+
+    def test_model_submenu_actions_are_accepted_by_pystray(self) -> None:
+        sink, items, _ = self._sink()
+        choices = [("Granite AR", SimpleNamespace(model_id="ibm-granite/x", backend="granite"))]
+
+        sink.model_submenu("models", "ASR model", choices)  # raises ValueError pre-fix
+
+        self.assertEqual(len(items), 1)
+
+    def test_history_submenu_actions_are_accepted_by_pystray(self) -> None:
+        sink, _, refs = self._sink()
+        refs["_history_entries"] = [("preview", "full transcript text")]
+
+        menu = sink._build_history_menu()  # raises ValueError pre-fix
+
+        self.assertIsNotNone(menu)
 
 
 if __name__ == "__main__":

--- a/tests/test_tray_win32.py
+++ b/tests/test_tray_win32.py
@@ -65,7 +65,7 @@ class TrayWin32RecordingNotifyTests(unittest.TestCase):
         from transclip.desktop.tray import win32
 
         with patch.object(win32, "windows_toast") as toast:
-            win32._notify_toggle(self._fake_outcome(action="started"), SimpleNamespace(recording_notifications=True))
+            win32._notify_toggle(self._fake_outcome(action="started"), SimpleNamespace(tray_notifications=True))
 
         toast.assert_called_once()
         self.assertIn("Recording", toast.call_args.args[1])
@@ -74,7 +74,7 @@ class TrayWin32RecordingNotifyTests(unittest.TestCase):
         from transclip.desktop.tray import win32
 
         with patch.object(win32, "windows_toast") as toast:
-            win32._notify_toggle(self._fake_outcome(action="started"), SimpleNamespace(recording_notifications=False))
+            win32._notify_toggle(self._fake_outcome(action="started"), SimpleNamespace(tray_notifications=False))
 
         toast.assert_not_called()
 
@@ -84,10 +84,30 @@ class TrayWin32RecordingNotifyTests(unittest.TestCase):
         with patch.object(win32, "windows_toast") as toast:
             win32._notify_toggle(
                 self._fake_outcome(action="stopped", paste_failed="UIPI blocked"),
-                SimpleNamespace(recording_notifications=True),
+                SimpleNamespace(tray_notifications=True),
             )
 
         self.assertIn("Ctrl+V", toast.call_args.args[1])
+
+
+@unittest.skipUnless(sys.platform == "win32", "tray win32 adapter requires pystray/Pillow")
+class TrayWin32ActionNotifyTests(unittest.TestCase):
+    def test_notify_action_toasts_when_enabled(self) -> None:
+        from transclip.desktop.tray import win32
+
+        with patch.object(win32, "windows_toast") as toast:
+            win32._notify_action("Restarting the dictation service", SimpleNamespace(tray_notifications=True))
+
+        toast.assert_called_once()
+        self.assertIn("Restarting the dictation service", toast.call_args.args[1])
+
+    def test_notify_action_suppressed_when_disabled(self) -> None:
+        from transclip.desktop.tray import win32
+
+        with patch.object(win32, "windows_toast") as toast:
+            win32._notify_action("anything", SimpleNamespace(tray_notifications=False))
+
+        toast.assert_not_called()
 
 
 @unittest.skipUnless(sys.platform == "win32", "tray win32 adapter requires pystray/Pillow")

--- a/tests/test_tray_win32.py
+++ b/tests/test_tray_win32.py
@@ -55,6 +55,42 @@ class TrayWin32HotkeyTests(unittest.TestCase):
 
 
 @unittest.skipUnless(sys.platform == "win32", "tray win32 adapter requires pystray/Pillow")
+class TrayWin32RecordingNotifyTests(unittest.TestCase):
+    def _fake_outcome(self, *, ok=True, action="started", paste_failed="", error=""):
+        return SimpleNamespace(
+            ok=ok, payload={"action": action}, paste_failed_message=paste_failed, error_message=error
+        )
+
+    def test_notifies_on_start_when_enabled(self) -> None:
+        from transclip.desktop.tray import win32
+
+        with patch.object(win32, "windows_toast") as toast:
+            win32._notify_toggle(self._fake_outcome(action="started"), SimpleNamespace(recording_notifications=True))
+
+        toast.assert_called_once()
+        self.assertIn("Recording", toast.call_args.args[1])
+
+    def test_suppressed_when_setting_disabled(self) -> None:
+        from transclip.desktop.tray import win32
+
+        with patch.object(win32, "windows_toast") as toast:
+            win32._notify_toggle(self._fake_outcome(action="started"), SimpleNamespace(recording_notifications=False))
+
+        toast.assert_not_called()
+
+    def test_blocked_paste_is_surfaced(self) -> None:
+        from transclip.desktop.tray import win32
+
+        with patch.object(win32, "windows_toast") as toast:
+            win32._notify_toggle(
+                self._fake_outcome(action="stopped", paste_failed="UIPI blocked"),
+                SimpleNamespace(recording_notifications=True),
+            )
+
+        self.assertIn("Ctrl+V", toast.call_args.args[1])
+
+
+@unittest.skipUnless(sys.platform == "win32", "tray win32 adapter requires pystray/Pillow")
 class TrayWin32IconTests(unittest.TestCase):
     def test_health_icon_color_maps_known_states(self) -> None:
         from transclip.desktop.tray.win32 import health_icon_color

--- a/tests/test_tray_win32.py
+++ b/tests/test_tray_win32.py
@@ -1,7 +1,15 @@
+import importlib.util
 import sys
 import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+
+def _has_pystray() -> bool:
+    # PystrayMenuSinkActionTests imports pystray directly; without the windows-ui
+    # extra it would error rather than skip. The other win32 tray classes import
+    # win32 lazily and do not need it.
+    return importlib.util.find_spec("pystray") is not None
 
 
 @unittest.skipUnless(sys.platform == "win32", "tray win32 adapter requires pystray/Pillow")
@@ -165,7 +173,7 @@ class TrayWin32IconTests(unittest.TestCase):
         self.assertEqual(health_icon_color("busy"), "gray")
 
 
-@unittest.skipUnless(sys.platform == "win32", "real pystray validates menu actions")
+@unittest.skipUnless(sys.platform == "win32" and _has_pystray(), "real pystray validates menu actions")
 class PystrayMenuSinkActionTests(unittest.TestCase):
     """The real pystray rejects menu actions taking >2 positional args.
 

--- a/tests/test_tray_win32.py
+++ b/tests/test_tray_win32.py
@@ -110,6 +110,44 @@ class TrayWin32ActionNotifyTests(unittest.TestCase):
         toast.assert_not_called()
 
 
+class CaptureHotkeyTests(unittest.TestCase):
+    def test_pauses_reads_then_resumes_in_order(self) -> None:
+        from transclip.desktop.tray.win32 import _capture_hotkey
+
+        calls: list[str] = []
+
+        def read() -> str:
+            calls.append("read")
+            return "ctrl+shift+space"
+
+        result = _capture_hotkey(
+            pause=lambda: calls.append("pause"),
+            resume=lambda: calls.append("resume"),
+            read_hotkey=read,
+        )
+
+        self.assertEqual(result, "ctrl+shift+space")
+        self.assertEqual(calls, ["pause", "read", "resume"])
+
+    def test_always_resumes_and_returns_none_when_read_fails(self) -> None:
+        from transclip.desktop.tray.win32 import _capture_hotkey
+
+        calls: list[str] = []
+
+        def boom() -> str:
+            calls.append("read")
+            raise RuntimeError("hook failed")
+
+        result = _capture_hotkey(
+            pause=lambda: calls.append("pause"),
+            resume=lambda: calls.append("resume"),
+            read_hotkey=boom,
+        )
+
+        self.assertIsNone(result)
+        self.assertEqual(calls, ["pause", "read", "resume"])  # resume runs even on failure
+
+
 @unittest.skipUnless(sys.platform == "win32", "tray win32 adapter requires pystray/Pillow")
 class TrayWin32IconTests(unittest.TestCase):
     def test_health_icon_color_maps_known_states(self) -> None:

--- a/tests/test_tray_win32.py
+++ b/tests/test_tray_win32.py
@@ -112,6 +112,27 @@ class PystrayMenuSinkActionTests(unittest.TestCase):
 
         self.assertIsNotNone(menu)
 
+    def test_status_label_is_updatable_after_creation(self) -> None:
+        # pystray MenuItem.text is read-only; the menu refresh updates the
+        # backing state and the item must re-read it.
+        sink, items, refs = self._sink()
+        sink.status_label("status_item", "Service: starting")
+
+        self.assertEqual(items[0].text, "Service: starting")
+        refs["status_item"].text = "Service: ready"  # what the view's setter does
+        self.assertEqual(items[0].text, "Service: ready")
+
+    def test_action_item_label_and_enabled_are_updatable(self) -> None:
+        sink, items, refs = self._sink()
+        sink.action("toggle_item", "Record", None, enabled=True, callback=lambda *_: None)
+
+        self.assertEqual(items[0].text, "Record")
+        self.assertTrue(items[0].enabled)
+        refs["toggle_item"].text = "Stop + paste"
+        refs["toggle_item"].enabled = False
+        self.assertEqual(items[0].text, "Stop + paste")
+        self.assertFalse(items[0].enabled)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tray_win32.py
+++ b/tests/test_tray_win32.py
@@ -41,12 +41,16 @@ class TrayWin32HotkeyTests(unittest.TestCase):
             patch.object(win32, "is_valid_hotkey", return_value=True),
             patch.object(win32, "patch_settings") as patch_settings_mock,
             patch.object(win32, "settings_path", return_value="cfg"),
+            patch.object(win32, "windows_toast") as toast_mock,
         ):
             win32._apply_hotkey_selection(session, "ctrl+alt+t", restart)
 
         patch_settings_mock.assert_called_once()
         self.assertEqual(patch_settings_mock.call_args.kwargs["hotkey_windows"], "ctrl+alt+t")
         restart.assert_called_once()
+        # The new binding is confirmed with a toast.
+        toast_mock.assert_called_once()
+        self.assertIn("ctrl+alt+t", toast_mock.call_args.args[1])
 
 
 @unittest.skipUnless(sys.platform == "win32", "tray win32 adapter requires pystray/Pillow")

--- a/tests/test_win32_app.py
+++ b/tests/test_win32_app.py
@@ -1,0 +1,52 @@
+import sys
+import unittest
+
+
+class DpiAwarenessTests(unittest.TestCase):
+    def test_prefers_per_monitor_v2_context(self) -> None:
+        from transclip.desktop.win32_app import set_dpi_awareness
+
+        result = set_dpi_awareness(
+            set_context=lambda: True,
+            set_shcore=lambda: True,
+            set_legacy=lambda: True,
+        )
+        self.assertEqual(result, "per-monitor-v2")
+
+    def test_falls_back_through_shcore_then_legacy_then_unaware(self) -> None:
+        from transclip.desktop.win32_app import set_dpi_awareness
+
+        self.assertEqual(
+            set_dpi_awareness(set_context=lambda: False, set_shcore=lambda: True, set_legacy=lambda: True),
+            "per-monitor",
+        )
+        self.assertEqual(
+            set_dpi_awareness(set_context=lambda: False, set_shcore=lambda: False, set_legacy=lambda: True),
+            "system",
+        )
+        self.assertEqual(
+            set_dpi_awareness(set_context=lambda: False, set_shcore=lambda: False, set_legacy=lambda: False),
+            "unaware",
+        )
+
+
+@unittest.skipUnless(sys.platform == "win32", "exercises the real DPI awareness API")
+class DpiAwarenessLiveTests(unittest.TestCase):
+    def test_process_reports_per_monitor_awareness(self) -> None:
+        import ctypes
+        from ctypes import wintypes
+
+        from transclip.desktop.win32_app import set_dpi_awareness
+
+        set_dpi_awareness()
+        user32 = ctypes.windll.user32
+        user32.GetThreadDpiAwarenessContext.restype = wintypes.HANDLE
+        user32.GetAwarenessFromDpiAwarenessContext.argtypes = [wintypes.HANDLE]
+        user32.GetAwarenessFromDpiAwarenessContext.restype = ctypes.c_int
+        awareness = user32.GetAwarenessFromDpiAwarenessContext(user32.GetThreadDpiAwarenessContext())
+        # DPI_AWARENESS_PER_MONITOR_AWARE == 2 (PMv2 also reports as 2 here).
+        self.assertEqual(awareness, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_win32_app.py
+++ b/tests/test_win32_app.py
@@ -48,5 +48,41 @@ class DpiAwarenessLiveTests(unittest.TestCase):
         self.assertEqual(awareness, 2)
 
 
+@unittest.skipIf(sys.platform == "win32", "CreateMutexW only exists on Windows")
+class SingleInstanceOffWindowsTests(unittest.TestCase):
+    def test_acquire_is_noop_off_windows(self) -> None:
+        from transclip.desktop.win32_app import acquire_single_instance
+
+        # Single-instance is only enforced on Windows; elsewhere it degrades to
+        # None so it never blocks a non-Windows caller.
+        self.assertIsNone(acquire_single_instance("anything"))
+
+
+@unittest.skipUnless(sys.platform == "win32", "exercises the real named mutex")
+class SingleInstanceLiveTests(unittest.TestCase):
+    def test_second_acquisition_of_same_name_is_blocked(self) -> None:
+        from transclip.desktop.win32_app import acquire_single_instance, release_single_instance
+
+        name = "TransClip-single-instance-test-9f3a21"
+        first = acquire_single_instance(name)
+        second = acquire_single_instance(name)
+        try:
+            self.assertIsNotNone(first)
+            self.assertIsNone(second)
+        finally:
+            release_single_instance(first)
+
+    def test_name_is_reusable_after_release(self) -> None:
+        from transclip.desktop.win32_app import acquire_single_instance, release_single_instance
+
+        name = "TransClip-single-instance-reuse-9f3a21"
+        release_single_instance(acquire_single_instance(name))
+        again = acquire_single_instance(name)
+        try:
+            self.assertIsNotNone(again)
+        finally:
+            release_single_instance(again)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_win32_app.py
+++ b/tests/test_win32_app.py
@@ -48,14 +48,39 @@ class DpiAwarenessLiveTests(unittest.TestCase):
         self.assertEqual(awareness, 2)
 
 
-@unittest.skipIf(sys.platform == "win32", "CreateMutexW only exists on Windows")
-class SingleInstanceOffWindowsTests(unittest.TestCase):
+@unittest.skipIf(sys.platform == "win32", "Win32-only APIs")
+class Win32AppOffWindowsTests(unittest.TestCase):
     def test_acquire_is_noop_off_windows(self) -> None:
         from transclip.desktop.win32_app import acquire_single_instance
 
         # Single-instance is only enforced on Windows; elsewhere it degrades to
         # None so it never blocks a non-Windows caller.
         self.assertIsNone(acquire_single_instance("anything"))
+
+    def test_set_app_user_model_id_is_noop_off_windows(self) -> None:
+        from transclip.desktop.win32_app import set_app_user_model_id
+
+        self.assertFalse(set_app_user_model_id("com.example.Test"))
+
+
+@unittest.skipUnless(sys.platform == "win32", "exercises the real shell32 AUMID API")
+class AppUserModelIdLiveTests(unittest.TestCase):
+    def test_sets_explicit_app_user_model_id(self) -> None:
+        import ctypes
+        from ctypes import wintypes
+
+        from transclip.desktop.win32_app import set_app_user_model_id
+
+        aumid = "com.paulbrav.TransClip.Test"
+        self.assertTrue(set_app_user_model_id(aumid))
+
+        shell32 = ctypes.windll.shell32
+        shell32.GetCurrentProcessExplicitAppUserModelID.argtypes = [ctypes.POINTER(wintypes.LPWSTR)]
+        shell32.GetCurrentProcessExplicitAppUserModelID.restype = ctypes.c_long
+        ptr = wintypes.LPWSTR()
+        hr = shell32.GetCurrentProcessExplicitAppUserModelID(ctypes.byref(ptr))
+        self.assertEqual(hr, 0)
+        self.assertEqual(ptr.value, aumid)
 
 
 @unittest.skipUnless(sys.platform == "win32", "exercises the real named mutex")

--- a/tests/test_win32_clipboard.py
+++ b/tests/test_win32_clipboard.py
@@ -1,4 +1,5 @@
 import ctypes
+import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -68,6 +69,32 @@ class Win32ClipboardTests(unittest.TestCase):
         user32.SendInput.assert_called_once()
         sent_count, _array, _size = user32.SendInput.call_args.args
         self.assertEqual(sent_count, 4)
+
+
+@unittest.skipUnless(sys.platform == "win32", "exercises the real Win32 clipboard")
+class Win32ClipboardLiveTests(unittest.TestCase):
+    """Round-trip against the real OS clipboard.
+
+    The mocked tests above replace ctypes wholesale, so they cannot catch a
+    64-bit handle/pointer being truncated by a missing ``restype`` (the value
+    faults on dereference). Driving the real Win32 calls is the only way to
+    prove the clipboard actually works on a 64-bit Windows host.
+    """
+
+    def setUp(self) -> None:
+        self._prior = read_clipboard_text()
+
+    def tearDown(self) -> None:
+        write_clipboard_text(self._prior)
+
+    def test_unicode_round_trip(self) -> None:
+        sample = "TransClip 12345 ✓ 日本語"
+        write_clipboard_text(sample)
+        self.assertEqual(read_clipboard_text(), sample)
+
+    def test_empty_string_round_trip(self) -> None:
+        write_clipboard_text("")
+        self.assertEqual(read_clipboard_text(), "")
 
 
 if __name__ == "__main__":

--- a/tests/test_win32_clipboard.py
+++ b/tests/test_win32_clipboard.py
@@ -72,6 +72,31 @@ class Win32ClipboardTests(unittest.TestCase):
         self.assertEqual(sent_count, 4)
 
 
+class OpenClipboardRetryTests(unittest.TestCase):
+    def test_retries_transient_contention_until_success(self) -> None:
+        from transclip.desktop.paste.win32 import _open_clipboard
+
+        user32 = MagicMock()
+        user32.OpenClipboard.side_effect = [0, 0, 1]  # busy, busy, then opened
+        sleeps: list[float] = []
+
+        _open_clipboard(user32, sleep=sleeps.append)
+
+        self.assertEqual(user32.OpenClipboard.call_count, 3)
+        self.assertEqual(len(sleeps), 2)  # slept only between the failed attempts
+
+    def test_raises_after_exhausting_attempts(self) -> None:
+        from transclip.desktop.paste.win32 import _open_clipboard
+
+        user32 = MagicMock()
+        user32.OpenClipboard.return_value = 0  # always busy
+
+        with self.assertRaisesRegex(RuntimeError, "OpenClipboard failed"):
+            _open_clipboard(user32, attempts=4, sleep=lambda _s: None)
+
+        self.assertEqual(user32.OpenClipboard.call_count, 4)
+
+
 @unittest.skipUnless(sys.platform == "win32", "exercises the real Win32 clipboard")
 class Win32ClipboardLiveTests(unittest.TestCase):
     """Round-trip against the real OS clipboard.

--- a/tests/test_win32_clipboard.py
+++ b/tests/test_win32_clipboard.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from transclip.desktop.paste.win32 import (
+    INPUT,
     read_clipboard_text,
     send_ctrl_v_paste,
     write_clipboard_text,
@@ -95,6 +96,37 @@ class Win32ClipboardLiveTests(unittest.TestCase):
     def test_empty_string_round_trip(self) -> None:
         write_clipboard_text("")
         self.assertEqual(read_clipboard_text(), "")
+
+
+class Win32InputStructTests(unittest.TestCase):
+    @unittest.skipUnless(sys.maxsize > 2**32, "INPUT ABI layout assertion is for 64-bit")
+    def test_input_struct_matches_win32_abi_size(self) -> None:
+        # SendInput requires cbSize == sizeof(INPUT). On x64 the real INPUT is
+        # 40 bytes; if the union omits its largest member (MOUSEINPUT) the
+        # struct is too small, SendInput rejects every call with
+        # ERROR_INVALID_PARAMETER, and no keystroke is injected.
+        self.assertEqual(ctypes.sizeof(INPUT), 40)
+
+
+@unittest.skipUnless(sys.platform == "win32", "exercises the real Win32 SendInput")
+class Win32PasteLiveTests(unittest.TestCase):
+    """Drive the real SendInput path.
+
+    A wrong-sized INPUT struct passes every mocked test (SendInput is faked to
+    return 4) but is rejected by the OS at runtime. Only a real call proves the
+    struct the kernel sees is the size it expects.
+    """
+
+    def setUp(self) -> None:
+        self._prior = read_clipboard_text()
+        write_clipboard_text("")  # paste of empty clipboard is a no-op
+
+    def tearDown(self) -> None:
+        write_clipboard_text(self._prior)
+
+    def test_send_ctrl_v_paste_is_accepted_by_the_os(self) -> None:
+        # Raises "SendInput returned 0, expected 4" if the struct size is wrong.
+        send_ctrl_v_paste()
 
 
 if __name__ == "__main__":

--- a/tests/test_win32_clipboard.py
+++ b/tests/test_win32_clipboard.py
@@ -36,7 +36,7 @@ class Win32ClipboardTests(unittest.TestCase):
         user32.GetClipboardData.return_value = 42
         kernel32.GlobalLock.return_value = ctypes.c_wchar_p("hello clipboard").value
 
-        with patch.object(ctypes, "windll", MagicMock(user32=user32, kernel32=kernel32), create=True):
+        with patch("transclip.desktop.paste.win32._win32_libraries", return_value=(user32, kernel32)):
             text = read_clipboard_text()
 
         self.assertEqual(text, "hello clipboard")
@@ -52,7 +52,7 @@ class Win32ClipboardTests(unittest.TestCase):
         kernel32.GlobalAlloc.return_value = 99
         kernel32.GlobalLock.return_value = ctypes.create_string_buffer(64)
 
-        with patch.object(ctypes, "windll", MagicMock(user32=user32, kernel32=kernel32), create=True):
+        with patch("transclip.desktop.paste.win32._win32_libraries", return_value=(user32, kernel32)):
             write_clipboard_text("saved")
 
         user32.SetClipboardData.assert_called_once()
@@ -64,7 +64,7 @@ class Win32ClipboardTests(unittest.TestCase):
         user32 = MagicMock()
         user32.SendInput.return_value = 4
 
-        with patch.object(ctypes, "windll", MagicMock(user32=user32), create=True):
+        with patch("transclip.desktop.paste.win32._win32_libraries", return_value=(user32, MagicMock())):
             send_ctrl_v_paste()
 
         user32.SendInput.assert_called_once()
@@ -96,6 +96,20 @@ class Win32ClipboardLiveTests(unittest.TestCase):
     def test_empty_string_round_trip(self) -> None:
         write_clipboard_text("")
         self.assertEqual(read_clipboard_text(), "")
+
+    def test_clipboard_calls_do_not_mutate_global_windll(self) -> None:
+        # ctypes.windll caches one function object per name for the whole
+        # process; other libraries depend on its default configuration. Our
+        # prototype setup must live on a private handle, not mutate this one.
+        fn = ctypes.windll.user32.GetClipboardData
+        original = fn.restype
+        fn.restype = ctypes.c_int
+        try:
+            write_clipboard_text("hygiene check")
+            read_clipboard_text()
+            self.assertIs(fn.restype, ctypes.c_int)
+        finally:
+            fn.restype = original
 
 
 class Win32InputStructTests(unittest.TestCase):

--- a/transclip/daemon/common.py
+++ b/transclip/daemon/common.py
@@ -42,7 +42,7 @@ def toggle_log_path(runtime: PlatformRuntime | None = None) -> Path:
 def _service_python() -> str:
     """Interpreter to bake into the service unit.
 
-    On Windows prefer ``pythonw.exe`` so the logon Task Scheduler task does not
+    On Windows prefer ``pythonw.exe`` so the logon autostart entry does not
     flash a console window at every sign-in: ``python.exe`` is a console
     (CUI) subsystem binary and gets its own window when launched without an
     inherited console, while ``pythonw.exe`` is a GUI subsystem binary.

--- a/transclip/daemon/common.py
+++ b/transclip/daemon/common.py
@@ -39,8 +39,24 @@ def toggle_log_path(runtime: PlatformRuntime | None = None) -> Path:
     return logs_dir(runtime) / "toggle-record.log"
 
 
+def _service_python() -> str:
+    """Interpreter to bake into the service unit.
+
+    On Windows prefer ``pythonw.exe`` so the logon Task Scheduler task does not
+    flash a console window at every sign-in: ``python.exe`` is a console
+    (CUI) subsystem binary and gets its own window when launched without an
+    inherited console, while ``pythonw.exe`` is a GUI subsystem binary.
+    """
+    executable = sys.executable
+    if sys.platform == "win32":
+        windowless = Path(executable).with_name("pythonw.exe")
+        if windowless.exists():
+            return str(windowless)
+    return executable
+
+
 def service_command(settings_path: Path | None = None) -> list[str]:
-    command = [sys.executable, "-m", f"{IMPORT_PACKAGE}.cli"]
+    command = [_service_python(), "-m", f"{IMPORT_PACKAGE}.cli"]
     if settings_path:
         command.extend(["--settings", service_settings_path(settings_path)])
     command.append("serve")

--- a/transclip/daemon/windows.py
+++ b/transclip/daemon/windows.py
@@ -1,71 +1,143 @@
 from __future__ import annotations
 
 import subprocess
-import xml.sax.saxutils as saxutils
+import sys
 from collections.abc import Callable
 from pathlib import Path
 
-from transclip.daemon.common import CommandResult, ServiceState, logs_dir, repo_root, run_command, service_command
+from transclip.daemon.common import (
+    CommandResult,
+    ServiceState,
+    repo_root,
+    run_command,
+    service_command,
+)
 from transclip.daemon.protocol import PlatformDaemon
 from transclip.platform.runtime import PlatformRuntime, get_runtime
-from transclip.product import DISPLAY_NAME, TASK_SCHEDULER_NAME
+from transclip.product import DISPLAY_NAME
 from transclip.settings import Settings, load_settings
 
 Runner = Callable[..., subprocess.CompletedProcess[str]]
 
+# Per-user autostart. The logon shell (explorer.exe) launches every value under
+# this key at interactive sign-in. It is writable by the user's own token, so -
+# unlike a root-folder Task Scheduler task - registering autostart here needs no
+# elevation. That was the whole reason for the switch: ``schtasks /Create``
+# failed with "Access is denied" for a non-admin user.
+RUN_KEY_PATH = r"Software\Microsoft\Windows\CurrentVersion\Run"
+RUN_KEY_VALUE_NAME = DISPLAY_NAME
 
-def task_scheduler_xml_path(runtime: PlatformRuntime | None = None) -> Path:
-    return logs_dir(runtime) / f"{TASK_SCHEDULER_NAME}.xml"
+
+# --- registry seams -------------------------------------------------------
+# ``winreg`` is a Windows-only stdlib module, but this file is imported on every
+# platform (CI runs the daemon tests on Linux). Import it lazily inside each
+# helper so the module loads everywhere; cross-platform tests patch these three
+# functions, and a win32-gated test exercises the real round-trip.
 
 
-def build_task_scheduler_xml(settings_path: Path | None = None) -> str:
-    command_parts = service_command(settings_path)
-    command = saxutils.escape(command_parts[0])
-    arguments = saxutils.escape(subprocess.list2cmdline([str(part) for part in command_parts[1:]]))
-    working_directory = saxutils.escape(str(repo_root()))
-    return "\n".join(
-        [
-            '<?xml version="1.0" encoding="UTF-16"?>',
-            '<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">',
-            "  <RegistrationInfo>",
-            f"    <Description>{DISPLAY_NAME} dictation service</Description>",
-            "  </RegistrationInfo>",
-            "  <Triggers>",
-            "    <LogonTrigger>",
-            "      <Enabled>true</Enabled>",
-            "    </LogonTrigger>",
-            "  </Triggers>",
-            "  <Principals>",
-            '    <Principal id="Author">',
-            "      <LogonType>InteractiveToken</LogonType>",
-            "      <RunLevel>LeastPrivilege</RunLevel>",
-            "    </Principal>",
-            "  </Principals>",
-            "  <Settings>",
-            "    <Enabled>true</Enabled>",
-            "    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>",
-            "    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>",
-            "    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>",
-            "    <AllowHardTerminate>true</AllowHardTerminate>",
-            "    <StartWhenAvailable>true</StartWhenAvailable>",
-            "    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>",
-            "    <Hidden>true</Hidden>",
-            "    <RestartOnFailure>",
-            "      <Interval>PT2M</Interval>",
-            "      <Count>3</Count>",
-            "    </RestartOnFailure>",
-            "  </Settings>",
-            '  <Actions Context="Author">',
-            "    <Exec>",
-            f"      <Command>{command}</Command>",
-            f"      <Arguments>{arguments}</Arguments>",
-            f"      <WorkingDirectory>{working_directory}</WorkingDirectory>",
-            "    </Exec>",
-            "  </Actions>",
-            "</Task>",
-            "",
-        ]
+def _set_autostart(command: str) -> None:
+    import winreg
+
+    with winreg.CreateKeyEx(winreg.HKEY_CURRENT_USER, RUN_KEY_PATH, 0, winreg.KEY_SET_VALUE) as key:
+        winreg.SetValueEx(key, RUN_KEY_VALUE_NAME, 0, winreg.REG_SZ, command)
+
+
+def _autostart_command() -> str | None:
+    import winreg
+
+    try:
+        with winreg.OpenKeyEx(winreg.HKEY_CURRENT_USER, RUN_KEY_PATH, 0, winreg.KEY_QUERY_VALUE) as key:
+            value, _kind = winreg.QueryValueEx(key, RUN_KEY_VALUE_NAME)
+    except FileNotFoundError:
+        # The Run key always exists, but the value (or, defensively, the key) may
+        # not - QueryValueEx raises FileNotFoundError when the value is absent.
+        return None
+    return str(value)
+
+
+def _clear_autostart() -> bool:
+    import winreg
+
+    try:
+        with winreg.OpenKeyEx(winreg.HKEY_CURRENT_USER, RUN_KEY_PATH, 0, winreg.KEY_SET_VALUE) as key:
+            winreg.DeleteValue(key, RUN_KEY_VALUE_NAME)
+    except FileNotFoundError:
+        return False
+    return True
+
+
+# --- process control ------------------------------------------------------
+
+
+def _spawn_service(command: str) -> None:
+    """Launch the dictation service detached from this console.
+
+    ``DETACHED_PROCESS`` + ``CREATE_NEW_PROCESS_GROUP`` cut the child loose so it
+    outlives the launching ``transclip install``/``start`` process, and
+    ``CREATE_NO_WINDOW`` suppresses the console flash (belt-and-suspenders with
+    the ``pythonw.exe`` GUI-subsystem interpreter baked into ``service_command``).
+    """
+    creationflags = 0
+    if sys.platform == "win32":
+        creationflags = (
+            subprocess.DETACHED_PROCESS  # type: ignore[attr-defined]
+            | subprocess.CREATE_NEW_PROCESS_GROUP
+            | subprocess.CREATE_NO_WINDOW  # type: ignore[attr-defined]
+        )
+    subprocess.Popen(command, cwd=str(repo_root()), close_fds=True, creationflags=creationflags)
+
+
+def _start_now(command: str) -> CommandResult:
+    try:
+        _spawn_service(command)
+    except OSError as exc:
+        return CommandResult(False, f"could not start dictation service: {exc}")
+    return CommandResult(True, "started dictation service")
+
+
+def _service_command_line(settings_path: Path | None = None) -> str:
+    return subprocess.list2cmdline(service_command(settings_path))
+
+
+# PowerShell matches the live service by command line rather than by image name:
+# the interpreter is ``pythonw.exe`` (or ``python.exe``), so the distinguishing
+# marker is ``transclip ... serve``. ``serve`` keeps this from catching the tray
+# (``transclip tray``) or a toggle invocation (``transclip ... toggle``).
+_SERVICE_PROCESS_FILTER = (
+    "Get-CimInstance Win32_Process | Where-Object { "
+    "$_.CommandLine -like '*transclip*' -and $_.CommandLine -like '*serve*' }"
+)
+
+
+def _count_service_processes(runner: Runner) -> int:
+    result = runner(
+        ["powershell", "-NoProfile", "-NonInteractive", "-Command", f"@({_SERVICE_PROCESS_FILTER}).Count"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
     )
+    if result.returncode != 0:
+        return 0
+    text = (result.stdout or "").strip()
+    return int(text) if text.isdigit() else 0
+
+
+def _stop_service(runner: Runner) -> CommandResult:
+    return run_command(
+        [
+            "powershell",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            f"{_SERVICE_PROCESS_FILTER} | ForEach-Object {{ Stop-Process -Id $_.ProcessId -Force }}",
+        ],
+        runner,
+        tolerate_failure=True,
+    )
+
+
+# --- public API -----------------------------------------------------------
 
 
 def install_windows_daemon(
@@ -76,17 +148,14 @@ def install_windows_daemon(
     *,
     hotkey_setup_message: Callable[..., str],
 ) -> list[CommandResult]:
-    results: list[CommandResult] = []
+    del runner  # autostart is registered via the registry, not a subprocess
     platform_runtime = get_runtime(runtime)
-    log_root = logs_dir(platform_runtime)
-    log_root.mkdir(parents=True, exist_ok=True)
-    xml_path = task_scheduler_xml_path(platform_runtime)
-    xml_path.write_text(build_task_scheduler_xml(settings_path), encoding="utf-16")
-    results.append(CommandResult(True, f"wrote {xml_path}"))
-    results.append(
-        run_command(["schtasks", "/Create", "/TN", TASK_SCHEDULER_NAME, "/XML", str(xml_path), "/F"], runner)
-    )
-    results.append(run_command(["schtasks", "/Run", "/TN", TASK_SCHEDULER_NAME], runner))
+    command = _service_command_line(settings_path)
+    _set_autostart(command)
+    results: list[CommandResult] = [
+        CommandResult(True, f"registered logon autostart ({RUN_KEY_VALUE_NAME}): {command}"),
+        _start_now(command),
+    ]
     settings = settings or load_settings(settings_path, runtime=platform_runtime)
     results.append(
         CommandResult(
@@ -108,14 +177,12 @@ def uninstall_windows_daemon(
     runner: Runner = subprocess.run,
     runtime: PlatformRuntime | None = None,
 ) -> list[CommandResult]:
-    results = [
-        run_command(["schtasks", "/End", "/TN", TASK_SCHEDULER_NAME], runner, tolerate_failure=True),
-        run_command(["schtasks", "/Delete", "/TN", TASK_SCHEDULER_NAME, "/F"], runner, tolerate_failure=True),
-    ]
-    path = task_scheduler_xml_path(runtime)
-    if path.exists():
-        path.unlink()
-        results.append(CommandResult(True, f"removed {path}"))
+    del runtime
+    results = [_stop_service(runner)]
+    if _clear_autostart():
+        results.append(CommandResult(True, f"removed logon autostart ({RUN_KEY_VALUE_NAME})"))
+    else:
+        results.append(CommandResult(True, "logon autostart was not registered"))
     return results
 
 
@@ -125,68 +192,35 @@ def windows_service_action(
     runtime: PlatformRuntime | None = None,
 ) -> CommandResult:
     del runtime
-    commands = {
-        "start": ["schtasks", "/Run", "/TN", TASK_SCHEDULER_NAME],
-        "stop": ["schtasks", "/End", "/TN", TASK_SCHEDULER_NAME],
-        "restart": ["schtasks", "/End", "/TN", TASK_SCHEDULER_NAME],
-    }
+    if action == "start":
+        return _start_now(_autostart_command() or _service_command_line())
+    if action == "stop":
+        return _stop_service(runner)
     if action == "restart":
-        stop = run_command(commands["stop"], runner, tolerate_failure=True)
-        start = run_command(["schtasks", "/Run", "/TN", TASK_SCHEDULER_NAME], runner)
-        return CommandResult(stop.ok and start.ok, f"{stop.detail}; {start.detail}")
-    return run_command(commands[action], runner)
-
-
-TASK_STATE_RUNNING = 4
+        stop = _stop_service(runner)
+        start = _start_now(_autostart_command() or _service_command_line())
+        return CommandResult(start.ok, f"{stop.detail}; {start.detail}")
+    raise ValueError(f"unknown service action: {action}")
 
 
 def windows_service_state(
     runner: Runner = subprocess.run,
     runtime: PlatformRuntime | None = None,
 ) -> ServiceState:
-    path = task_scheduler_xml_path(runtime)
-    query = runner(
-        ["schtasks", "/Query", "/TN", TASK_SCHEDULER_NAME],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        check=False,
-    )
-    installed = query.returncode == 0 or path.exists()
-    active = installed and _windows_task_state(runner) == TASK_STATE_RUNNING
-    return ServiceState(
-        installed=installed,
-        active=active,
-        detail=query.stdout.strip() or f"exit {query.returncode}",
-    )
-
-
-def _windows_task_state(runner: Runner) -> int | None:
-    """Return the task's numeric MSFT_ScheduledTask.State, or None.
-
-    ``schtasks /Query`` prints a *localized* status string ("Running" only on
-    English Windows), so it cannot be parsed reliably. PowerShell's
-    ``Get-ScheduledTask`` exposes ``State`` as a numeric enum that is identical
-    in every display language: Ready == 3, Running == 4.
-    """
-    result = runner(
-        [
-            "powershell",
-            "-NoProfile",
-            "-NonInteractive",
-            "-Command",
-            f"(Get-ScheduledTask -TaskName '{TASK_SCHEDULER_NAME}' "
-            "-ErrorAction SilentlyContinue).State.value__",
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        return None
-    text = result.stdout.strip()
-    return int(text) if text.isdigit() else None
+    del runtime
+    command = _autostart_command()
+    installed = command is not None
+    running = _count_service_processes(runner)
+    active = running > 0
+    if installed and active:
+        detail = f"autostart registered; {running} service process(es) running"
+    elif installed:
+        detail = "autostart registered; service not running"
+    elif active:
+        detail = f"{running} service process(es) running; autostart not registered"
+    else:
+        detail = "autostart not registered; service not running"
+    return ServiceState(installed=installed, active=active, detail=detail)
 
 
 class WindowsPlatformDaemon:

--- a/transclip/daemon/windows.py
+++ b/transclip/daemon/windows.py
@@ -99,13 +99,20 @@ def _service_command_line(settings_path: Path | None = None) -> str:
     return subprocess.list2cmdline(service_command(settings_path))
 
 
-# PowerShell matches the live service by command line rather than by image name:
-# the interpreter is ``pythonw.exe`` (or ``python.exe``), so the distinguishing
-# marker is ``transclip ... serve``. ``serve`` keeps this from catching the tray
+# PowerShell matches the live service by command line: the interpreter is
+# ``pythonw.exe`` (or ``python.exe``), so the distinguishing marker is
+# ``transclip ... serve``. ``serve`` keeps this from catching the tray
 # (``transclip tray``) or a toggle invocation (``transclip ... toggle``).
+#
+# The image-name guard (``$_.Name -like 'python*'``) is load-bearing, not an
+# optimisation: ``Get-CimInstance`` enumerates *this very PowerShell process*,
+# whose own command line contains the literals ``*transclip*`` and ``*serve*``
+# (they are in the ``-Command`` text). Without the guard the query counts and
+# tries to kill itself - a phantom "1 service process running" after uninstall,
+# and a "cannot find process" error when that PID exits mid-pipeline.
 _SERVICE_PROCESS_FILTER = (
     "Get-CimInstance Win32_Process | Where-Object { "
-    "$_.CommandLine -like '*transclip*' -and $_.CommandLine -like '*serve*' }"
+    "$_.Name -like 'python*' -and $_.CommandLine -like '*transclip*' -and $_.CommandLine -like '*serve*' }"
 )
 
 
@@ -130,7 +137,8 @@ def _stop_service(runner: Runner) -> CommandResult:
             "-NoProfile",
             "-NonInteractive",
             "-Command",
-            f"{_SERVICE_PROCESS_FILTER} | ForEach-Object {{ Stop-Process -Id $_.ProcessId -Force }}",
+            f"{_SERVICE_PROCESS_FILTER} | ForEach-Object {{ "
+            "Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }",
         ],
         runner,
         tolerate_failure=True,

--- a/transclip/daemon/windows.py
+++ b/transclip/daemon/windows.py
@@ -137,34 +137,56 @@ def windows_service_action(
     return run_command(commands[action], runner)
 
 
+TASK_STATE_RUNNING = 4
+
+
 def windows_service_state(
     runner: Runner = subprocess.run,
     runtime: PlatformRuntime | None = None,
 ) -> ServiceState:
     path = task_scheduler_xml_path(runtime)
-    result = runner(
-        ["schtasks", "/Query", "/TN", TASK_SCHEDULER_NAME, "/FO", "LIST", "/V"],
+    query = runner(
+        ["schtasks", "/Query", "/TN", TASK_SCHEDULER_NAME],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
         check=False,
     )
-    installed = result.returncode == 0 or path.exists()
-    active = result.returncode == 0 and _windows_task_reports_running(result.stdout)
+    installed = query.returncode == 0 or path.exists()
+    active = installed and _windows_task_state(runner) == TASK_STATE_RUNNING
     return ServiceState(
         installed=installed,
         active=active,
-        detail=result.stdout.strip() or f"exit {result.returncode}",
+        detail=query.stdout.strip() or f"exit {query.returncode}",
     )
 
 
-def _windows_task_reports_running(output: str) -> bool:
-    for line in output.splitlines():
-        stripped = line.strip()
-        if stripped.lower().startswith("status:"):
-            status = stripped.split(":", 1)[1].strip().lower()
-            return status == "running"
-    return False
+def _windows_task_state(runner: Runner) -> int | None:
+    """Return the task's numeric MSFT_ScheduledTask.State, or None.
+
+    ``schtasks /Query`` prints a *localized* status string ("Running" only on
+    English Windows), so it cannot be parsed reliably. PowerShell's
+    ``Get-ScheduledTask`` exposes ``State`` as a numeric enum that is identical
+    in every display language: Ready == 3, Running == 4.
+    """
+    result = runner(
+        [
+            "powershell",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            f"(Get-ScheduledTask -TaskName '{TASK_SCHEDULER_NAME}' "
+            "-ErrorAction SilentlyContinue).State.value__",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    text = result.stdout.strip()
+    return int(text) if text.isdigit() else None
 
 
 class WindowsPlatformDaemon:

--- a/transclip/desktop/hotkey/common.py
+++ b/transclip/desktop/hotkey/common.py
@@ -32,6 +32,6 @@ def windows_hotkey_setup_message(
     current = settings or Settings()
     binding = active_hotkey(current, runtime)
     return (
-        f"Task Scheduler service installed. Global hotkey {binding!r} is registered when "
+        f"Logon autostart registered. Global hotkey {binding!r} is registered when "
         f"transclip tray is running; change it from the tray Set hotkey menu or hotkey_windows."
     )

--- a/transclip/desktop/hotkey/windows.py
+++ b/transclip/desktop/hotkey/windows.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from collections.abc import Callable
 
 from transclip.platform.runtime import PlatformRuntime, get_runtime
@@ -43,6 +44,10 @@ def start_windows_hotkey(
     handle = keyboard.add_hotkey(binding, callback, suppress=False)
 
     def stop() -> None:
-        keyboard.remove_hotkey(handle)
+        # Idempotent: keyboard.remove_hotkey raises KeyError if the hotkey is
+        # already gone, and stop() may be called more than once (e.g. a pause
+        # followed by a restart).
+        with contextlib.suppress(KeyError):
+            keyboard.remove_hotkey(handle)
 
     return stop

--- a/transclip/desktop/hotkey/windows.py
+++ b/transclip/desktop/hotkey/windows.py
@@ -6,6 +6,25 @@ from transclip.platform.runtime import PlatformRuntime, get_runtime
 from transclip.settings import Settings, active_hotkey
 
 
+def is_valid_hotkey(binding: str) -> bool:
+    """Return whether the keyboard library can parse this hotkey binding.
+
+    The tray "Set hotkey" dialog accepts free-form text. An unparseable value
+    would make ``keyboard.add_hotkey`` raise ValueError during registration,
+    crashing the tray - and only after the bad value had been persisted.
+    Validate up front so a typo is rejected with a message instead.
+    """
+    try:
+        import keyboard
+    except ImportError:
+        return False
+    try:
+        keyboard.parse_hotkey(binding)
+    except (ValueError, ImportError):
+        return False
+    return True
+
+
 def start_windows_hotkey(
     callback: Callable[[], None],
     settings: Settings,

--- a/transclip/desktop/notifications.py
+++ b/transclip/desktop/notifications.py
@@ -1,0 +1,71 @@
+"""Best-effort Windows toast notifications via the WinRT projection (pywinrt).
+
+All entry points degrade to a no-op (returning False) when the winrt packages
+are not installed or the call is made off Windows, so callers can fire a toast
+unconditionally without guarding.
+"""
+
+from __future__ import annotations
+
+import xml.sax.saxutils as saxutils
+from typing import Any
+
+from transclip.product import APP_USER_MODEL_ID, DISPLAY_NAME
+
+
+def toast_xml(title: str, message: str) -> str:
+    """Build a ToastGeneric notification payload with XML-escaped text."""
+    return (
+        '<toast><visual><binding template="ToastGeneric">'
+        f"<text>{saxutils.escape(title)}</text>"
+        f"<text>{saxutils.escape(message)}</text>"
+        "</binding></visual></toast>"
+    )
+
+
+def _winrt_toast_api() -> tuple[Any, Any, Any]:
+    """Import seam for the WinRT toast classes (kept tiny so it is mockable)."""
+    from winrt.windows.data.xml.dom import XmlDocument
+    from winrt.windows.ui.notifications import ToastNotification, ToastNotificationManager
+
+    return XmlDocument, ToastNotification, ToastNotificationManager
+
+
+def windows_toast(title: str, message: str, *, app_id: str = APP_USER_MODEL_ID) -> bool:
+    """Show a toast attributed to ``app_id``; return whether it was delivered.
+
+    ``create_toast_notifier_with_id`` is the AppUserModelID overload required by
+    unpackaged apps (the no-arg variant is for packaged apps only).
+    """
+    try:
+        xml_document, toast_notification, toast_manager = _winrt_toast_api()
+    except (ImportError, OSError):
+        return False
+    try:
+        document = xml_document()
+        document.load_xml(toast_xml(title, message))
+        notifier = toast_manager.create_toast_notifier_with_id(app_id)
+        notifier.show(toast_notification(document))
+        return True
+    except Exception:
+        return False
+
+
+def register_toast_app_id(app_id: str = APP_USER_MODEL_ID, display_name: str = DISPLAY_NAME) -> bool:
+    """Register the AUMID under HKCU so unpackaged toasts attribute correctly.
+
+    Windows 11 will display a toast for an unregistered AUMID, but registering a
+    DisplayName gives proper attribution and is needed for reliable display and
+    Action Center persistence on Windows 10. Idempotent; best-effort.
+    """
+    try:
+        import winreg
+    except ImportError:
+        return False
+    try:
+        key_path = rf"Software\Classes\AppUserModelId\{app_id}"
+        with winreg.CreateKey(winreg.HKEY_CURRENT_USER, key_path) as key:
+            winreg.SetValueEx(key, "DisplayName", 0, winreg.REG_SZ, display_name)
+        return True
+    except OSError:
+        return False

--- a/transclip/desktop/notifications.py
+++ b/transclip/desktop/notifications.py
@@ -23,6 +23,24 @@ def toast_xml(title: str, message: str) -> str:
     )
 
 
+def recording_toast_message(ok: bool, action: str | None, *, paste_failed: bool, error: str = "") -> str | None:
+    """Body text for a recording-toggle toast, or None when no toast is warranted.
+
+    Covers the whole "recording on/off" story: started, stopped+pasted, the
+    blocked-paste case (UIPI / elevated target, where the transcript is on the
+    clipboard but did not paste), and a failed toggle.
+    """
+    if not ok:
+        return f"Recording failed: {error or 'unknown error'}"
+    if action == "started":
+        return "Recording… press the hotkey again to stop"
+    if action == "stopped":
+        if paste_failed:
+            return "Transcript copied — paste was blocked; press Ctrl+V to paste"
+        return "Transcribed and pasted"
+    return None
+
+
 def _winrt_toast_api() -> tuple[Any, Any, Any]:
     """Import seam for the WinRT toast classes (kept tiny so it is mockable)."""
     from winrt.windows.data.xml.dom import XmlDocument

--- a/transclip/desktop/paste/win32.py
+++ b/transclip/desktop/paste/win32.py
@@ -78,7 +78,7 @@ def _require_windows() -> None:
         raise RuntimeError("Win32 clipboard APIs are only available on Windows")
 
 
-def _configure_prototypes(user32: ctypes.WinDLL, kernel32: ctypes.WinDLL) -> None:
+def _configure_prototypes(user32: ctypes.WinDLL, kernel32: ctypes.WinDLL) -> None:  # type: ignore[name-defined]
     """Declare 64-bit-safe argument and return types for the Win32 calls.
 
     Without an explicit ``restype``, ctypes assumes a 32-bit ``int`` return and
@@ -109,7 +109,7 @@ def _configure_prototypes(user32: ctypes.WinDLL, kernel32: ctypes.WinDLL) -> Non
 
 
 @functools.cache
-def _win32_libraries() -> tuple[ctypes.WinDLL, ctypes.WinDLL]:
+def _win32_libraries() -> tuple[ctypes.WinDLL, ctypes.WinDLL]:  # type: ignore[name-defined]
     """Bind private ``user32``/``kernel32`` handles with configured prototypes.
 
     A private ``WinDLL`` keeps our argtypes/restype declarations off the
@@ -123,7 +123,7 @@ def _win32_libraries() -> tuple[ctypes.WinDLL, ctypes.WinDLL]:
 
 
 def _open_clipboard(
-    user32: ctypes.WinDLL,
+    user32: ctypes.WinDLL,  # type: ignore[name-defined]
     *,
     attempts: int = _OPEN_CLIPBOARD_ATTEMPTS,
     sleep: Callable[[float], object] = time.sleep,

--- a/transclip/desktop/paste/win32.py
+++ b/transclip/desktop/paste/win32.py
@@ -26,9 +26,32 @@ class KEYBDINPUT(ctypes.Structure):
     ]
 
 
+class MOUSEINPUT(ctypes.Structure):
+    _fields_ = [
+        ("dx", wintypes.LONG),
+        ("dy", wintypes.LONG),
+        ("mouseData", wintypes.DWORD),
+        ("dwFlags", wintypes.DWORD),
+        ("time", wintypes.DWORD),
+        ("dwExtraInfo", ctypes.c_ulonglong),
+    ]
+
+
+class HARDWAREINPUT(ctypes.Structure):
+    _fields_ = [
+        ("uMsg", wintypes.DWORD),
+        ("wParamL", wintypes.WORD),
+        ("wParamH", wintypes.WORD),
+    ]
+
+
 class INPUT(ctypes.Structure):
     class _INPUTUNION(ctypes.Union):
-        _fields_ = [("ki", KEYBDINPUT)]
+        # SendInput validates cbSize against the real Win32 INPUT (40 bytes on
+        # x64). MOUSEINPUT is the largest union member, so it must be present
+        # for sizeof(INPUT) to match even though we only ever send keystrokes;
+        # omitting it makes the struct 32 bytes and SendInput rejects the call.
+        _fields_ = [("mi", MOUSEINPUT), ("ki", KEYBDINPUT), ("hi", HARDWAREINPUT)]
 
     _anonymous_ = ("u",)
     _fields_ = [

--- a/transclip/desktop/paste/win32.py
+++ b/transclip/desktop/paste/win32.py
@@ -22,32 +22,39 @@ _OPEN_CLIPBOARD_ATTEMPTS = 10
 _OPEN_CLIPBOARD_RETRY_DELAY_S = 0.015
 
 
+# Win32 INPUT-family structs. Use fixed-width ctypes types, NOT wintypes.WORD/
+# DWORD/LONG: the latter alias c_ushort/c_ulong/c_long, and c_ulong/c_long are 8
+# bytes on LP64 (Linux/macOS) vs 4 on Windows (LLP64). That would make
+# sizeof(INPUT) host-dependent (56 bytes off-Windows vs the real 40-byte x64 ABI)
+# and break the cross-platform test suite. Fixed-width keeps the layout identical
+# everywhere; on Windows it is byte-for-byte unchanged. (WORD=c_uint16,
+# DWORD=c_uint32, LONG=c_int32.)
 class KEYBDINPUT(ctypes.Structure):
     _fields_ = [
-        ("wVk", wintypes.WORD),
-        ("wScan", wintypes.WORD),
-        ("dwFlags", wintypes.DWORD),
-        ("time", wintypes.DWORD),
+        ("wVk", ctypes.c_uint16),
+        ("wScan", ctypes.c_uint16),
+        ("dwFlags", ctypes.c_uint32),
+        ("time", ctypes.c_uint32),
         ("dwExtraInfo", ctypes.c_ulonglong),
     ]
 
 
 class MOUSEINPUT(ctypes.Structure):
     _fields_ = [
-        ("dx", wintypes.LONG),
-        ("dy", wintypes.LONG),
-        ("mouseData", wintypes.DWORD),
-        ("dwFlags", wintypes.DWORD),
-        ("time", wintypes.DWORD),
+        ("dx", ctypes.c_int32),
+        ("dy", ctypes.c_int32),
+        ("mouseData", ctypes.c_uint32),
+        ("dwFlags", ctypes.c_uint32),
+        ("time", ctypes.c_uint32),
         ("dwExtraInfo", ctypes.c_ulonglong),
     ]
 
 
 class HARDWAREINPUT(ctypes.Structure):
     _fields_ = [
-        ("uMsg", wintypes.DWORD),
-        ("wParamL", wintypes.WORD),
-        ("wParamH", wintypes.WORD),
+        ("uMsg", ctypes.c_uint32),
+        ("wParamL", ctypes.c_uint16),
+        ("wParamH", ctypes.c_uint16),
     ]
 
 
@@ -61,7 +68,7 @@ class INPUT(ctypes.Structure):
 
     _anonymous_ = ("u",)
     _fields_ = [
-        ("type", wintypes.DWORD),
+        ("type", ctypes.c_uint32),
         ("u", _INPUTUNION),
     ]
 

--- a/transclip/desktop/paste/win32.py
+++ b/transclip/desktop/paste/win32.py
@@ -42,10 +42,40 @@ def _require_windows() -> None:
         raise RuntimeError("Win32 clipboard APIs are only available on Windows")
 
 
+def _configure_clipboard_prototypes(user32: ctypes.WinDLL, kernel32: ctypes.WinDLL) -> None:
+    """Declare 64-bit-safe argument and return types for the clipboard calls.
+
+    Without an explicit ``restype``, ctypes assumes a 32-bit ``int`` return and
+    truncates the 64-bit ``HANDLE``/pointer values these functions return. The
+    truncated pointer then faults when dereferenced (``GlobalLock`` ->
+    ``wstring_at``). Assignment is idempotent, so configuring per call is cheap
+    and keeps the functions easy to mock.
+    """
+    user32.OpenClipboard.argtypes = [wintypes.HWND]
+    user32.OpenClipboard.restype = wintypes.BOOL
+    user32.CloseClipboard.argtypes = []
+    user32.CloseClipboard.restype = wintypes.BOOL
+    user32.EmptyClipboard.argtypes = []
+    user32.EmptyClipboard.restype = wintypes.BOOL
+    user32.GetClipboardData.argtypes = [wintypes.UINT]
+    user32.GetClipboardData.restype = wintypes.HANDLE
+    user32.SetClipboardData.argtypes = [wintypes.UINT, wintypes.HANDLE]
+    user32.SetClipboardData.restype = wintypes.HANDLE
+    kernel32.GlobalAlloc.argtypes = [wintypes.UINT, ctypes.c_size_t]
+    kernel32.GlobalAlloc.restype = wintypes.HGLOBAL
+    kernel32.GlobalLock.argtypes = [wintypes.HGLOBAL]
+    kernel32.GlobalLock.restype = wintypes.LPVOID
+    kernel32.GlobalUnlock.argtypes = [wintypes.HGLOBAL]
+    kernel32.GlobalUnlock.restype = wintypes.BOOL
+    kernel32.GlobalFree.argtypes = [wintypes.HGLOBAL]
+    kernel32.GlobalFree.restype = wintypes.HGLOBAL
+
+
 def read_clipboard_text() -> str:
     _require_windows()
     user32 = ctypes.windll.user32
     kernel32 = ctypes.windll.kernel32
+    _configure_clipboard_prototypes(user32, kernel32)
     if not user32.OpenClipboard(None):
         raise RuntimeError("OpenClipboard failed")
     try:
@@ -67,6 +97,7 @@ def write_clipboard_text(text: str) -> None:
     _require_windows()
     user32 = ctypes.windll.user32
     kernel32 = ctypes.windll.kernel32
+    _configure_clipboard_prototypes(user32, kernel32)
     if not user32.OpenClipboard(None):
         raise RuntimeError("OpenClipboard failed")
     try:

--- a/transclip/desktop/paste/win32.py
+++ b/transclip/desktop/paste/win32.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
 import ctypes
+import functools
 import platform
 import time
 from ctypes import wintypes
-
-if not hasattr(wintypes, "WWORD"):
-    wintypes.WWORD = wintypes.WORD
 
 CF_UNICODETEXT = 13
 GMEM_MOVEABLE = 0x0002
@@ -19,7 +17,7 @@ VK_V = 0x56
 class KEYBDINPUT(ctypes.Structure):
     _fields_ = [
         ("wVk", wintypes.WORD),
-        ("wScan", wintypes.WWORD),
+        ("wScan", wintypes.WORD),
         ("dwFlags", wintypes.DWORD),
         ("time", wintypes.DWORD),
         ("dwExtraInfo", ctypes.c_ulonglong),
@@ -65,14 +63,13 @@ def _require_windows() -> None:
         raise RuntimeError("Win32 clipboard APIs are only available on Windows")
 
 
-def _configure_clipboard_prototypes(user32: ctypes.WinDLL, kernel32: ctypes.WinDLL) -> None:
-    """Declare 64-bit-safe argument and return types for the clipboard calls.
+def _configure_prototypes(user32: ctypes.WinDLL, kernel32: ctypes.WinDLL) -> None:
+    """Declare 64-bit-safe argument and return types for the Win32 calls.
 
     Without an explicit ``restype``, ctypes assumes a 32-bit ``int`` return and
     truncates the 64-bit ``HANDLE``/pointer values these functions return. The
     truncated pointer then faults when dereferenced (``GlobalLock`` ->
-    ``wstring_at``). Assignment is idempotent, so configuring per call is cheap
-    and keeps the functions easy to mock.
+    ``wstring_at``).
     """
     user32.OpenClipboard.argtypes = [wintypes.HWND]
     user32.OpenClipboard.restype = wintypes.BOOL
@@ -84,6 +81,8 @@ def _configure_clipboard_prototypes(user32: ctypes.WinDLL, kernel32: ctypes.WinD
     user32.GetClipboardData.restype = wintypes.HANDLE
     user32.SetClipboardData.argtypes = [wintypes.UINT, wintypes.HANDLE]
     user32.SetClipboardData.restype = wintypes.HANDLE
+    user32.SendInput.argtypes = [wintypes.UINT, ctypes.POINTER(INPUT), ctypes.c_int]
+    user32.SendInput.restype = wintypes.UINT
     kernel32.GlobalAlloc.argtypes = [wintypes.UINT, ctypes.c_size_t]
     kernel32.GlobalAlloc.restype = wintypes.HGLOBAL
     kernel32.GlobalLock.argtypes = [wintypes.HGLOBAL]
@@ -94,11 +93,23 @@ def _configure_clipboard_prototypes(user32: ctypes.WinDLL, kernel32: ctypes.WinD
     kernel32.GlobalFree.restype = wintypes.HGLOBAL
 
 
+@functools.cache
+def _win32_libraries() -> tuple[ctypes.WinDLL, ctypes.WinDLL]:
+    """Bind private ``user32``/``kernel32`` handles with configured prototypes.
+
+    A private ``WinDLL`` keeps our argtypes/restype declarations off the
+    process-global ``ctypes.windll`` cache, whose function objects are shared
+    with any other code in the process that imports them.
+    """
+    user32 = ctypes.WinDLL("user32")
+    kernel32 = ctypes.WinDLL("kernel32")
+    _configure_prototypes(user32, kernel32)
+    return user32, kernel32
+
+
 def read_clipboard_text() -> str:
     _require_windows()
-    user32 = ctypes.windll.user32
-    kernel32 = ctypes.windll.kernel32
-    _configure_clipboard_prototypes(user32, kernel32)
+    user32, kernel32 = _win32_libraries()
     if not user32.OpenClipboard(None):
         raise RuntimeError("OpenClipboard failed")
     try:
@@ -118,9 +129,7 @@ def read_clipboard_text() -> str:
 
 def write_clipboard_text(text: str) -> None:
     _require_windows()
-    user32 = ctypes.windll.user32
-    kernel32 = ctypes.windll.kernel32
-    _configure_clipboard_prototypes(user32, kernel32)
+    user32, kernel32 = _win32_libraries()
     if not user32.OpenClipboard(None):
         raise RuntimeError("OpenClipboard failed")
     try:
@@ -153,7 +162,7 @@ def _keyboard_input(vk: int, *, key_up: bool = False) -> INPUT:
 
 def send_ctrl_v_paste() -> None:
     _require_windows()
-    user32 = ctypes.windll.user32
+    user32, _kernel32 = _win32_libraries()
     inputs = (
         _keyboard_input(VK_CONTROL),
         _keyboard_input(VK_V),

--- a/transclip/desktop/paste/win32.py
+++ b/transclip/desktop/paste/win32.py
@@ -4,6 +4,7 @@ import ctypes
 import functools
 import platform
 import time
+from collections.abc import Callable
 from ctypes import wintypes
 
 CF_UNICODETEXT = 13
@@ -12,6 +13,13 @@ INPUT_KEYBOARD = 1
 KEYEVENTF_KEYUP = 0x0002
 VK_CONTROL = 0x11
 VK_V = 0x56
+
+# The clipboard is a single global resource that another process (a clipboard
+# manager, browser, Office, RDP) can hold open for a few milliseconds, making
+# OpenClipboard fail transiently. Retry a bounded number of times before giving
+# up rather than failing the paste outright.
+_OPEN_CLIPBOARD_ATTEMPTS = 10
+_OPEN_CLIPBOARD_RETRY_DELAY_S = 0.015
 
 
 class KEYBDINPUT(ctypes.Structure):
@@ -107,11 +115,25 @@ def _win32_libraries() -> tuple[ctypes.WinDLL, ctypes.WinDLL]:
     return user32, kernel32
 
 
+def _open_clipboard(
+    user32: ctypes.WinDLL,
+    *,
+    attempts: int = _OPEN_CLIPBOARD_ATTEMPTS,
+    sleep: Callable[[float], object] = time.sleep,
+) -> None:
+    """Open the clipboard, retrying transient contention before failing."""
+    for attempt in range(attempts):
+        if user32.OpenClipboard(None):
+            return
+        if attempt + 1 < attempts:
+            sleep(_OPEN_CLIPBOARD_RETRY_DELAY_S)
+    raise RuntimeError(f"OpenClipboard failed after {attempts} attempts")
+
+
 def read_clipboard_text() -> str:
     _require_windows()
     user32, kernel32 = _win32_libraries()
-    if not user32.OpenClipboard(None):
-        raise RuntimeError("OpenClipboard failed")
+    _open_clipboard(user32)
     try:
         handle = user32.GetClipboardData(CF_UNICODETEXT)
         if not handle:
@@ -130,8 +152,7 @@ def read_clipboard_text() -> str:
 def write_clipboard_text(text: str) -> None:
     _require_windows()
     user32, kernel32 = _win32_libraries()
-    if not user32.OpenClipboard(None):
-        raise RuntimeError("OpenClipboard failed")
+    _open_clipboard(user32)
     try:
         if not user32.EmptyClipboard():
             raise RuntimeError("EmptyClipboard failed")

--- a/transclip/desktop/tray/menu_update.py
+++ b/transclip/desktop/tray/menu_update.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
@@ -37,6 +38,8 @@ class TrayMenuView(Protocol):
     def rebuild_history(self, entries: Sequence[tuple[str, str]]) -> None: ...
 
     def set_health_icon(self, icon: str) -> None: ...
+
+    def batch(self) -> AbstractContextManager[None]: ...
 
 
 @runtime_checkable
@@ -88,13 +91,14 @@ def apply_menu_snapshot(
     *,
     model_rows: Sequence[tuple[Any, str]],
 ) -> None:
-    view.set_label("status_item", snapshot.status_label)
-    view.set_label("toggle_item", snapshot.toggle_label)
-    view.set_enabled("partial_item", snapshot.partial_enabled)
-    view.set_enabled("latest_item", snapshot.latest_enabled)
-    view.set_label("model_cleanup_item", snapshot.model_cleanup_label)
-    view.set_model_labels(model_rows)
-    view.set_health_icon(snapshot.health_icon)
+    with view.batch():
+        view.set_label("status_item", snapshot.status_label)
+        view.set_label("toggle_item", snapshot.toggle_label)
+        view.set_enabled("partial_item", snapshot.partial_enabled)
+        view.set_enabled("latest_item", snapshot.latest_enabled)
+        view.set_label("model_cleanup_item", snapshot.model_cleanup_label)
+        view.set_model_labels(model_rows)
+        view.set_health_icon(snapshot.health_icon)
 
 
 def after_tray_action(

--- a/transclip/desktop/tray/sinks/win32.py
+++ b/transclip/desktop/tray/sinks/win32.py
@@ -6,6 +6,30 @@ from typing import Any
 from ..menu import MODEL_ITEMS_REF
 
 
+class _ItemState:
+    """Mutable label/enabled state behind a pystray MenuItem.
+
+    pystray MenuItems are immutable - ``text`` and ``enabled`` are read-only - so
+    dynamic items are backed by callables that re-read this state on each render.
+    The RefDrivenMenuView setters mutate this object and the tray repaints via
+    ``icon.update_menu()`` (GTK/macOS mutate their widgets directly instead).
+    """
+
+    __slots__ = ("enabled", "text")
+
+    def __init__(self, text: str, enabled: bool = True) -> None:
+        self.text = text
+        self.enabled = enabled
+
+
+def _label_of(state: _ItemState) -> Callable[[Any], str]:
+    return lambda _item: state.text
+
+
+def _enabled_of(state: _ItemState) -> Callable[[Any], bool]:
+    return lambda _item: state.enabled
+
+
 class PystrayMenuSink:
     def __init__(
         self,
@@ -28,15 +52,18 @@ class PystrayMenuSink:
         self._items.append(self._pystray.Menu.SEPARATOR)
 
     def status_label(self, ref: str, text: str) -> None:
-        item = self._pystray.MenuItem(text, None, enabled=False)
+        state = _ItemState(text, enabled=False)
+        item = self._pystray.MenuItem(_label_of(state), None, enabled=_enabled_of(state))
         self._items.append(item)
-        self._menu_refs[ref] = item
+        self._menu_refs[ref] = state
 
     def action(self, ref: str, label: str, action, *, enabled: bool = True, callback=None) -> None:
-        item = self._pystray.MenuItem(label, callback, enabled=enabled)
+        del action
+        state = _ItemState(label, enabled=enabled)
+        item = self._pystray.MenuItem(_label_of(state), callback, enabled=_enabled_of(state))
         self._items.append(item)
         if ref:
-            self._menu_refs[ref] = item
+            self._menu_refs[ref] = state
 
     def _build_history_menu(self) -> Any:
         entries = self._menu_refs.get(
@@ -76,9 +103,10 @@ class PystrayMenuSink:
         submenu_items: list = []
         self._menu_refs[MODEL_ITEMS_REF] = []
         for label, row in choices:
-            model_item = self._pystray.MenuItem(label, self._set_model_action(row.model_id, row.backend))
+            state = _ItemState(label)
+            model_item = self._pystray.MenuItem(_label_of(state), self._set_model_action(row.model_id, row.backend))
             submenu_items.append(model_item)
-            self._menu_refs[MODEL_ITEMS_REF].append((model_item, row))
+            self._menu_refs[MODEL_ITEMS_REF].append((state, row))
         self._items.append(self._pystray.MenuItem(title, self._pystray.Menu(*submenu_items)))
 
     def _set_model_action(self, model_id: str, backend: str) -> Callable[[Any, Any], None]:

--- a/transclip/desktop/tray/sinks/win32.py
+++ b/transclip/desktop/tray/sinks/win32.py
@@ -48,12 +48,16 @@ class PystrayMenuSink:
             if not full_text:
                 submenu_items.append(self._pystray.MenuItem(preview, None, enabled=False))
                 continue
-
-            def copy_history(_icon, _item, value=full_text):
-                self._on_copy_history(value)
-
-            submenu_items.append(self._pystray.MenuItem(preview, copy_history))
+            submenu_items.append(self._pystray.MenuItem(preview, self._copy_history_action(full_text)))
         return self._pystray.Menu(*submenu_items)
+
+    def _copy_history_action(self, value: str) -> Callable[[Any, Any], None]:
+        # A factory so `value` is bound here and the handler takes only
+        # (icon, item): pystray rejects actions with > 2 positional parameters.
+        def handler(_icon: Any, _item: Any) -> None:
+            self._on_copy_history(value)
+
+        return handler
 
     def history_submenu(self, ref: str, title: str, on_open=None) -> None:
         del ref
@@ -72,11 +76,15 @@ class PystrayMenuSink:
         submenu_items: list = []
         self._menu_refs[MODEL_ITEMS_REF] = []
         for label, row in choices:
-
-            def set_model(_icon, _item, model_id=row.model_id, backend=row.backend):
-                self._after_action(lambda: self._set_model(model_id, backend))
-
-            model_item = self._pystray.MenuItem(label, set_model)
+            model_item = self._pystray.MenuItem(label, self._set_model_action(row.model_id, row.backend))
             submenu_items.append(model_item)
             self._menu_refs[MODEL_ITEMS_REF].append((model_item, row))
         self._items.append(self._pystray.MenuItem(title, self._pystray.Menu(*submenu_items)))
+
+    def _set_model_action(self, model_id: str, backend: str) -> Callable[[Any, Any], None]:
+        # Bind the per-row values in this factory scope so the handler takes
+        # only (icon, item): pystray rejects actions with > 2 positional args.
+        def handler(_icon: Any, _item: Any) -> None:
+            self._after_action(lambda: self._set_model(model_id, backend))
+
+        return handler

--- a/transclip/desktop/tray/views.py
+++ b/transclip/desktop/tray/views.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+import contextlib
+from collections.abc import Callable, Iterator, Sequence
 from typing import Any
 
 
@@ -26,23 +27,45 @@ class RefDrivenMenuView:
         # items are immutable: the win32 adapter updates backing state and must
         # repaint via this hook (icon.update_menu()). Defaults to a no-op.
         self._on_updated = on_updated or (lambda: None)
+        self._batching = False
+
+    @contextlib.contextmanager
+    def batch(self) -> Iterator[None]:
+        """Group several updates into a single repaint.
+
+        A full menu refresh mutates ~6 items; without batching the win32 hook
+        would repaint once per item. Inside this context the repaint is deferred
+        and fired exactly once on exit.
+        """
+        outer = self._batching
+        self._batching = True
+        try:
+            yield
+        finally:
+            self._batching = outer
+            if not outer:
+                self._on_updated()
+
+    def _repaint(self) -> None:
+        if not self._batching:
+            self._on_updated()
 
     def set_label(self, ref: str, text: str) -> None:
         self._set_item_label(self._menu_refs[ref], text)
-        self._on_updated()
+        self._repaint()
 
     def set_enabled(self, ref: str, enabled: bool) -> None:
         self._set_item_enabled(self._menu_refs[ref], enabled)
-        self._on_updated()
+        self._repaint()
 
     def set_model_labels(self, rows: Sequence[tuple[Any, str]]) -> None:
         for item, label in rows:
             self._set_item_label(item, label)
-        self._on_updated()
+        self._repaint()
 
     def rebuild_history(self, entries: Sequence[tuple[str, str]]) -> None:
         self._rebuild_history(entries)
-        self._on_updated()
+        self._repaint()
 
     def set_health_icon(self, icon: str) -> None:
         self._set_health_icon(icon)

--- a/transclip/desktop/tray/views.py
+++ b/transclip/desktop/tray/views.py
@@ -15,25 +15,34 @@ class RefDrivenMenuView:
         set_item_enabled: Callable[[Any, bool], None],
         rebuild_history: Callable[[Sequence[tuple[str, str]]], None],
         set_health_icon: Callable[[str], None],
+        on_updated: Callable[[], None] | None = None,
     ) -> None:
         self._menu_refs = menu_refs
         self._set_item_label = set_item_label
         self._set_item_enabled = set_item_enabled
         self._rebuild_history = rebuild_history
         self._set_health_icon = set_health_icon
+        # Mutating-in-place updates the live menu on GTK/macOS, but pystray menu
+        # items are immutable: the win32 adapter updates backing state and must
+        # repaint via this hook (icon.update_menu()). Defaults to a no-op.
+        self._on_updated = on_updated or (lambda: None)
 
     def set_label(self, ref: str, text: str) -> None:
         self._set_item_label(self._menu_refs[ref], text)
+        self._on_updated()
 
     def set_enabled(self, ref: str, enabled: bool) -> None:
         self._set_item_enabled(self._menu_refs[ref], enabled)
+        self._on_updated()
 
     def set_model_labels(self, rows: Sequence[tuple[Any, str]]) -> None:
         for item, label in rows:
             self._set_item_label(item, label)
+        self._on_updated()
 
     def rebuild_history(self, entries: Sequence[tuple[str, str]]) -> None:
         self._rebuild_history(entries)
+        self._on_updated()
 
     def set_health_icon(self, icon: str) -> None:
         self._set_health_icon(icon)

--- a/transclip/desktop/tray/win32.py
+++ b/transclip/desktop/tray/win32.py
@@ -39,7 +39,7 @@ def health_icon_color(name: str) -> str:
 
 def _notify_toggle(outcome: Any, settings: Settings) -> None:
     """Toast the result of a recording toggle when notifications are enabled."""
-    if not settings.recording_notifications:
+    if not settings.tray_notifications:
         return
     message = recording_toast_message(
         outcome.ok,
@@ -48,6 +48,12 @@ def _notify_toggle(outcome: Any, settings: Settings) -> None:
         error=outcome.error_message or "",
     )
     if message:
+        windows_toast(DISPLAY_NAME, message)
+
+
+def _notify_action(message: str, settings: Settings) -> None:
+    """Toast a tray action (e.g. a service/model change) when enabled."""
+    if settings.tray_notifications:
         windows_toast(DISPLAY_NAME, message)
 
 
@@ -149,6 +155,30 @@ def run_windows_tray(
     # Notify on both toggle paths (global hotkey and the tray menu item).
     action_callbacks["toggle"] = lambda *_: toggle_and_notify()
 
+    def _action_with_toast(message: str, action: Callable[[], object]) -> Callable[..., object]:
+        def run(*_args: object) -> object:
+            _notify_action(message, session.settings)
+            return action()
+
+        return run
+
+    # These tray actions restart the service (a few seconds of unavailability),
+    # which is otherwise invisible - so they get a heads-up toast.
+    action_callbacks["start_service"] = _action_with_toast(
+        "Starting the dictation service…", lambda: controller.run_tray_action(session.start_service)
+    )
+    action_callbacks["restart_service"] = _action_with_toast(
+        "Restarting the dictation service…", lambda: controller.run_tray_action(session.restart_service)
+    )
+    action_callbacks["model_cleanup"] = _action_with_toast(
+        "Toggling model cleanup — restarting the service…",
+        lambda: controller.run_tray_action(session.toggle_model_cleanup),
+    )
+
+    def set_model_and_notify(model_id: str, backend: str) -> object:
+        _notify_action("Switching ASR model — restarting the service…", session.settings)
+        return session.set_asr_model(model_id, backend)
+
     def build_menu() -> pystray.Menu:
         items: list = []
         materialize_tray_menu(
@@ -159,7 +189,7 @@ def run_windows_tray(
                 menu_refs,
                 pystray=pystray,
                 after_action=controller.run_tray_action,
-                set_model=session.set_asr_model,
+                set_model=set_model_and_notify,
                 on_copy_history=controller.copy_history_text,
             ),
             action_callbacks=action_callbacks,
@@ -277,4 +307,5 @@ def _apply_hotkey_selection(
     session.settings = patch_settings(path, hotkey_windows=binding)
     restart_hotkey()
     session.set_detail(f"Hotkey set to {binding}")
-    windows_toast(DISPLAY_NAME, f"Hotkey set to {binding}")
+    if session.settings.tray_notifications:
+        windows_toast(DISPLAY_NAME, f"Hotkey set to {binding}")

--- a/transclip/desktop/tray/win32.py
+++ b/transclip/desktop/tray/win32.py
@@ -6,7 +6,11 @@ from pathlib import Path
 from typing import Any
 
 from transclip.desktop.hotkey.windows import is_valid_hotkey, start_windows_hotkey
-from transclip.desktop.win32_app import acquire_single_instance, set_dpi_awareness
+from transclip.desktop.win32_app import (
+    acquire_single_instance,
+    set_app_user_model_id,
+    set_dpi_awareness,
+)
 from transclip.platform.runtime import PlatformRuntime
 from transclip.product import DISPLAY_NAME
 from transclip.settings import Settings, patch_settings, settings_path
@@ -38,6 +42,9 @@ def run_windows_tray(
     # Opt into per-monitor-v2 DPI awareness before any window is created so the
     # tray dialog is not bitmap-stretched (blurry) on high-DPI displays.
     set_dpi_awareness()
+    # Identify the process to the shell so the taskbar groups it as TransClip
+    # and notifications are attributed correctly (rather than to python).
+    set_app_user_model_id()
     # A second tray would install a second global hotkey hook and double-fire
     # the toggle. The mutex is held for the life of this process (released on
     # exit), so a plain acquire-and-check is enough.

--- a/transclip/desktop/tray/win32.py
+++ b/transclip/desktop/tray/win32.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from transclip.desktop.hotkey.windows import start_windows_hotkey
+from transclip.desktop.hotkey.windows import is_valid_hotkey, start_windows_hotkey
 from transclip.platform.runtime import PlatformRuntime
 from transclip.product import DISPLAY_NAME
 from transclip.settings import Settings, patch_settings, settings_path
@@ -17,6 +17,16 @@ from .menu_update import HistoryMenuState
 from .session import TraySession
 from .sinks.win32 import PystrayMenuSink
 from .views import RefDrivenMenuView
+
+
+def health_icon_color(name: str) -> str:
+    """Tray icon fill for a health state, with a safe fallback.
+
+    build_image runs inside the pystray event loop, so a KeyError here (e.g. a
+    health state added later that this map does not know) would crash the tray
+    rather than just show the wrong color.
+    """
+    return {"recording": "red", "ready": "green", "offline": "orange"}.get(name, "gray")
 
 
 def run_windows_tray(
@@ -42,8 +52,7 @@ def run_windows_tray(
     history_state = HistoryMenuState(signature=object())
 
     def build_image(icon_name: str):
-        color = {"recording": "red", "ready": "green", "offline": "orange"}[icon_name]
-        image = Image.new("RGB", (64, 64), color)
+        image = Image.new("RGB", (64, 64), health_icon_color(icon_name))
         draw = ImageDraw.Draw(image)
         draw.ellipse((16, 16, 48, 48), fill="white")
         return image
@@ -150,11 +159,24 @@ def _set_hotkey_dialog(session: TraySession, restart_hotkey: Callable[[], None])
         parent=root,
     )
     root.destroy()
-    if not value:
+    _apply_hotkey_selection(session, value, restart_hotkey)
+
+
+def _apply_hotkey_selection(
+    session: TraySession,
+    candidate: str | None,
+    restart_hotkey: Callable[[], None],
+) -> None:
+    if not candidate or not candidate.strip():
         session.set_detail("Hotkey was not changed")
         return
+    binding = candidate.strip()
+    if not is_valid_hotkey(binding):
+        # Reject before persisting: an unparseable binding would otherwise be
+        # saved and then crash keyboard.add_hotkey on the next registration.
+        session.set_detail(f"Invalid hotkey {binding!r}; keeping {session.settings.hotkey_windows!r}")
+        return
     path = session.explicit_settings_path or settings_path()
-    binding = value.strip()
     session.settings = patch_settings(path, hotkey_windows=binding)
     restart_hotkey()
     session.set_detail(f"Hotkey set to {binding}")

--- a/transclip/desktop/tray/win32.py
+++ b/transclip/desktop/tray/win32.py
@@ -6,8 +6,10 @@ from pathlib import Path
 from typing import Any
 
 from transclip.desktop.hotkey.windows import is_valid_hotkey, start_windows_hotkey
+from transclip.desktop.notifications import register_toast_app_id, windows_toast
 from transclip.desktop.win32_app import (
     acquire_single_instance,
+    release_single_instance,
     set_app_user_model_id,
     set_dpi_awareness,
 )
@@ -45,10 +47,12 @@ def run_windows_tray(
     # Identify the process to the shell so the taskbar groups it as TransClip
     # and notifications are attributed correctly (rather than to python).
     set_app_user_model_id()
+    register_toast_app_id()
     # A second tray would install a second global hotkey hook and double-fire
-    # the toggle. The mutex is held for the life of this process (released on
-    # exit), so a plain acquire-and-check is enough.
-    if acquire_single_instance() is None:
+    # the toggle. Hold the mutex for the lifetime of this run and release it on
+    # every exit path so the guard is re-entrant across runs.
+    instance = acquire_single_instance()
+    if instance is None:
         print("TransClip tray is already running.", file=sys.stderr)
         return 0
     try:
@@ -60,6 +64,7 @@ def run_windows_tray(
             "uv sync --extra windows-ui or pip install 'transclip[windows-ui]'",
             file=sys.stderr,
         )
+        release_single_instance(instance)
         return 1
 
     session = TraySession(settings, explicit_settings_path, runtime)
@@ -157,6 +162,7 @@ def run_windows_tray(
         stop = hotkey_holder["stop"]
         if stop is not None:
             stop()
+        release_single_instance(instance)
     return 0
 
 
@@ -197,3 +203,4 @@ def _apply_hotkey_selection(
     session.settings = patch_settings(path, hotkey_windows=binding)
     restart_hotkey()
     session.set_detail(f"Hotkey set to {binding}")
+    windows_toast(DISPLAY_NAME, f"Hotkey set to {binding}")

--- a/transclip/desktop/tray/win32.py
+++ b/transclip/desktop/tray/win32.py
@@ -93,12 +93,20 @@ def run_windows_tray(
         if icon_obj is not None:
             icon_obj.icon = build_image(icon)
 
+    def refresh_menu_display() -> None:
+        # pystray items are immutable; the setters above update backing state,
+        # so the menu must be repainted for the new labels/enabled to show.
+        icon_obj = icon_holder["icon"]
+        if icon_obj is not None:
+            icon_obj.update_menu()
+
     menu_view = RefDrivenMenuView(
         menu_refs,
         set_item_label=lambda item, text: setattr(item, "text", text),
         set_item_enabled=lambda item, enabled: setattr(item, "enabled", enabled),
         rebuild_history=rebuild_history,
         set_health_icon=set_health_icon,
+        on_updated=refresh_menu_display,
     )
     controller = TrayController(
         session,

--- a/transclip/desktop/tray/win32.py
+++ b/transclip/desktop/tray/win32.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 import sys
 import threading
 from collections.abc import Callable
@@ -379,7 +380,15 @@ def _prompt_hotkey(
         entry.focus_set()
         root.mainloop()
 
-    thread = threading.Thread(target=run, name="transclip-hotkey-dialog", daemon=True)
+    def run_and_cleanup() -> None:
+        run()
+        # The Tk interpreter was created on this thread; finalize it here, after
+        # run()'s widgets are out of scope, so the cyclic GC does not free it on
+        # the main thread - which aborts with
+        # "Tcl_AsyncDelete: async handler deleted by the wrong thread".
+        gc.collect()
+
+    thread = threading.Thread(target=run_and_cleanup, name="transclip-hotkey-dialog", daemon=True)
     thread.start()
     thread.join()
     return state["value"], state["available"]

--- a/transclip/desktop/tray/win32.py
+++ b/transclip/desktop/tray/win32.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from transclip.desktop.hotkey.windows import is_valid_hotkey, start_windows_hotkey
-from transclip.desktop.notifications import register_toast_app_id, windows_toast
+from transclip.desktop.notifications import recording_toast_message, register_toast_app_id, windows_toast
 from transclip.desktop.win32_app import (
     acquire_single_instance,
     release_single_instance,
@@ -34,6 +34,20 @@ def health_icon_color(name: str) -> str:
     rather than just show the wrong color.
     """
     return {"recording": "red", "ready": "green", "offline": "orange"}.get(name, "gray")
+
+
+def _notify_toggle(outcome: Any, settings: Settings) -> None:
+    """Toast the result of a recording toggle when notifications are enabled."""
+    if not settings.recording_notifications:
+        return
+    message = recording_toast_message(
+        outcome.ok,
+        outcome.payload.get("action"),
+        paste_failed=bool(outcome.paste_failed_message),
+        error=outcome.error_message or "",
+    )
+    if message:
+        windows_toast(DISPLAY_NAME, message)
 
 
 def run_windows_tray(
@@ -120,12 +134,19 @@ def run_windows_tray(
         _set_hotkey_dialog(session, restart_hotkey)
         controller.update_menu()
 
+    def toggle_and_notify() -> object:
+        outcome = controller.toggle_record()
+        _notify_toggle(outcome, session.settings)
+        return outcome
+
     action_callbacks = build_tray_action_callbacks(
         controller,
         session,
         set_hotkey=set_hotkey,
         quit=lambda: icon_holder["icon"].stop() if icon_holder["icon"] is not None else None,
     )
+    # Notify on both toggle paths (global hotkey and the tray menu item).
+    action_callbacks["toggle"] = lambda *_: toggle_and_notify()
 
     def build_menu() -> pystray.Menu:
         items: list = []
@@ -148,7 +169,7 @@ def run_windows_tray(
         return pystray.Menu(*items)
 
     def on_hotkey() -> None:
-        controller.toggle_record()
+        toggle_and_notify()
 
     icon = pystray.Icon(
         DISPLAY_NAME,

--- a/transclip/desktop/tray/win32.py
+++ b/transclip/desktop/tray/win32.py
@@ -157,13 +157,21 @@ def run_windows_tray(
         on_health_icon=lambda: menu_view.set_health_icon(session.health.icon),
     )
 
+    def pause_hotkey() -> None:
+        # Stop and clear the handle so resume (restart_hotkey) re-registers
+        # cleanly instead of trying to remove the already-removed hotkey.
+        stop = hotkey_holder["stop"]
+        if stop is not None:
+            stop()
+            hotkey_holder["stop"] = None
+
     def capture_hotkey() -> str | None:
         try:
             import keyboard
         except ImportError:
             return None
         return _capture_hotkey(
-            pause=lambda: hotkey_holder["stop"]() if hotkey_holder["stop"] is not None else None,
+            pause=pause_hotkey,
             resume=restart_hotkey,
             read_hotkey=lambda: keyboard.read_hotkey(suppress=False),
         )
@@ -346,8 +354,12 @@ def _prompt_hotkey(
             entry.config(state="disabled")
 
             def worker() -> None:
-                recording["result"] = capture()
-                recording["active"] = False
+                # finally so a failure in capture() can never leave the dialog
+                # stuck in the recording state (entry disabled, buttons inert).
+                try:
+                    recording["result"] = capture()
+                finally:
+                    recording["active"] = False
 
             threading.Thread(target=worker, name="transclip-hotkey-capture", daemon=True).start()
             poll_capture()

--- a/transclip/desktop/tray/win32.py
+++ b/transclip/desktop/tray/win32.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import threading
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -82,7 +83,7 @@ def run_windows_tray(
         return 1
 
     session = TraySession(settings, explicit_settings_path, runtime)
-    icon_holder: dict[str, object] = {"icon": None}
+    icon_holder: dict[str, Any] = {"icon": None}
     hotkey_holder: dict[str, Callable[[], None] | None] = {"stop": None}
     menu_refs: dict[str, Any] = {}
     history_state = HistoryMenuState(signature=object())
@@ -196,22 +197,66 @@ def run_windows_tray(
 
 
 def _set_hotkey_dialog(session: TraySession, restart_hotkey: Callable[[], None]) -> None:
-    try:
-        import tkinter as tk
-        from tkinter import simpledialog
-    except ImportError:
+    value, available = _prompt_hotkey(session.settings.hotkey_windows)
+    if not available:
         session.set_detail("tkinter is unavailable for hotkey dialog")
         return
-    root = tk.Tk()
-    root.withdraw()
-    value = simpledialog.askstring(
-        "Set hotkey",
-        "Enter a keyboard-library hotkey, e.g. ctrl+shift+space",
-        initialvalue=session.settings.hotkey_windows,
-        parent=root,
-    )
-    root.destroy()
     _apply_hotkey_selection(session, value, restart_hotkey)
+
+
+def _prompt_hotkey(initial: str) -> tuple[str | None, bool]:
+    """Prompt for a hotkey on a dedicated thread; return (value, tk_available).
+
+    pystray runs its Win32 message loop on the main thread and invokes the menu
+    action synchronously inside that loop, after making its own hidden window
+    the foreground window. A tkinter dialog created there is nested inside
+    pystray's message pump and can never take the foreground, so it renders but
+    every click is dead. Running our own small dialog on a separate thread gives
+    it a clean message queue and event loop; topmost + focus_force make it
+    interactive. The caller blocks (join) until it closes - i.e. it is modal.
+    """
+    state: dict[str, Any] = {"value": None, "available": True}
+
+    def run() -> None:
+        try:
+            import tkinter as tk
+        except ImportError:
+            state["available"] = False
+            return
+        root = tk.Tk()
+        root.title("Set hotkey")
+        root.resizable(False, False)
+        root.attributes("-topmost", True)
+        tk.Label(root, text="Enter a keyboard-library hotkey, e.g. ctrl+shift+space").pack(padx=16, pady=(14, 6))
+        entry = tk.Entry(root, width=44)
+        entry.insert(0, initial)
+        entry.select_range(0, "end")
+        entry.pack(padx=16, pady=6)
+
+        def submit() -> None:
+            state["value"] = entry.get()
+            root.destroy()
+
+        def cancel() -> None:
+            state["value"] = None
+            root.destroy()
+
+        buttons = tk.Frame(root)
+        buttons.pack(pady=(6, 14))
+        tk.Button(buttons, text="OK", width=10, command=submit).pack(side="left", padx=8)
+        tk.Button(buttons, text="Cancel", width=10, command=cancel).pack(side="left", padx=8)
+        root.bind("<Return>", lambda _event: submit())
+        root.bind("<Escape>", lambda _event: cancel())
+        root.protocol("WM_DELETE_WINDOW", cancel)
+        root.lift()
+        root.focus_force()
+        entry.focus_set()
+        root.mainloop()
+
+    thread = threading.Thread(target=run, name="transclip-hotkey-dialog", daemon=True)
+    thread.start()
+    thread.join()
+    return state["value"], state["available"]
 
 
 def _apply_hotkey_selection(

--- a/transclip/desktop/tray/win32.py
+++ b/transclip/desktop/tray/win32.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from transclip.desktop.hotkey.windows import is_valid_hotkey, start_windows_hotkey
-from transclip.desktop.win32_app import set_dpi_awareness
+from transclip.desktop.win32_app import acquire_single_instance, set_dpi_awareness
 from transclip.platform.runtime import PlatformRuntime
 from transclip.product import DISPLAY_NAME
 from transclip.settings import Settings, patch_settings, settings_path
@@ -38,6 +38,12 @@ def run_windows_tray(
     # Opt into per-monitor-v2 DPI awareness before any window is created so the
     # tray dialog is not bitmap-stretched (blurry) on high-DPI displays.
     set_dpi_awareness()
+    # A second tray would install a second global hotkey hook and double-fire
+    # the toggle. The mutex is held for the life of this process (released on
+    # exit), so a plain acquire-and-check is enough.
+    if acquire_single_instance() is None:
+        print("TransClip tray is already running.", file=sys.stderr)
+        return 0
     try:
         import pystray
         from PIL import Image, ImageDraw

--- a/transclip/desktop/tray/win32.py
+++ b/transclip/desktop/tray/win32.py
@@ -57,6 +57,26 @@ def _notify_action(message: str, settings: Settings) -> None:
         windows_toast(DISPLAY_NAME, message)
 
 
+def _capture_hotkey(
+    pause: Callable[[], None],
+    resume: Callable[[], None],
+    read_hotkey: Callable[[], str | None],
+) -> str | None:
+    """Pause the live hotkey, capture a chord, then restore the hotkey.
+
+    Pausing stops the keys pressed for capture from also triggering the
+    currently registered global hotkey. resume() always runs (even if the read
+    fails), and a failed read yields None rather than propagating.
+    """
+    pause()
+    try:
+        return read_hotkey()
+    except Exception:
+        return None
+    finally:
+        resume()
+
+
 def run_windows_tray(
     settings: Settings,
     explicit_settings_path: Path | None = None,
@@ -137,8 +157,19 @@ def run_windows_tray(
         on_health_icon=lambda: menu_view.set_health_icon(session.health.icon),
     )
 
+    def capture_hotkey() -> str | None:
+        try:
+            import keyboard
+        except ImportError:
+            return None
+        return _capture_hotkey(
+            pause=lambda: hotkey_holder["stop"]() if hotkey_holder["stop"] is not None else None,
+            resume=restart_hotkey,
+            read_hotkey=lambda: keyboard.read_hotkey(suppress=False),
+        )
+
     def set_hotkey(_icon=None, _item=None) -> None:
-        _set_hotkey_dialog(session, restart_hotkey)
+        _set_hotkey_dialog(session, restart_hotkey, capture_hotkey)
         controller.update_menu()
 
     def toggle_and_notify() -> object:
@@ -226,15 +257,22 @@ def run_windows_tray(
     return 0
 
 
-def _set_hotkey_dialog(session: TraySession, restart_hotkey: Callable[[], None]) -> None:
-    value, available = _prompt_hotkey(session.settings.hotkey_windows)
+def _set_hotkey_dialog(
+    session: TraySession,
+    restart_hotkey: Callable[[], None],
+    capture: Callable[[], str | None] | None = None,
+) -> None:
+    value, available = _prompt_hotkey(session.settings.hotkey_windows, capture)
     if not available:
         session.set_detail("tkinter is unavailable for hotkey dialog")
         return
     _apply_hotkey_selection(session, value, restart_hotkey)
 
 
-def _prompt_hotkey(initial: str) -> tuple[str | None, bool]:
+def _prompt_hotkey(
+    initial: str,
+    capture: Callable[[], str | None] | None = None,
+) -> tuple[str | None, bool]:
     """Prompt for a hotkey on a dedicated thread; return (value, tk_available).
 
     pystray runs its Win32 message loop on the main thread and invokes the menu
@@ -244,6 +282,11 @@ def _prompt_hotkey(initial: str) -> tuple[str | None, bool]:
     every click is dead. Running our own small dialog on a separate thread gives
     it a clean message queue and event loop; topmost + focus_force make it
     interactive. The caller blocks (join) until it closes - i.e. it is modal.
+
+    When ``capture`` is supplied a "Record keys" button captures the pressed
+    chord (on a worker thread, since it blocks); the entry is disabled and the
+    buttons are inert during capture, so the press cannot close the dialog or
+    type into the field, and the result is filled in via after() polling.
     """
     state: dict[str, Any] = {"value": None, "available": True}
 
@@ -257,22 +300,63 @@ def _prompt_hotkey(initial: str) -> tuple[str | None, bool]:
         root.title("Set hotkey")
         root.resizable(False, False)
         root.attributes("-topmost", True)
-        tk.Label(root, text="Enter a keyboard-library hotkey, e.g. ctrl+shift+space").pack(padx=16, pady=(14, 6))
+        prompt = "Type a keyboard-library hotkey (e.g. ctrl+shift+space)"
+        if capture is not None:
+            prompt += ",\nor click Record keys and press the combination."
+        tk.Label(root, text=prompt, justify="left").pack(padx=16, pady=(14, 6))
         entry = tk.Entry(root, width=44)
         entry.insert(0, initial)
         entry.select_range(0, "end")
         entry.pack(padx=16, pady=6)
 
+        recording: dict[str, Any] = {"active": False, "result": None}
+        record_button: Any = None
+
         def submit() -> None:
+            if recording["active"]:
+                return
             state["value"] = entry.get()
             root.destroy()
 
         def cancel() -> None:
+            if recording["active"]:
+                return
             state["value"] = None
             root.destroy()
 
+        def poll_capture() -> None:
+            if recording["active"]:
+                root.after(100, poll_capture)
+                return
+            entry.config(state="normal")
+            record_button.config(text="Record keys")
+            chord = recording["result"]
+            recording["result"] = None
+            if chord:
+                entry.delete(0, "end")
+                entry.insert(0, chord)
+                entry.select_range(0, "end")
+            entry.focus_set()
+
+        def begin_capture() -> None:
+            if capture is None or recording["active"]:
+                return
+            recording["active"] = True
+            record_button.config(text="Press your hotkey…")
+            entry.config(state="disabled")
+
+            def worker() -> None:
+                recording["result"] = capture()
+                recording["active"] = False
+
+            threading.Thread(target=worker, name="transclip-hotkey-capture", daemon=True).start()
+            poll_capture()
+
         buttons = tk.Frame(root)
         buttons.pack(pady=(6, 14))
+        if capture is not None:
+            record_button = tk.Button(buttons, text="Record keys", width=12, command=begin_capture)
+            record_button.pack(side="left", padx=8)
         tk.Button(buttons, text="OK", width=10, command=submit).pack(side="left", padx=8)
         tk.Button(buttons, text="Cancel", width=10, command=cancel).pack(side="left", padx=8)
         root.bind("<Return>", lambda _event: submit())

--- a/transclip/desktop/tray/win32.py
+++ b/transclip/desktop/tray/win32.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from transclip.desktop.hotkey.windows import is_valid_hotkey, start_windows_hotkey
+from transclip.desktop.win32_app import set_dpi_awareness
 from transclip.platform.runtime import PlatformRuntime
 from transclip.product import DISPLAY_NAME
 from transclip.settings import Settings, patch_settings, settings_path
@@ -34,6 +35,9 @@ def run_windows_tray(
     explicit_settings_path: Path | None = None,
     runtime: PlatformRuntime | None = None,
 ) -> int:
+    # Opt into per-monitor-v2 DPI awareness before any window is created so the
+    # tray dialog is not bitmap-stretched (blurry) on high-DPI displays.
+    set_dpi_awareness()
     try:
         import pystray
         from PIL import Image, ImageDraw

--- a/transclip/desktop/tray/win32.py
+++ b/transclip/desktop/tray/win32.py
@@ -240,6 +240,10 @@ def run_windows_tray(
         return pystray.Menu(*items)
 
     def on_hotkey() -> None:
+        # Runs on the keyboard library's low-level hook thread, not the pystray
+        # message loop: it mutates menu-item backing state and calls
+        # update_menu(). Writes are simple attribute sets, so the worst case is a
+        # torn read that self-heals on the next repaint.
         toggle_and_notify()
 
     icon = pystray.Icon(

--- a/transclip/desktop/win32_app.py
+++ b/transclip/desktop/win32_app.py
@@ -1,0 +1,69 @@
+"""Windows process-setup helpers for the tray/GUI process.
+
+These configure process-wide Windows attributes that should be set once, early,
+when the interactive (tray) process starts: DPI awareness so windows render
+crisply, the AppUserModelID so the shell attributes the app correctly, and a
+single-instance guard so a second tray cannot double-register the hotkey.
+
+Each real syscall degrades to a no-op off Windows (``ctypes.windll`` does not
+exist there), so the module imports everywhere and the helpers are safe to call
+unconditionally.
+"""
+
+from __future__ import annotations
+
+import ctypes
+from collections.abc import Callable
+from ctypes import wintypes
+
+# DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 is a sentinel HANDLE value (-4).
+_PER_MONITOR_AWARE_V2 = ctypes.c_void_p(-4)
+_PROCESS_PER_MONITOR_DPI_AWARE = 2  # shcore PROCESS_DPI_AWARENESS
+
+
+def _set_dpi_context() -> bool:
+    try:
+        user32 = ctypes.windll.user32
+        user32.SetProcessDpiAwarenessContext.argtypes = [wintypes.HANDLE]
+        user32.SetProcessDpiAwarenessContext.restype = wintypes.BOOL
+        return bool(user32.SetProcessDpiAwarenessContext(_PER_MONITOR_AWARE_V2))
+    except (AttributeError, OSError):
+        return False
+
+
+def _set_dpi_shcore() -> bool:
+    try:
+        shcore = ctypes.windll.shcore
+        shcore.SetProcessDpiAwareness.argtypes = [ctypes.c_int]
+        shcore.SetProcessDpiAwareness.restype = ctypes.c_long  # HRESULT
+        return shcore.SetProcessDpiAwareness(_PROCESS_PER_MONITOR_DPI_AWARE) == 0  # S_OK
+    except (AttributeError, OSError):
+        return False
+
+
+def _set_dpi_legacy() -> bool:
+    try:
+        return bool(ctypes.windll.user32.SetProcessDPIAware())
+    except (AttributeError, OSError):
+        return False
+
+
+def set_dpi_awareness(
+    set_context: Callable[[], bool] = _set_dpi_context,
+    set_shcore: Callable[[], bool] = _set_dpi_shcore,
+    set_legacy: Callable[[], bool] = _set_dpi_legacy,
+) -> str:
+    """Opt the process into the best available DPI awareness mode.
+
+    Microsoft recommends Per-Monitor-v2 (Win10 1703+) so windows render crisply
+    instead of being bitmap-stretched (blurry) on high-DPI / multi-monitor
+    setups. Falls back to per-monitor (shcore, Win8.1) then system awareness on
+    older Windows. Returns the mode that was applied.
+    """
+    if set_context():
+        return "per-monitor-v2"
+    if set_shcore():
+        return "per-monitor"
+    if set_legacy():
+        return "system"
+    return "unaware"

--- a/transclip/desktop/win32_app.py
+++ b/transclip/desktop/win32_app.py
@@ -30,7 +30,7 @@ SINGLE_INSTANCE_MUTEX = "TransClip-tray-singleton"
 
 
 @functools.cache
-def _kernel32() -> ctypes.WinDLL:
+def _kernel32() -> ctypes.WinDLL:  # type: ignore[name-defined]
     """Private kernel32 handle with use_last_error so get_last_error is reliable.
 
     Raises AttributeError off Windows (ctypes.WinDLL does not exist there), which

--- a/transclip/desktop/win32_app.py
+++ b/transclip/desktop/win32_app.py
@@ -18,6 +18,8 @@ import functools
 from collections.abc import Callable
 from ctypes import wintypes
 
+from transclip.product import APP_USER_MODEL_ID
+
 # DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 is a sentinel HANDLE value (-4).
 _PER_MONITOR_AWARE_V2 = ctypes.c_void_p(-4)
 _PROCESS_PER_MONITOR_DPI_AWARE = 2  # shcore PROCESS_DPI_AWARENESS
@@ -88,6 +90,23 @@ def set_dpi_awareness(
     if set_legacy():
         return "system"
     return "unaware"
+
+
+def set_app_user_model_id(aumid: str = APP_USER_MODEL_ID) -> bool:
+    """Give the process an explicit AppUserModelID for the Windows shell.
+
+    Without one, the shell derives an implicit identity from the host
+    executable (python.exe/pythonw.exe), which groups TransClip under Python on
+    the taskbar and misattributes notifications. Must be called before any
+    window is created. Returns True on success (S_OK).
+    """
+    try:
+        shell32 = ctypes.windll.shell32
+        shell32.SetCurrentProcessExplicitAppUserModelID.argtypes = [wintypes.LPCWSTR]
+        shell32.SetCurrentProcessExplicitAppUserModelID.restype = ctypes.c_long  # HRESULT
+        return shell32.SetCurrentProcessExplicitAppUserModelID(aumid) == 0
+    except (AttributeError, OSError):
+        return False
 
 
 def acquire_single_instance(name: str = SINGLE_INSTANCE_MUTEX) -> int | None:

--- a/transclip/desktop/win32_app.py
+++ b/transclip/desktop/win32_app.py
@@ -12,13 +12,34 @@ unconditionally.
 
 from __future__ import annotations
 
+import contextlib
 import ctypes
+import functools
 from collections.abc import Callable
 from ctypes import wintypes
 
 # DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 is a sentinel HANDLE value (-4).
 _PER_MONITOR_AWARE_V2 = ctypes.c_void_p(-4)
 _PROCESS_PER_MONITOR_DPI_AWARE = 2  # shcore PROCESS_DPI_AWARENESS
+_ERROR_ALREADY_EXISTS = 183
+
+# Per-session (Local namespace) mutex name; one interactive tray per login.
+SINGLE_INSTANCE_MUTEX = "TransClip-tray-singleton"
+
+
+@functools.cache
+def _kernel32() -> ctypes.WinDLL:
+    """Private kernel32 handle with use_last_error so get_last_error is reliable.
+
+    Raises AttributeError off Windows (ctypes.WinDLL does not exist there), which
+    the callers catch and degrade to a no-op.
+    """
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateMutexW.argtypes = [wintypes.LPVOID, wintypes.BOOL, wintypes.LPCWSTR]
+    kernel32.CreateMutexW.restype = wintypes.HANDLE
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    return kernel32
 
 
 def _set_dpi_context() -> bool:
@@ -67,3 +88,31 @@ def set_dpi_awareness(
     if set_legacy():
         return "system"
     return "unaware"
+
+
+def acquire_single_instance(name: str = SINGLE_INSTANCE_MUTEX) -> int | None:
+    """Acquire a named mutex; return its handle, or None if already held.
+
+    A second ``transclip tray`` would otherwise install a second low-level
+    keyboard hook and make the toggle hotkey fire twice. The handle must be kept
+    alive for the process lifetime (the mutex releases when it is closed or the
+    process exits). Returns None off Windows, where there is nothing to guard.
+    """
+    try:
+        kernel32 = _kernel32()
+    except (AttributeError, OSError):
+        return None
+    handle = kernel32.CreateMutexW(None, False, name)
+    if not handle:
+        return None
+    if ctypes.get_last_error() == _ERROR_ALREADY_EXISTS:
+        kernel32.CloseHandle(handle)
+        return None
+    return handle
+
+
+def release_single_instance(handle: int | None) -> None:
+    if not handle:
+        return
+    with contextlib.suppress(AttributeError, OSError):
+        _kernel32().CloseHandle(handle)

--- a/transclip/doctor/__init__.py
+++ b/transclip/doctor/__init__.py
@@ -29,6 +29,7 @@ from .platform import (
     check_hotkey_readiness,
     check_microphone_devices,
     check_tcc_permissions,
+    check_windows_elevated_paste,
     check_windows_version,
 )
 from .types import Check
@@ -69,6 +70,7 @@ def run_checks(
         check_session_type(platform_runtime),
         check_clipboard_tools(platform_runtime),
         check_paste_tools(platform_runtime),
+        check_windows_elevated_paste(platform_runtime),
         *build_backend_checks(settings, platform_runtime),
         check_hotkey_readiness(settings, platform_runtime),
         check_microphone_devices(settings, platform_runtime),

--- a/transclip/doctor/__init__.py
+++ b/transclip/doctor/__init__.py
@@ -126,8 +126,8 @@ def check_service_manager(
             "missing LaunchAgent; run: transclip install",
         ),
         "Windows": (
-            "Task Scheduler logon task installed",
-            "missing Task Scheduler task; run: transclip install",
+            "logon autostart registered (Run key)",
+            "autostart not registered; run: transclip install",
         ),
     }
     if system not in messages:

--- a/transclip/doctor/platform.py
+++ b/transclip/doctor/platform.py
@@ -144,6 +144,21 @@ def check_windows_version(runtime: PlatformRuntime | None = None) -> Check:
     )
 
 
+def check_windows_elevated_paste(runtime: PlatformRuntime | None = None) -> Check:
+    platform_runtime = get_runtime(runtime)
+    if platform_runtime.system() != "Windows":
+        return Check("windows_elevated_paste", True, "not checked off Windows", required=False)
+    return Check(
+        "windows_elevated_paste",
+        True,
+        "paste uses SendInput; Windows UIPI silently blocks injection into a "
+        "window owned by a process running as administrator. If paste does "
+        "nothing in an elevated app, run that app without elevation (or run "
+        "TransClip at the same elevation).",
+        required=False,
+    )
+
+
 def check_tcc_permissions(runtime: PlatformRuntime | None = None) -> Check:
     platform_runtime = get_runtime(runtime)
     if platform_runtime.system() != "Darwin":

--- a/transclip/product.py
+++ b/transclip/product.py
@@ -17,3 +17,6 @@ LEGACY_SHORTCUT_PATH = "/org/gnome/settings-daemon/plugins/media-keys/custom-key
 FALLBACK_HOTKEY_LINUX = "XF86TouchpadOff"
 TASK_SCHEDULER_NAME = DISPLAY_NAME
 IMPORT_PACKAGE = "transclip"
+# Windows AppUserModelID: shell identity for taskbar grouping and notification
+# attribution. Reverse-DNS style, no spaces, <= 128 chars.
+APP_USER_MODEL_ID = "com.paulbrav.TransClip"

--- a/transclip/product.py
+++ b/transclip/product.py
@@ -15,7 +15,6 @@ SHORTCUT_ALT_PATH = "/org/gnome/settings-daemon/plugins/media-keys/custom-keybin
 LEGACY_SHORTCUT_NAME = "Granite Speach Toggle"
 LEGACY_SHORTCUT_PATH = "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/granite-speach-toggle/"
 FALLBACK_HOTKEY_LINUX = "XF86TouchpadOff"
-TASK_SCHEDULER_NAME = DISPLAY_NAME
 IMPORT_PACKAGE = "transclip"
 # Windows AppUserModelID: shell identity for taskbar grouping and notification
 # attribution. Reverse-DNS style, no spaces, <= 128 chars.

--- a/transclip/settings.py
+++ b/transclip/settings.py
@@ -37,6 +37,7 @@ class Settings:
     min_recording_ms: int = 250
     max_recording_ms: int = 300_000
     toggle_cooldown_ms: int = 500
+    recording_notifications: bool = True
     debug_capture: bool = False
     debug_capture_dir: str = "debug-captures"
     asr_backend: str = "granite_nar"
@@ -132,7 +133,7 @@ def settings_to_toml(settings: Settings) -> str:
             "paste_injection_delay_ms",
             "clipboard_restore_delay_ms",
         ),
-        ("min_recording_ms", "max_recording_ms", "toggle_cooldown_ms"),
+        ("min_recording_ms", "max_recording_ms", "toggle_cooldown_ms", "recording_notifications"),
         ("debug_capture", "debug_capture_dir"),
         (
             "asr_backend",

--- a/transclip/settings.py
+++ b/transclip/settings.py
@@ -37,7 +37,7 @@ class Settings:
     min_recording_ms: int = 250
     max_recording_ms: int = 300_000
     toggle_cooldown_ms: int = 500
-    recording_notifications: bool = True
+    tray_notifications: bool = True
     debug_capture: bool = False
     debug_capture_dir: str = "debug-captures"
     asr_backend: str = "granite_nar"
@@ -133,7 +133,7 @@ def settings_to_toml(settings: Settings) -> str:
             "paste_injection_delay_ms",
             "clipboard_restore_delay_ms",
         ),
-        ("min_recording_ms", "max_recording_ms", "toggle_cooldown_ms", "recording_notifications"),
+        ("min_recording_ms", "max_recording_ms", "toggle_cooldown_ms", "tray_notifications"),
         ("debug_capture", "debug_capture_dir"),
         (
             "asr_backend",

--- a/transclip/shell_command.py
+++ b/transclip/shell_command.py
@@ -15,6 +15,10 @@ from .text_generation import TextGenerationBackend
 
 SHELL_SYNTAX_ERROR_CODES = ("SC107", "SC108")
 SHELL_VALIDATION_TIMEOUT_SECONDS = 2.0
+# bash exits 2 from `bash -n` only for an actual syntax error. Any other
+# nonzero means bash could not run the check (e.g. the Windows WSL launcher
+# relaying into a distro with no /bin/bash) - not a verdict on the command.
+BASH_SYNTAX_ERROR_RETURNCODE = 2
 
 
 @dataclass(frozen=True, slots=True)
@@ -182,9 +186,15 @@ def validate_shell_command(
         metadata["bash_returncode"] = completed.returncode
         if completed.stderr.strip():
             metadata["bash_stderr"] = completed.stderr.strip()
-        if completed.returncode != 0:
+        if completed.returncode == BASH_SYNTAX_ERROR_RETURNCODE:
             diagnostics.append(_single_line(completed.stderr) or "bash syntax check failed")
             return ShellValidationResult(False, diagnostics, metadata)
+        if completed.returncode != 0:
+            # bash is present but could not run the check (e.g. the Windows WSL
+            # launcher relaying into a distro with no /bin/bash). We cannot
+            # validate, so skip rather than reject a possibly-valid command -
+            # mirroring the behaviour when bash is not found at all.
+            metadata["bash_nonfunctional"] = True
 
     shellcheck = platform_runtime.which("shellcheck") if settings.shellcheck_enabled else None
     metadata["shellcheck_available"] = bool(shellcheck)


### PR DESCRIPTION
## Summary

Hardens the existing Windows support so the tray, paste, notifications, and
service-install paths actually work on real Windows 11 hardware. Most of these
were latent bugs that never surfaced in CI because the unit tests mocked the OS
boundary (ctypes / pystray / registry); they only appear against the real Win32
APIs. Every change is Windows-only or platform-gated and does not alter
Linux/macOS behaviour.

Validated end-to-end on Windows 11 (NVIDIA RTX 5090): dictate -> cleanup -> paste
into Notepad, tray menu + global hotkey, and `install` / `status` / `uninstall`.

## What's fixed

**Win32 interop (the core "it crashes" bugs)**
- Clipboard access crashed on 64-bit: ctypes used the default `c_int` restype and
  truncated handles -> declare explicit `argtypes`/`restype` for every call.
- `SendInput` paste silently failed: the `INPUT` union omitted
  `MOUSEINPUT`/`HARDWAREINPUT`, so `sizeof(INPUT)` didn't match the x64 ABI.
- Use a private `WinDLL(use_last_error=True)` handle instead of mutating the
  shared `ctypes.windll` cache.
- Retry `OpenClipboard` under transient contention.

**System tray (pystray)**
- pystray rejects menu-action callbacks with >2 positional args (a default-arg
  loop binding inflated `co_argcount`) -> factory-built 2-arg handlers.
- pystray `MenuItem.text`/`enabled` are read-only -> drive labels from backing
  state + `icon.update_menu()`; coalesce repaints into one per refresh.
- Per-monitor-v2 DPI awareness, a single-instance named mutex, and an explicit
  AppUserModelID for taskbar grouping + notification attribution.
- Set-hotkey dialog runs on its own Tk thread (it was unresponsive nested in the
  pystray loop), with a "Record keys" capture; fixes for the capture crash and a
  `Tcl_AsyncDelete` on dialog close.
- Reject invalid hotkey strings and unknown health-icon states before they reach
  the event loop.

**Notifications**
- Modern toast notifications via the WinRT projection (pywinrt) - recording
  on/off and service/model toasts under a single `tray_notifications` setting.

**Service install / autostart**
- Run the service via `pythonw.exe` so it doesn't flash a console window at logon.
- **Autostart via the per-user HKCU Run key instead of Task Scheduler.** Creating
  a root-folder scheduled task requires admin, so `install` failed with "Access is
  denied" for a normal user. The Run key is writable by the user's own token (no
  UAC): `install` registers it and starts the service; `uninstall` stops it and
  removes the value; `status` matches the running service by command line
  (locale-independent, unlike parsing `schtasks` output).

**Doctor / docs / misc**
- Document the UIPI limitation (a normal-integrity app can't paste into an
  elevated window) in `doctor` and the README.
- `docs/windows-roadmap.md` for a future on-device Windows Speech backend.
- Skip shell-command syntax validation when `bash` exists but can't execute (e.g.
  a broken WSL relay), instead of rejecting all shell commands.

## Testing

- `ruff check` + `compileall` + `python -m tests`: **436 tests pass**, including
  Win32-gated tests that exercise the real registry, named mutex, AUMID,
  SendInput, and pystray rather than mocks.
- `ty` clean on the changed modules.
- Manual: install/status/uninstall, mic dictation -> paste, tray hotkey
  set/capture, toasts.

## Notes

- Complementary to the OpenVINO Windows backend - this is daemon/tray/paste
  hardening (+ Granite on CUDA), not a new ASR backend.
- Independent of the NAR-on-Windows PR.
