### PR TITLE
Add OpenAI-compatible POST /v1/audio/transcriptions route

### DIFF
--- a/tests/service_helpers.py
+++ b/tests/service_helpers.py
@@ -1,5 +1,8 @@
+import http.client
+import io
 import json
 import threading
+import wave
 from collections.abc import Callable, Iterable
 from pathlib import Path
 from urllib import request
@@ -227,6 +230,71 @@ def stop_server(server, thread: threading.Thread) -> None:
     server.shutdown()
     server.server_close()
     thread.join(timeout=5)
+
+
+def tiny_wav_bytes(frames: int = 1600, sample_rate: int = 16000) -> bytes:
+    """A minimal but genuinely decodable mono 16-bit PCM WAV (soundfile.info-valid)."""
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(b"\x00\x00" * frames)
+    return buffer.getvalue()
+
+
+def build_multipart_body(
+    fields: dict[str, str] | None = None,
+    files: list[tuple[str, str | None, bytes]] | None = None,
+    boundary: bytes = b"----transcliptestboundary",
+) -> tuple[str, bytes]:
+    """Return (content_type, body) for a multipart/form-data payload.
+
+    ``files`` entries are (field_name, filename_or_None, content_bytes). This is
+    the raw multipart counterpart to ``http_json`` (which is JSON-only).
+    """
+    body = b""
+    for name, value in (fields or {}).items():
+        body += b"--" + boundary + b"\r\n"
+        body += b'Content-Disposition: form-data; name="' + name.encode("utf-8") + b'"\r\n\r\n'
+        body += value.encode("utf-8") + b"\r\n"
+    for name, filename, content in files or []:
+        body += b"--" + boundary + b"\r\n"
+        disposition = b'Content-Disposition: form-data; name="' + name.encode("utf-8") + b'"'
+        if filename is not None:
+            disposition += b'; filename="' + filename.encode("utf-8") + b'"'
+        body += disposition + b"\r\n"
+        body += b"Content-Type: application/octet-stream\r\n\r\n"
+        body += content + b"\r\n"
+    body += b"--" + boundary + b"--\r\n"
+    return "multipart/form-data; boundary=" + boundary.decode("ascii"), body
+
+
+def http_multipart(
+    host: str,
+    port: int,
+    path: str,
+    *,
+    content_type: str,
+    body: bytes,
+    extra_headers: dict[str, str] | None = None,
+) -> tuple[int, dict[str, str], bytes]:
+    """POST a raw multipart body and return (status, lower-cased headers, raw bytes).
+
+    Headers are passed verbatim, so a caller may spoof ``content-length`` (e.g. to
+    exercise the 413 boundary without sending a real oversize body).
+    """
+    conn = http.client.HTTPConnection(host, port, timeout=5)
+    try:
+        headers = {"content-type": content_type}
+        if extra_headers:
+            headers.update(extra_headers)
+        conn.request("POST", path, body=body, headers=headers)
+        response = conn.getresponse()
+        raw = response.read()
+        return response.status, {k.lower(): v for k, v in response.getheaders()}, raw
+    finally:
+        conn.close()
 
 
 def http_json(method: str, url: str, payload: dict | None = None) -> dict:

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -1,0 +1,274 @@
+import json
+import unittest
+
+from transclip.asr import TranscriptionResult
+from transclip.service.openai_compat import (
+    MultipartError,
+    handle_transcriptions,
+    openai_error_body,
+    parse_multipart,
+    sanitize_suffix,
+)
+
+from tests.service_helpers import build_multipart_body as build_multipart
+from tests.service_helpers import tiny_wav_bytes
+
+try:  # pre-validation is best-effort: only installs with the model extras have soundfile
+    import soundfile as _soundfile  # noqa: F401
+
+    _HAVE_SOUNDFILE = True
+except ImportError:
+    _HAVE_SOUNDFILE = False
+
+
+class FakeRawEngine:
+    def __init__(self, text: str = "raw transcript", error: Exception | None = None):
+        self.text = text
+        self.error = error
+        self.calls: list = []
+
+    def transcribe_raw(self, wav_path) -> TranscriptionResult:
+        self.calls.append(wav_path)
+        if self.error is not None:
+            raise self.error
+        return TranscriptionResult(self.text, {"asr": 1.0}, "fake", "fake-model")
+
+
+class ParseMultipartTests(unittest.TestCase):
+    def test_well_formed_extracts_file_bytes_filename_and_fields(self):
+        content_type, body = build_multipart(
+            fields={"model": "whisper-1", "response_format": "json"},
+            files=[("file", "clip.wav", b"AUDIOBYTES")],
+        )
+        parsed = parse_multipart(content_type, body)
+        file_part = parsed.get("file")
+        self.assertIsNotNone(file_part)
+        self.assertEqual(file_part.content, b"AUDIOBYTES")
+        self.assertEqual(file_part.filename, "clip.wav")
+        self.assertEqual(parsed.field_text("model"), "whisper-1")
+        self.assertEqual(parsed.field_text("response_format"), "json")
+
+    def test_missing_file_field_yields_no_file_part(self):
+        content_type, body = build_multipart(fields={"model": "whisper-1"})
+        parsed = parse_multipart(content_type, body)
+        self.assertIsNone(parsed.get("file"))
+
+    def test_file_part_without_filename_is_still_extracted(self):
+        content_type, body = build_multipart(files=[("file", None, b"NOFILENAME")])
+        parsed = parse_multipart(content_type, body)
+        file_part = parsed.get("file")
+        self.assertIsNotNone(file_part)
+        self.assertIsNone(file_part.filename)
+        self.assertEqual(file_part.content, b"NOFILENAME")
+
+    def test_utf8_filename_is_decoded(self):
+        content_type, body = build_multipart(files=[("file", "grüße.wav", b"X")])
+        parsed = parse_multipart(content_type, body)
+        self.assertEqual(parsed.get("file").filename, "grüße.wav")
+
+    def test_rfc2231_extended_filename_is_decoded(self):
+        boundary = b"----transcliptestboundary"
+        body = b"--" + boundary + b"\r\n"
+        body += b"Content-Disposition: form-data; name=\"file\"; filename*=UTF-8''caf%C3%A9.wav\r\n\r\n"
+        body += b"DATA\r\n"
+        body += b"--" + boundary + b"--\r\n"
+        content_type = "multipart/form-data; boundary=" + boundary.decode("ascii")
+        parsed = parse_multipart(content_type, body)
+        self.assertEqual(parsed.get("file").filename, "café.wav")
+
+    def test_hostile_filename_survives_parse_and_sanitizes_to_wav(self):
+        content_type, body = build_multipart(files=[("file", "../../etc/passwd", b"X")])
+        parsed = parse_multipart(content_type, body)
+        self.assertEqual(parsed.get("file").filename, "../../etc/passwd")
+        self.assertEqual(sanitize_suffix(parsed.get("file").filename), ".wav")
+
+    def test_extra_fields_are_ignored_but_parsed(self):
+        content_type, body = build_multipart(
+            fields={"model": "m", "language": "en", "prompt": "hi", "temperature": "0"},
+            files=[("file", "a.wav", b"X")],
+        )
+        parsed = parse_multipart(content_type, body)
+        self.assertEqual(parsed.field_text("language"), "en")
+        self.assertEqual(parsed.field_text("temperature"), "0")
+
+    def test_binary_body_integrity_is_preserved(self):
+        blob = bytes(range(256)) * 8
+        content_type, body = build_multipart(files=[("file", "raw.bin", blob)])
+        parsed = parse_multipart(content_type, body)
+        self.assertEqual(parsed.get("file").content, blob)
+
+    def test_payloads_with_trailing_line_endings_round_trip_exactly(self):
+        # The classic multipart corruption bug is a trailing-CRLF strip; pin
+        # payloads ending in \r\n, bare \r, bare \n, and \r\n\r\n byte-for-byte.
+        for tail in (b"\r\n", b"\r", b"\n", b"\r\n\r\n"):
+            with self.subTest(tail=tail):
+                blob = b"RIFFdata" + tail
+                content_type, body = build_multipart(files=[("file", "raw.bin", blob)])
+                parsed = parse_multipart(content_type, body)
+                self.assertEqual(parsed.get("file").content, blob)
+
+    def test_client_set_content_transfer_encoding_does_not_corrupt_binary(self):
+        # A stray `Content-Transfer-Encoding: base64` on the file part must not
+        # make email base64-DECODE an already-raw binary audio payload. The
+        # parser strips per-part CTE so the bytes round-trip verbatim. (RFC 7578
+        # deprecates CTE in form-data; real SDK clients never send it, but a
+        # corruption path is worth pinning shut.)
+        raw = bytes(range(256)) + b"\r\nRIFF\x00\xff"
+        boundary = "----ctestboundary"
+        body = (
+            f"--{boundary}\r\n".encode()
+            + b'Content-Disposition: form-data; name="file"; filename="a.wav"\r\n'
+            + b"Content-Transfer-Encoding: base64\r\n\r\n"
+            + raw
+            + f"\r\n--{boundary}--\r\n".encode()
+        )
+        parsed = parse_multipart(f"multipart/form-data; boundary={boundary}", body)
+        self.assertEqual(parsed.get("file").content, raw)
+
+    def test_non_multipart_content_type_raises(self):
+        with self.assertRaises(MultipartError):
+            parse_multipart("application/json", b"{}")
+
+    def test_boundary_with_preamble_and_epilogue(self):
+        boundary = b"----transcliptestboundary"
+        body = b"this is ignored preamble\r\n"
+        body += b"--" + boundary + b"\r\n"
+        body += b'Content-Disposition: form-data; name="file"; filename="a.wav"\r\n\r\n'
+        body += b"PAYLOAD\r\n"
+        body += b"--" + boundary + b"--\r\n"
+        body += b"trailing epilogue is ignored\r\n"
+        content_type = "multipart/form-data; boundary=" + boundary.decode("ascii")
+        parsed = parse_multipart(content_type, body)
+        self.assertEqual(parsed.get("file").content, b"PAYLOAD")
+
+
+class SanitizeSuffixTests(unittest.TestCase):
+    def test_none_filename_defaults_to_wav(self):
+        self.assertEqual(sanitize_suffix(None), ".wav")
+
+    def test_empty_filename_defaults_to_wav(self):
+        self.assertEqual(sanitize_suffix(""), ".wav")
+
+    def test_plain_wav_suffix_is_kept(self):
+        self.assertEqual(sanitize_suffix("clip.wav"), ".wav")
+
+    def test_flac_suffix_is_kept(self):
+        self.assertEqual(sanitize_suffix("clip.flac"), ".flac")
+
+    def test_no_suffix_defaults_to_wav(self):
+        self.assertEqual(sanitize_suffix("noext"), ".wav")
+
+    def test_suffix_with_hostile_characters_defaults_to_wav(self):
+        self.assertEqual(sanitize_suffix("evil.w!v"), ".wav")
+
+    def test_overlong_suffix_defaults_to_wav(self):
+        self.assertEqual(sanitize_suffix("clip.superlongextension"), ".wav")
+
+
+class OpenAiErrorBodyTests(unittest.TestCase):
+    def test_error_body_has_exact_openai_shape(self):
+        raw = openai_error_body("bad", error_type="invalid_request_error", param="file")
+        payload = json.loads(raw.decode("utf-8"))
+        self.assertEqual(set(payload), {"error"})
+        self.assertEqual(set(payload["error"]), {"message", "type", "param", "code"})
+        self.assertEqual(payload["error"]["message"], "bad")
+        self.assertEqual(payload["error"]["type"], "invalid_request_error")
+        self.assertEqual(payload["error"]["param"], "file")
+        self.assertIsNone(payload["error"]["code"])
+
+    def test_error_body_param_defaults_to_null(self):
+        payload = json.loads(openai_error_body("boom", error_type="api_error").decode("utf-8"))
+        self.assertIsNone(payload["error"]["param"])
+        self.assertEqual(payload["error"]["type"], "api_error")
+
+
+class HandleTranscriptionsTests(unittest.TestCase):
+    def test_json_success_returns_text_payload(self):
+        engine = FakeRawEngine(text="hello raw")
+        content_type, body = build_multipart(files=[("file", "clip.wav", tiny_wav_bytes())])
+        status, response_content_type, response_body = handle_transcriptions(engine, content_type, body)
+        self.assertEqual(status, 200)
+        self.assertEqual(response_content_type, "application/json")
+        self.assertEqual(json.loads(response_body.decode("utf-8")), {"text": "hello raw"})
+        self.assertEqual(len(engine.calls), 1)
+
+    def test_text_response_format_returns_bare_transcript(self):
+        engine = FakeRawEngine(text="bare text out")
+        content_type, body = build_multipart(
+            fields={"response_format": "text"},
+            files=[("file", "clip.wav", tiny_wav_bytes())],
+        )
+        status, response_content_type, response_body = handle_transcriptions(engine, content_type, body)
+        self.assertEqual(status, 200)
+        self.assertEqual(response_content_type, "text/plain; charset=utf-8")
+        self.assertEqual(response_body, b"bare text out")
+
+    def test_unsupported_response_format_is_rejected(self):
+        engine = FakeRawEngine()
+        content_type, body = build_multipart(
+            fields={"response_format": "verbose_json"},
+            files=[("file", "clip.wav", tiny_wav_bytes())],
+        )
+        status, response_content_type, response_body = handle_transcriptions(engine, content_type, body)
+        self.assertEqual(status, 400)
+        self.assertEqual(response_content_type, "application/json")
+        payload = json.loads(response_body.decode("utf-8"))
+        self.assertEqual(payload["error"]["type"], "invalid_request_error")
+        self.assertEqual(payload["error"]["param"], "response_format")
+        self.assertEqual(engine.calls, [])
+
+    def test_missing_file_is_rejected(self):
+        engine = FakeRawEngine()
+        content_type, body = build_multipart(fields={"model": "whisper-1"})
+        status, _content_type, response_body = handle_transcriptions(engine, content_type, body)
+        self.assertEqual(status, 400)
+        payload = json.loads(response_body.decode("utf-8"))
+        self.assertEqual(payload["error"]["type"], "invalid_request_error")
+        self.assertEqual(payload["error"]["param"], "file")
+        self.assertEqual(engine.calls, [])
+
+    def test_empty_file_is_rejected(self):
+        engine = FakeRawEngine()
+        content_type, body = build_multipart(files=[("file", "clip.wav", b"")])
+        status, _content_type, response_body = handle_transcriptions(engine, content_type, body)
+        self.assertEqual(status, 400)
+        payload = json.loads(response_body.decode("utf-8"))
+        self.assertEqual(payload["error"]["param"], "file")
+        self.assertEqual(engine.calls, [])
+
+    @unittest.skipUnless(_HAVE_SOUNDFILE, "pre-validation (and its 400) requires soundfile")
+    def test_garbage_audio_is_rejected_before_backend(self):
+        engine = FakeRawEngine()
+        content_type, body = build_multipart(files=[("file", "clip.wav", b"not audio at all")])
+        status, _content_type, response_body = handle_transcriptions(engine, content_type, body)
+        self.assertEqual(status, 400)
+        payload = json.loads(response_body.decode("utf-8"))
+        self.assertEqual(payload["error"]["type"], "invalid_request_error")
+        self.assertEqual(payload["error"]["param"], "file")
+        # Pre-validation must run in the route, before the backend is touched.
+        self.assertEqual(engine.calls, [])
+
+    def test_backend_failure_returns_api_error_without_internal_shape(self):
+        engine = FakeRawEngine(error=RuntimeError("weights on fire at /home/user/secret"))
+        content_type, body = build_multipart(files=[("file", "clip.wav", tiny_wav_bytes())])
+        status, response_content_type, response_body = handle_transcriptions(engine, content_type, body)
+        self.assertEqual(status, 500)
+        self.assertEqual(response_content_type, "application/json")
+        payload = json.loads(response_body.decode("utf-8"))
+        # OpenAI-shaped nested error object, NOT the internal {"error": str} shape.
+        self.assertIsInstance(payload["error"], dict)
+        self.assertEqual(payload["error"]["type"], "api_error")
+        self.assertIsNone(payload["error"]["param"])
+        self.assertIsNone(payload["error"]["code"])
+
+    def test_non_multipart_body_is_rejected(self):
+        engine = FakeRawEngine()
+        status, _content_type, response_body = handle_transcriptions(engine, "application/json", b"{}")
+        self.assertEqual(status, 400)
+        payload = json.loads(response_body.decode("utf-8"))
+        self.assertEqual(payload["error"]["type"], "invalid_request_error")
+        self.assertEqual(engine.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_service_openai.py
+++ b/tests/test_service_openai.py
@@ -1,0 +1,232 @@
+import getpass
+import http.client
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from transclip.asr import TranscriptionResult
+from transclip.cleanup import FaithfulRuleCleanupBackend
+from transclip.service import InferenceEngine
+from transclip.service.openai_compat import MAX_UPLOAD_BYTES
+from transclip.settings import Settings
+
+from tests.service_helpers import (
+    FakeASR,
+    build_multipart_body,
+    http_multipart,
+    serve_test_engine,
+    stop_server,
+    tiny_wav_bytes,
+)
+
+_PATH = "/v1/audio/transcriptions"
+
+
+class RaisingASR:
+    name = "raising"
+    model = "raising-model"
+
+    def transcribe(self, wav_path: Path, keywords: list[str] | None = None) -> TranscriptionResult:
+        raise RuntimeError("weights on fire at /home/user/secret")
+
+
+def _serve(engine: InferenceEngine | None = None):
+    settings = Settings(host="127.0.0.1", port=0)
+    engine = engine or InferenceEngine(
+        settings,
+        asr_backend=FakeASR(),
+        cleanup_backend=FaithfulRuleCleanupBackend(),
+    )
+    return serve_test_engine(settings, engine)
+
+
+class OpenAiTranscriptionsRouteTest(unittest.TestCase):
+    def test_wav_upload_returns_json_text(self):
+        server, thread, host, port = _serve()
+        try:
+            content_type, body = build_multipart_body(files=[("file", "clip.wav", tiny_wav_bytes())])
+            status, headers, raw = http_multipart(host, port, _PATH, content_type=content_type, body=body)
+        finally:
+            stop_server(server, thread)
+        self.assertEqual(status, 200)
+        self.assertEqual(headers["content-type"], "application/json")
+        # Raw ASR text, NOT the dictation-cleaned "Hello from ROCm."
+        self.assertEqual(json.loads(raw.decode("utf-8")), {"text": "hello from ROCm"})
+
+    def test_response_format_text_returns_plain_transcript(self):
+        server, thread, host, port = _serve()
+        try:
+            content_type, body = build_multipart_body(
+                fields={"response_format": "text", "model": "whisper-1"},
+                files=[("file", "clip.wav", tiny_wav_bytes())],
+            )
+            status, headers, raw = http_multipart(host, port, _PATH, content_type=content_type, body=body)
+        finally:
+            stop_server(server, thread)
+        self.assertEqual(status, 200)
+        self.assertEqual(headers["content-type"], "text/plain; charset=utf-8")
+        self.assertEqual(raw, b"hello from ROCm")
+
+    def test_unsupported_response_format_returns_openai_400(self):
+        server, thread, host, port = _serve()
+        try:
+            content_type, body = build_multipart_body(
+                fields={"response_format": "srt"},
+                files=[("file", "clip.wav", tiny_wav_bytes())],
+            )
+            status, _headers, raw = http_multipart(host, port, _PATH, content_type=content_type, body=body)
+        finally:
+            stop_server(server, thread)
+        self.assertEqual(status, 400)
+        payload = json.loads(raw.decode("utf-8"))
+        self.assertEqual(payload["error"]["type"], "invalid_request_error")
+        self.assertEqual(payload["error"]["param"], "response_format")
+        self.assertIsNone(payload["error"]["code"])
+
+    def test_missing_file_returns_openai_400(self):
+        server, thread, host, port = _serve()
+        try:
+            content_type, body = build_multipart_body(fields={"model": "whisper-1"})
+            status, _headers, raw = http_multipart(host, port, _PATH, content_type=content_type, body=body)
+        finally:
+            stop_server(server, thread)
+        self.assertEqual(status, 400)
+        payload = json.loads(raw.decode("utf-8"))
+        self.assertEqual(payload["error"]["type"], "invalid_request_error")
+        self.assertEqual(payload["error"]["param"], "file")
+
+    def test_garbage_audio_returns_openai_400_under_fake_backend(self):
+        asr = FakeASR()
+        settings = Settings(host="127.0.0.1", port=0)
+        engine = InferenceEngine(settings, asr_backend=asr, cleanup_backend=FaithfulRuleCleanupBackend())
+        server, thread, host, port = serve_test_engine(settings, engine)
+        try:
+            content_type, body = build_multipart_body(files=[("file", "clip.wav", b"this is not audio")])
+            status, _headers, raw = http_multipart(host, port, _PATH, content_type=content_type, body=body)
+        finally:
+            stop_server(server, thread)
+        self.assertEqual(status, 400)
+        payload = json.loads(raw.decode("utf-8"))
+        self.assertEqual(payload["error"]["param"], "file")
+        # Pre-validation rejected it before the backend was ever invoked.
+        self.assertEqual(asr.calls, [])
+        # The message is static: libsndfile's exception text embeds the
+        # server-local temp path (and with it the OS username) and must never
+        # ship on the wire.
+        message = payload["error"]["message"]
+        self.assertNotIn("transclip-", message)
+        self.assertNotIn(tempfile.gettempdir().lower(), message.lower())
+        self.assertNotIn(getpass.getuser(), message)
+
+    def test_oversize_upload_gets_a_clean_413_not_a_connection_reset(self):
+        # A REAL over-limit upload (body actually sent, matching Content-Length)
+        # must receive a clean 413 the client can read — NOT a mid-upload socket
+        # reset. The server drains the body before responding; without that drain
+        # a Windows RST would surface to the OpenAI SDK as a retryable connection
+        # error and re-upload the oversize body. (This is the honest form of the
+        # cap test: the header-only variant could never see the reset it dodged.)
+        server, thread, host, port = _serve()
+        try:
+            oversize = b"\x00" * (MAX_UPLOAD_BYTES + 4096)
+            content_type, body = build_multipart_body(files=[("file", "big.wav", oversize)])
+            conn = http.client.HTTPConnection(host, port, timeout=30)
+            try:
+                conn.request("POST", _PATH, body=body, headers={"Content-Type": content_type})
+                response = conn.getresponse()
+                status, raw = response.status, response.read()
+            finally:
+                conn.close()
+        finally:
+            stop_server(server, thread)
+        self.assertEqual(status, 413)
+        payload = json.loads(raw.decode("utf-8"))
+        self.assertEqual(payload["error"]["type"], "invalid_request_error")
+
+    def test_missing_content_length_returns_411(self):
+        server, thread, host, port = _serve()
+        try:
+            conn = http.client.HTTPConnection(host, port, timeout=5)
+            try:
+                # Skip_* keeps http.client from auto-adding a Content-Length header.
+                conn.putrequest("POST", _PATH, skip_accept_encoding=True)
+                conn.putheader("content-type", "multipart/form-data; boundary=----x")
+                conn.endheaders()
+                response = conn.getresponse()
+                status = response.status
+                payload = json.loads(response.read().decode("utf-8"))
+            finally:
+                conn.close()
+        finally:
+            stop_server(server, thread)
+        self.assertEqual(status, 411)
+        self.assertEqual(payload["error"]["type"], "invalid_request_error")
+
+    def test_backend_failure_returns_openai_500_without_internal_leak(self):
+        settings = Settings(host="127.0.0.1", port=0)
+        engine = InferenceEngine(settings, asr_backend=RaisingASR(), cleanup_backend=FaithfulRuleCleanupBackend())
+        server, thread, host, port = serve_test_engine(settings, engine)
+        try:
+            content_type, body = build_multipart_body(files=[("file", "clip.wav", tiny_wav_bytes())])
+            status, _headers, raw = http_multipart(host, port, _PATH, content_type=content_type, body=body)
+        finally:
+            stop_server(server, thread)
+        self.assertEqual(status, 500)
+        payload = json.loads(raw.decode("utf-8"))
+        # OpenAI-shaped nested error object; the internal {"error": str} /
+        # debug_capture_dir shape must NOT reach the wire.
+        self.assertIsInstance(payload["error"], dict)
+        self.assertEqual(payload["error"]["type"], "api_error")
+        self.assertNotIn("debug_capture_dir", payload)
+        self.assertNotIn("/home/user/secret", raw.decode("utf-8"))
+
+    def test_foreign_origin_is_rejected_on_new_path(self):
+        server, thread, host, port = _serve()
+        try:
+            content_type, _body = build_multipart_body(files=[("file", "clip.wav", tiny_wav_bytes())])
+            # Headers only, no body: the guard rejects before any body read, and
+            # an early close with unread body bytes can RST before the client
+            # reads the 403 on Windows (same race class as the 413 test).
+            conn = http.client.HTTPConnection(host, port, timeout=10)
+            try:
+                conn.putrequest("POST", _PATH)
+                conn.putheader("Content-Type", content_type)
+                conn.putheader("Content-Length", "0")
+                conn.putheader("Origin", "https://evil.example")
+                conn.endheaders()
+                status = conn.getresponse().status
+            finally:
+                conn.close()
+        finally:
+            stop_server(server, thread)
+        self.assertEqual(status, 403)
+
+    def test_preflight_with_authorization_header_succeeds(self):
+        server, thread, host, port = _serve()
+        try:
+            origin = f"http://127.0.0.1:{port}"
+            conn = http.client.HTTPConnection(host, port, timeout=5)
+            try:
+                conn.request(
+                    "OPTIONS",
+                    _PATH,
+                    headers={
+                        "origin": origin,
+                        "access-control-request-method": "POST",
+                        "access-control-request-headers": "authorization, content-type",
+                    },
+                )
+                response = conn.getresponse()
+                status = response.status
+                headers = {k.lower(): v for k, v in response.getheaders()}
+                response.read()
+            finally:
+                conn.close()
+        finally:
+            stop_server(server, thread)
+        self.assertEqual(status, 204)
+        self.assertIn("authorization", headers.get("access-control-allow-headers", "").lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_service_openai.py
+++ b/tests/test_service_openai.py
@@ -22,6 +22,13 @@ from tests.service_helpers import (
 
 _PATH = "/v1/audio/transcriptions"
 
+try:  # pre-validation is best-effort: only installs with the model extras have soundfile
+    import soundfile as _soundfile  # noqa: F401
+
+    _HAVE_SOUNDFILE = True
+except ImportError:
+    _HAVE_SOUNDFILE = False
+
 
 class RaisingASR:
     name = "raising"
@@ -96,6 +103,7 @@ class OpenAiTranscriptionsRouteTest(unittest.TestCase):
         self.assertEqual(payload["error"]["type"], "invalid_request_error")
         self.assertEqual(payload["error"]["param"], "file")
 
+    @unittest.skipUnless(_HAVE_SOUNDFILE, "pre-validation (and its 400) requires soundfile")
     def test_garbage_audio_returns_openai_400_under_fake_backend(self):
         asr = FakeASR()
         settings = Settings(host="127.0.0.1", port=0)

--- a/transclip/service/engine.py
+++ b/transclip/service/engine.py
@@ -248,6 +248,16 @@ class InferenceEngine:
             record_history=record_history,
         )
 
+    def transcribe_raw(self, wav_path: Path) -> TranscriptionResult:
+        """Raw ASR for the OpenAI-compatible route: backend transcription only.
+
+        Deliberately bypasses the dictation ``transcribe()`` pipeline (keyword
+        restore, voice-mode routing, cleanup, history, debug capture). OpenAI
+        ``/v1/audio/transcriptions`` semantics are verbatim ASR text, so the
+        dictation-shaped path is not reused.
+        """
+        return self.asr_backend.transcribe(wav_path)
+
     def warm_asr(self) -> None:
         """Load and compile the ASR backend before the service reports ready."""
         sample_rate = max(1, self.settings.sample_rate)

--- a/transclip/service/openai_compat.py
+++ b/transclip/service/openai_compat.py
@@ -1,0 +1,270 @@
+"""OpenAI-compatible ``POST /v1/audio/transcriptions`` route.
+
+This module is the entire compat surface: a binary-safe multipart parser (stdlib
+``email`` — ``cgi`` is gone in 3.13 and ``requires-python >=3.12``), the OpenAI
+error/response serializers, and the pure route handler ``handle_transcriptions``.
+Everything here is a pure function with an injectable engine, so the whole route
+is unit-testable without sockets.
+
+Threading/failure model: ``handle_transcriptions`` catches every exception and
+always returns an OpenAI-shaped body — the compat route must NEVER surface the
+internal ``{"error": str, "debug_capture_dir": ...}`` shape used by the other
+routes. A single module-level lock serializes only the backend call (N concurrent
+OpenAI clients must not stampede an unlocked model); it deliberately does not
+serialize against ``/transcribe`` or dictation (pre-existing upstream posture).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import tempfile
+import threading
+from dataclasses import dataclass
+from email.parser import BytesParser
+from email.policy import default as _EMAIL_POLICY
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from transclip.asr import TranscriptionResult
+
+_log = logging.getLogger(__name__)
+
+# OpenAI's own documented upload limit (25 MiB). Pinned to the exact byte count so
+# the 413 boundary test is deterministic; this doubles as the memory-safety cap the
+# server otherwise lacks. Fixed constant, no knob.
+MAX_UPLOAD_BYTES = 26_214_400
+
+# A tempfile suffix derived from an uploaded filename must never carry a hostile
+# path/extension into the NamedTemporaryFile call. Keep only a short, benign suffix.
+_SAFE_SUFFIX_RE = re.compile(r"[A-Za-z0-9.]{1,8}")
+
+_SUPPORTED_RESPONSE_FORMATS = frozenset({"json", "text"})
+
+# Serializes only the backend call for this route (see module docstring).
+_BACKEND_LOCK = threading.Lock()
+
+_CONTENT_TYPE_JSON = "application/json"
+_CONTENT_TYPE_TEXT = "text/plain; charset=utf-8"
+
+
+class RawTranscriber(Protocol):
+    def transcribe_raw(self, wav_path: Path) -> TranscriptionResult: ...
+
+
+class MultipartError(ValueError):
+    """The request body is not a decodable multipart/form-data payload."""
+
+
+@dataclass(frozen=True, slots=True)
+class MultipartPart:
+    name: str
+    filename: str | None
+    content: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedMultipart:
+    parts: tuple[MultipartPart, ...]
+
+    def get(self, name: str) -> MultipartPart | None:
+        for part in self.parts:
+            if part.name == name:
+                return part
+        return None
+
+    def field_text(self, name: str) -> str | None:
+        part = self.get(name)
+        if part is None:
+            return None
+        return part.content.decode("utf-8", errors="replace")
+
+
+def parse_multipart(content_type: str, body: bytes) -> ParsedMultipart:
+    """Parse a multipart/form-data body into its named parts.
+
+    Uses the modern ``email.policy.default`` parser: binary-safe
+    (``get_payload(decode=True)`` round-trips the raw bytes) and it decodes both
+    RFC 2231 extended filenames and raw-UTF-8 filename parameters (as browsers
+    actually send) to proper unicode. Raises ``MultipartError`` if the payload is
+    not a decodable multipart body.
+    """
+    if "multipart/form-data" not in content_type.lower():
+        raise MultipartError("Content-Type is not multipart/form-data")
+    header_block = b"Content-Type: " + content_type.encode("latin-1", "replace") + b"\r\n\r\n"
+    message = BytesParser(policy=_EMAIL_POLICY).parsebytes(header_block + body)
+    if not message.is_multipart():
+        raise MultipartError("Request body is not a valid multipart/form-data payload")
+    parts: list[MultipartPart] = []
+    for part in message.iter_parts():
+        if part.get("content-disposition") is None:
+            continue
+        name = part.get_param("name", header="content-disposition")
+        if name is None:
+            continue
+        filename = part.get_filename()
+        # A multipart FILE part carries raw bytes; RFC 7578 §4.7 deprecates
+        # Content-Transfer-Encoding in form-data. Strip any the client set so
+        # get_payload(decode=True) returns the bytes verbatim — otherwise a
+        # stray `Content-Transfer-Encoding: base64` header makes email decode
+        # (corrupt) an already-raw binary audio payload.
+        del part["content-transfer-encoding"]
+        payload = part.get_payload(decode=True)
+        parts.append(
+            MultipartPart(
+                name=str(name),
+                filename=str(filename) if filename is not None else None,
+                content=payload if isinstance(payload, bytes) else b"",
+            )
+        )
+    return ParsedMultipart(parts=tuple(parts))
+
+
+def sanitize_suffix(filename: str | None) -> str:
+    """Return a safe tempfile suffix from an uploaded filename.
+
+    ``Path(name).suffix`` only, accepted when it matches ``[A-Za-z0-9.]{1,8}``;
+    anything else (missing, hostile, overlong) falls back to ``.wav``.
+    """
+    if not filename:
+        return ".wav"
+    suffix = Path(filename).suffix
+    if suffix and _SAFE_SUFFIX_RE.fullmatch(suffix):
+        return suffix
+    return ".wav"
+
+
+def openai_error_body(
+    message: str,
+    *,
+    error_type: str,
+    param: str | None = None,
+    code: str | None = None,
+) -> bytes:
+    """Serialize the exact OpenAI error envelope for this route."""
+    return json.dumps(
+        {
+            "error": {
+                "message": message,
+                "type": error_type,
+                "param": param,
+                "code": code,
+            }
+        }
+    ).encode("utf-8")
+
+
+def _error(
+    status: int,
+    message: str,
+    *,
+    error_type: str = "invalid_request_error",
+    param: str | None = None,
+) -> tuple[int, str, bytes]:
+    return status, _CONTENT_TYPE_JSON, openai_error_body(message, error_type=error_type, param=param)
+
+
+def handle_transcriptions(
+    engine: RawTranscriber,
+    content_type: str | None,
+    body: bytes,
+) -> tuple[int, str, bytes]:
+    """Handle a compat transcription request.
+
+    Returns ``(status, content_type, body_bytes)``. Content-Length limits (411/413)
+    are enforced by the server before this is called; here we parse, validate, and
+    run raw ASR. Every failure path returns an OpenAI-shaped body; the ``except``
+    guarantees the internal error shape can never leak.
+
+    The standard OpenAI fields ``model``/``language``/``prompt``/``temperature`` are
+    parsed but IGNORED: this service transcribes with its one configured backend, so
+    there is no model to select and no decoding-hint plumbing (the local-server norm).
+    ``response_format`` is honored for ``json``/``text`` only.
+    """
+    try:
+        if not content_type or "multipart/form-data" not in content_type.lower():
+            return _error(400, "Request must be multipart/form-data.")
+        try:
+            parsed = parse_multipart(content_type, body)
+        except MultipartError as exc:
+            return _error(400, f"Could not parse multipart request: {exc}")
+
+        response_format = (parsed.field_text("response_format") or "json").strip()
+        if response_format not in _SUPPORTED_RESPONSE_FORMATS:
+            # Truncate the echoed value: an attacker-supplied field can be up to
+            # the whole upload, and reflecting it unbounded is a needless amplifier.
+            shown = response_format[:32]
+            return _error(
+                400,
+                f"Unsupported response_format {shown!r}; supported: json, text.",
+                param="response_format",
+            )
+
+        file_part = parsed.get("file")
+        if file_part is None or not file_part.content:
+            return _error(400, "No audio file was provided in the 'file' field.", param="file")
+
+        return _transcribe_upload(engine, file_part, response_format)
+    except Exception:
+        # Opaque api_error on the WIRE (never surface internal exception text —
+        # paths, the internal {"error": str} shape), but log server-side so an
+        # operator debugging a 500 has the traceback the sibling do_POST path
+        # gets via debug_capture. Opaque-to-client, not opaque-to-operator.
+        _log.exception("OpenAI-compat transcription route failed")
+        return (
+            500,
+            _CONTENT_TYPE_JSON,
+            openai_error_body(
+                "The transcription backend failed to process the request.",
+                error_type="api_error",
+            ),
+        )
+
+
+def _transcribe_upload(
+    engine: RawTranscriber,
+    file_part: MultipartPart,
+    response_format: str,
+) -> tuple[int, str, bytes]:
+    # Best-effort pre-validation: soundfile ships with every extra that can
+    # actually transcribe (models/mlx/openvino) but is not a core dependency,
+    # so a fake-backend install (CI, the file: test backend) must not 500 on
+    # import. Without soundfile, undecodable audio surfaces as the backend's
+    # own failure instead of the friendly 400.
+    try:
+        import soundfile as sf
+    except ImportError:
+        sf = None
+
+    suffix = sanitize_suffix(file_part.filename)
+    with tempfile.NamedTemporaryFile(prefix="transclip-", suffix=suffix, delete=False) as handle:
+        # Bind the path BEFORE the write so a mid-write failure (e.g. disk full)
+        # still reaches the finally-unlink instead of leaking the partial temp.
+        wav_path = Path(handle.name)
+        handle.write(file_part.content)
+    try:
+        # Pre-validate in the route so undecodable audio is a real, testable 400
+        # (reachable even under a fake backend) instead of a 500 from deep in ASR.
+        if sf is not None:
+            try:
+                sf.info(str(wav_path))
+            except Exception:
+                # Static message, same discipline as the 500 path: libsndfile's
+                # exception text embeds the server-local temp path (and with it
+                # the OS username) — never echo internal exception text on the wire.
+                return _error(
+                    400,
+                    "Could not decode the uploaded audio; supported formats include WAV, FLAC and OGG.",
+                    param="file",
+                )
+        with _BACKEND_LOCK:
+            result = engine.transcribe_raw(wav_path)
+        text = result.text
+    finally:
+        wav_path.unlink(missing_ok=True)
+
+    if response_format == "text":
+        return 200, _CONTENT_TYPE_TEXT, text.encode("utf-8")
+    return 200, _CONTENT_TYPE_JSON, json.dumps({"text": text}).encode("utf-8")

--- a/transclip/service/server.py
+++ b/transclip/service/server.py
@@ -10,9 +10,15 @@ from urllib.parse import urlsplit
 from transclip.settings import Settings, load_settings
 
 from .engine import InferenceEngine
+from .openai_compat import MAX_UPLOAD_BYTES, handle_transcriptions, openai_error_body
 from .routes import dispatch_get, dispatch_post
 
 _LOOPBACK_HOSTNAMES = frozenset({"localhost", "127.0.0.1", "::1"})
+
+# Upper bound on how much of an over-limit upload we will discard to deliver a
+# clean 413 (the cap plus one chunk of slack). A client declaring more than this
+# is abusive and forfeits clean delivery.
+_OVERSIZE_DRAIN_LIMIT = MAX_UPLOAD_BYTES + 65536
 
 
 class TransclipHTTPServer(ThreadingHTTPServer):
@@ -101,6 +107,13 @@ def create_server(
             if not self._guard():
                 return
             path = urlsplit(self.path).path
+            # Self-contained compat branch: runs AFTER _guard() (loopback/origin
+            # protection) but BEFORE the generic JSON dispatch and its exception
+            # wrapper, so it never flows through _read_json/_json and can never
+            # leak the internal {"error": str, "debug_capture_dir": ...} shape.
+            if path == "/v1/audio/transcriptions":
+                self._handle_openai_transcriptions()
+                return
             try:
                 body = self._read_json()
                 response = dispatch_post(active_engine, path, body)
@@ -115,6 +128,65 @@ def create_server(
                 if capture_dir:
                     payload["debug_capture_dir"] = str(capture_dir)
                 self._json(500, payload)
+
+        def _handle_openai_transcriptions(self) -> None:
+            raw_length = self.headers.get("content-length")
+            if raw_length is None:
+                self._openai_write(
+                    411,
+                    "application/json",
+                    openai_error_body("Content-Length header is required.", error_type="invalid_request_error"),
+                )
+                return
+            try:
+                length = int(raw_length)
+            except ValueError:
+                self._openai_write(
+                    400,
+                    "application/json",
+                    openai_error_body("Invalid Content-Length header.", error_type="invalid_request_error"),
+                )
+                return
+            if length > MAX_UPLOAD_BYTES:
+                # Reject on the declared length rather than buffering the body
+                # (memory safety), but DRAIN it first (bounded, in chunks — O(1)
+                # memory) so an over-limit client's upload completes and it reads
+                # a clean 413 instead of a connection reset. Without the drain,
+                # closing the socket mid-upload RSTs on Windows and the OpenAI SDK
+                # sees a retryable connection error, re-uploading the oversize
+                # body up to max_retries times. A client declaring more than the
+                # drain limit forfeits clean delivery — that is the abuse case.
+                self._drain_body(min(length, _OVERSIZE_DRAIN_LIMIT))
+                self._openai_write(
+                    413,
+                    "application/json",
+                    openai_error_body(
+                        f"Uploaded file exceeds the {MAX_UPLOAD_BYTES}-byte limit.",
+                        error_type="invalid_request_error",
+                    ),
+                )
+                return
+            body = self.rfile.read(length) if length > 0 else b""
+            status, content_type, payload = handle_transcriptions(active_engine, self.headers.get("content-type"), body)
+            self._openai_write(status, content_type, payload)
+
+        def _drain_body(self, limit: int) -> None:
+            # Discard up to `limit` bytes of the request body in fixed chunks so a
+            # rejected client's send completes without buffering the payload.
+            remaining = limit
+            while remaining > 0:
+                chunk = self.rfile.read(min(remaining, 65536))
+                if not chunk:
+                    return
+                remaining -= len(chunk)
+
+        def _openai_write(self, status: int, content_type: str, body: bytes) -> None:
+            self.send_response(status)
+            self._cors()
+            self.send_header("content-type", content_type)
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
 
         def log_message(self, format: str, *args: Any) -> None:
             return
@@ -157,7 +229,7 @@ def create_server(
             self.send_header("access-control-allow-origin", origin)
             self.send_header("vary", "origin")
             self.send_header("access-control-allow-methods", "GET, POST, OPTIONS")
-            self.send_header("access-control-allow-headers", "content-type")
+            self.send_header("access-control-allow-headers", "authorization, content-type")
 
     stop_event = threading.Event()
     server = TransclipHTTPServer((settings.host, settings.port), Handler)


### PR DESCRIPTION
This adds an OpenAI-compatible transcription route on the existing local
service so any standard OpenAI client/frontend can use TransClip as its
transcription backend (`base_url=http://127.0.0.1:8765/v1`; the SDK appends
`/audio/transcriptions`).

**Contract (deliberate compat subset):** multipart `file` (formats = what
the bundled soundfile/libsndfile decodes — WAV/FLAC/OGG/mp3 on libsndfile
1.2.2; m4a/webm unsupported, no ffmpeg); `model`/`language`/`prompt`/
`temperature` accepted and ignored (single configured backend serves, the
local-OpenAI-server norm); `response_format` `json` (default, `{"text"}`)
or `text` (text/plain); anything else 400. OpenAI error JSON shape on this
route only. 25 MB cap (`26_214_400`, OpenAI's own limit) enforced against
Content-Length BEFORE the body is read — which also gives the server the
request-size bound it previously lacked on this path. Streaming,
verbose_json/srt/vtt, and /v1/audio/translations are explicitly out.

**Dictation path untouched:** the route is a self-contained branch in
`do_POST` (after `_guard()`, before the JSON dispatch and its exception
wrapper) with its own writer and its own error handling — the internal
`{"error": str, "debug_capture_dir": ...}` shape is unreachable from it
(pinned by test). The only shared-surface changes: a thin
`InferenceEngine.transcribe_raw()` (raw ASR — no cleanup/voice-mode/
history/debug-capture: OpenAI semantics) and `authorization` added to the
CORS allow-headers (browser OpenAI clients preflight it; grants nothing —
the loopback-origin guard still gates everything).

**Safety details:** undecodable audio → 400 via soundfile pre-validation in
the route, with a static message (libsndfile's exception text embeds the
server temp path — never echoed; same discipline for the 500 path, both
pinned by tests). Uploaded-filename suffix sanitized before the tempfile
call. A module-level lock serializes THIS route's backend calls; note the
pre-existing service posture (no inference lock across `/transcribe` /
dictation) is unchanged — flagging rather than fixing in a thin PR.

The over-limit path drains the request body (bounded, in chunks) before
sending the 413, so a real oversize upload receives a clean status instead
of a connection reset that an SDK would retry.

**Tests:** 29 unit (multipart parser incl. UTF-8/RFC 2231 filenames, binary
+ trailing-CRLF + stray-`Content-Transfer-Encoding` round-trips, sanitizer,
handler with fakes) + 10 socket round trips (json/text/400s, a real
oversize upload → clean 413, 411, 500-no-leak, 403, preflight) via the
existing `serve_test_engine` harness + a new multipart helper. Full suite:
490 OK (5 skipped) at this branch.

**One pre-existing quirk noticed, not touched (exists at ba25cb0):** the
`ruff format` non-compliance in `server.py`'s `_guard`/`_cors` blocks (and
`_worker_loop`). Also, on Windows the pre-existing `_guard` early-reject
path (403 before the body is read) can occasionally reset the connection
before a client with a body in flight reads the response — the new route's
own reject paths drain first to avoid this, but I left the shared `_guard`
untouched in a thin PR; happy to apply the same drain there if you'd like.

